### PR TITLE
docs: align infra/deploy docs with fork identity

### DIFF
--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -1,6 +1,6 @@
 # Setting up User Analytics
 
-User Analytics within the Bloom reference apps is handled by Google Analytics (GA). In order to support additional analytics or tag integrations in the future, the default implementation is to use Google Tag Manager (GTM) from the reference code, which is then set up to call GA from within the GTM console.
+User Analytics within the front-end apps is handled by Google Analytics (GA). In order to support additional analytics or tag integrations in the future, the default implementation is to use Google Tag Manager (GTM) from the reference code, which is then set up to call GA from within the GTM console.
 
 ## GA and GTM Console Setup
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -1,8 +1,8 @@
 # Authentication
 
-The [backend/core](./backend/core) service handles authentication for the bloom system using the
-[auth module](backend/core/src/auth). Routes can then use
-[Nest.js guards and Passport](ihttps://docs.nestjs.com/techniques/authentication#authentication) to guard individual
+The API service handles authentication using the
+[auth module](../api/src/auth). Routes can then use
+[Nest.js guards and Passport](https://docs.nestjs.com/techniques/authentication#authentication) to guard individual
 routes.
 
 ## Protect a Route
@@ -71,7 +71,7 @@ The context is provided to a React App using `AuthProvider`, which in turn requi
 properly:
 
 ```tsx
-import { UserProvider, ConfigProvider } from "@bloom-housing/ui-components"
+import { UserProvider, ConfigProvider } from "@bloom-housing/shared-helpers"
 
 <ConfigProvider apiUrl={...}>
   <AuthProvider>
@@ -139,7 +139,7 @@ if (!user) {
 For API authorization, we use a combination of Role Based Access Control (RBAC) and ABAC (Attribute Based Access
 Control) implemented using the [casbin library](https://casbin.org/). We define authorizations in the context of
 performing a given _action_ on _resource type_ as a _role_. Actions are strings defined in
-[authz.service.ts](../backend/core/src/auth/authz.service.ts) as an enum `authzActions`.
+[authz.service.ts](../api/src/auth/authz.service.ts) as an enum `authzActions`.
 
 For high-level Role-Based Access Control (RBAC), a Nest.js guard, `AuthzGuard` is provided. It can be defined on either
 a controller or individual request handler (method) scope, although the former is probably a more common use case. It
@@ -155,7 +155,7 @@ we are checking specific attributes about the resource access is requested on, s
 handler rather than as a guard (since the resource must be loaded from the DB). This is accomplished using the
 `AuthzService.can` or `AuthzService.canOrThrow` methods.
 
-The rules themselves are defined in [authz_policy.csv](../backend/core/src/auth/authz_policy.csv). Each line in this
+The rules themselves are defined in [authz_policy.csv](../api/src/auth/authz_policy.csv). Each line in this
 CSV starting with `p` is a policy and follows the following format:
 
 ```

--- a/docs/DeployAppsNetlify.md
+++ b/docs/DeployAppsNetlify.md
@@ -1,10 +1,12 @@
-# Deplying Bloom Apps to Netlify
+# Deploying Front-End Apps to Netlify
 
-The Bloom front-end applications are designed to be stateless, and thus can be deployed as static sites to Netlify or directly to any major hosting environment. The following information is intended to help guide the deployment of the reference implementation to Netlify, but can also serve as a starting point for other front-end deployment scenarios
+> **Note:** This document originates from the upstream [Bloom Housing](https://github.com/bloom-housing/bloom) project. Instructions may need adaptation for this fork's deployment setup.
+
+The front-end applications are designed to be stateless, and thus can be deployed as static sites to Netlify or directly to any major hosting environment. The following information is intended to help guide the deployment to Netlify, but can also serve as a starting point for other front-end deployment scenarios.
 
 ## Per-app Deployment
 
-Because Bloom uses a monorepo style of organization, there are likely multiple apps (e.g. public and partners) that will each need their own deployment configuration. Each build configuation should make sure to work from the correct code base directory, for example the public app build command might be:
+Because this project uses a monorepo style of organization, there are likely multiple apps (e.g. public and partners) that will each need their own deployment configuration. Each build configuration should make sure to work from the correct code base directory, for example the public app build command might be:
 
     cd sites/public; yarn run build ; yarn run export
 
@@ -18,7 +20,7 @@ In order to make this configuration work, make sure to have an empty yarn.lock i
 
 ## Environment Variables
 
-In addition to those environment variables defined in .env.template for the relevant applications, make sure to define the following variables to ensure the release process is consistent with the Bloom supported versions:
+In addition to those environment variables defined in .env.template for the relevant applications, make sure to define the following variables to ensure the release process uses the correct versions:
 
 - NODE_VERSION
 - YARN_VERSION

--- a/docs/DeployServicesHeroku.md
+++ b/docs/DeployServicesHeroku.md
@@ -1,6 +1,8 @@
-# Deploying Bloom Services to Heroku
+# Deploying Backend Services to Heroku
 
-Bloom is designed to use a set of independently run services that provide the data and business logic processing needed by the front-end apps. While the Bloom architecture accomodates services built and operated in a variety of environments, the reference implementation includes services that can be easily run within the [Heroku PaaS environment](https://www.heroku.com/).
+> **Note:** This document originates from the upstream [Bloom Housing](https://github.com/bloom-housing/bloom) project. Instructions may need adaptation for this fork's deployment setup.
+
+The application is designed to use a set of independently run services that provide the data and business logic processing needed by the front-end apps. While the architecture accommodates services built and operated in a variety of environments, the reference implementation includes services that can be easily run within the [Heroku PaaS environment](https://www.heroku.com/).
 
 ## Resources
 
@@ -10,11 +12,11 @@ Bloom is designed to use a set of independently run services that provide the da
 
 ### Monorepo Buildpack
 
-Since the Bloom repository uses a monorepo layout, all Heroku services must use the [monorepo buildpack](https://elements.heroku.com/buildpacks/lstoll/heroku-buildpack-monorepo).
+Since the repository uses a monorepo layout, all Heroku services must use the [monorepo buildpack](https://elements.heroku.com/buildpacks/lstoll/heroku-buildpack-monorepo).
 
 ### Node.js Buildpack
 
-Bloom's backend runs on Node.js and Heroku must be setup with [Heroku Buildpack for Node.js](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-nodejs).
+The backend runs on Node.js and Heroku must be set up with [Heroku Buildpack for Node.js](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-nodejs).
 
 ## Procfile
 

--- a/docs/Styling2ndGen.md
+++ b/docs/Styling2ndGen.md
@@ -1,14 +1,14 @@
 # Styling 2nd Generation Components
 
-This covers preliminary documentation for the "2nd generation" UI components in the Bloom design system. (General styling information can be found in the [README for ui-components](https://github.com/bloom-housing/ui-components).)
+This covers preliminary documentation for the "2nd generation" UI components in the design system. (General styling information can be found in the upstream [README for ui-components](https://github.com/bloom-housing/ui-components) — retained as a reference.)
 
 First, we'll go over the what & why of the new component architecture, then we'll explain the process for converting a "1st gen" component to 2nd gen.
 
-## What are Bloom Design Tokens?
+## What are Design Tokens?
 
-In this updated system, the Bloom design tokens are defined as [CSS Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) (aka CSS Variables). They're values you can insert into (almost) every place you would put an actual property value in CSS.
+In this updated system, the design tokens (prefixed `--bloom-*` for historical reasons) are defined as [CSS Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) (aka CSS Variables). They're values you can insert into (almost) every place you would put an actual property value in CSS.
 
-Bloom design tokens include colors, typography settings, sizes, borders, and so forth. They're located in the [src/global/tokens](https://github.com/bloom-housing/ui-components/tree/main/src/global/tokens) folder.
+Design tokens include colors, typography settings, sizes, borders, and so forth. They originate from the upstream [ui-components tokens folder](https://github.com/bloom-housing/ui-components/tree/main/src/global/tokens) (retained as a reference).
 
 For example, some colors in `tokens/colors.scss`:
 
@@ -208,4 +208,4 @@ It's worth noting what we _didn't_ consider for this upgrade effort.
 
 As the [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) spec has matured and solidified in all evergreen browsers, many design systems are starting to migrate to using web component technology as the substrate, with "wrappers" generated for specific JS frameworks like React, Vue, Angular, etc. (plus they're completely usable directly within "vanilla" HTML). While web components can be authored completely vanilla without any framework or build process, lightweight libraries such as [Lit](https://lit.dev) have made web components DX rival "legacy" frameworks such as React. Component systems ranging from the open source [Shoelace](https://shoelace.style) to closed source [Nord Health](https://nordhealth.design/components/) show us the breadth of what's possible with this approach.
 
-However, porting Bloom components over to a pure web components toolchain (possibly using Lit) and then exporting React wrappers for use elsewhere seems like a bridge too far at this juncture, particularly since all `ui-components` consumers at present are only using React. The good news is: by migrating to our 2nd-gen styling API based on vanilla CSS techniques, it positions us to consider a web components-based solution farther down the road. While we don't have the ability to use [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), [shadow parts](https://developer.mozilla.org/en-US/docs/Web/CSS/::part), and [slots](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots#adding_flexibility_with_slots) to aid in our component architecture, we are able to get pretty far simply by utilizing CSS variables and a close 1:1 convention between React props and CSS class-based variants.
+However, porting the existing components over to a pure web components toolchain (possibly using Lit) and then exporting React wrappers for use elsewhere seems like a bridge too far at this juncture, particularly since all `ui-components` consumers at present are only using React. The good news is: by migrating to our 2nd-gen styling API based on vanilla CSS techniques, it positions us to consider a web components-based solution farther down the road. While we don't have the ability to use [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), [shadow parts](https://developer.mozilla.org/en-US/docs/Web/CSS/::part), and [slots](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots#adding_flexibility_with_slots) to aid in our component architecture, we are able to get pretty far simply by utilizing CSS variables and a close 1:1 convention between React props and CSS class-based variants.

--- a/infra/DEVELOPMENT.md
+++ b/infra/DEVELOPMENT.md
@@ -12,8 +12,8 @@
 
 [./Dockerfile.dev](./Dockerfile.dev) builds a container image with the required binaries. Run the
 container with `docker container run` or `podman container run`. The infra-dev container does not
-include the infra source code in its root filesystem - clone the Bloom repo on your host and give
-the container access through volume mounts:
+include the infra source code in its root filesystem - clone the repo on your host and give the
+container access through volume mounts:
 
 1. `-v ./infra:/infra:z` makes the infra directory available to the container.
 2. `-v "${HOME}/.aws/cli":/home/.aws/cli:z` makes the AWS cli directory available to the
@@ -56,19 +56,19 @@ docker container run --rm -it \
 -v ./infra:/infra:z \
 -v "${HOME}/.aws/cli":/home/.aws/cli:z \
 -v "${HOME}/.aws/sso/cache":/home/.aws/sso/cache:z \
-ghcr.io/bloom-housing/bloom/infra-dev \
+ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra-dev \
 [[--skip-sso] | [--skip-init]] <ROOT_MODULE_NAME> <OPEN_TOFU_ARGS>
 ```
 
-You may find it convenient to add an alias. From the root of the Bloom repo:
+You may find it convenient to add an alias. From the root of the repo:
 
 ```bash
-alias bloomtofu="docker container run --rm -it --user $(id -u):$(id -g) -v ${PWD}/infra:/infra:z -v ${HOME}/.aws/cli:/home/.aws/cli:z -v ${HOME}/.aws/sso/cache:/home/.aws/sso/cache:z ghcr.io/bloom-housing/bloom/infra-dev"
+alias infratofu="docker container run --rm -it --user $(id -u):$(id -g) -v ${PWD}/infra:/infra:z -v ${HOME}/.aws/cli:/home/.aws/cli:z -v ${HOME}/.aws/sso/cache:/home/.aws/sso/cache:z ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra-dev"
 
-bloomtofu -ss -si bloom_dev apply
+infratofu -ss -si bloom_dev apply
 ```
 
-## Testing changes in the bloom-dev account:
+## Testing changes in the dev account:
 
 1. Edit the `.tf` files.
 2. Run `tofu apply` on the `bloom_dev` root module and review the planned changes. If there are

--- a/infra/Dockerfile.dev
+++ b/infra/Dockerfile.dev
@@ -1,9 +1,9 @@
-# This file creates a docker image with the required binaries to develop on the Bloom infra Open
-# Tofu modules. It is meant to be used for interactive development of the tofu source code. To use:
+# This file creates a docker image with the required binaries to develop on the infra OpenTofu
+# modules. It is meant to be used for interactive development of the tofu source code. To use:
 #
-# 1. Clone the Bloom repo onto their host machine.
-# 2. Run this container, mounting the Bloom infra directory to /infra inside the container
-# filesystem. For example, if your shell is in the root of the Bloom git repo on your host:
+# 1. Clone the repo onto your host machine.
+# 2. Run this container, mounting the infra directory to /infra inside the container filesystem.
+# For example, if your shell is in the root of the git repo on your host:
 #
 #    If using docker:
 #    `docker container run --rm -it --user "$(id -u):$(id -g)" -v ./infra:/infra:z -v "${HOME}/.aws/sso/cache":/home/.aws/sso/cache:z <this_image_name> ...`
@@ -57,7 +57,7 @@ EOF
 ENV HOME=/home
 
 # To help users disambiguate their shell if they run this container with `--entrypoint /bin/bash`.
-ENV PS1='bloom-infra-dev-container$ '
+ENV PS1='infra-dev-container$ '
 
 WORKDIR /infra
 ENTRYPOINT [ "python3", "/infra/docker-entrypoint.py" ]

--- a/infra/aws_deployment_guide/0_README.md
+++ b/infra/aws_deployment_guide/0_README.md
@@ -1,14 +1,16 @@
 # AWS Deployment Guide
 
-This directory contains instructions for deploying Bloom an AWS organization. The guide is separated
-into a series of files that should be followed in order:
+> **Note:** This guide originates from the upstream [Bloom Housing](https://github.com/bloom-housing/bloom) project. Resource names (e.g. `bloom-dev`, `bloom-prod`) reflect the upstream naming convention and may be renamed for your deployment.
+
+This directory contains instructions for deploying the application to an AWS organization. The guide
+is separated into a series of files that should be followed in order:
 
 1. [Create AWS Accounts](./1_create_aws_accounts.md)
 2. [IAM Identity Center Configuration](./2_iam_identity_center_configuration.md)
 3. [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md)
-4. [Fork the Bloom Repo](./4_fork_bloom_repo.md)
+4. [Fork the Repo](./4_fork_bloom_repo.md)
 5. [Apply Deployer Permission Set Tofu Modules](./5_apply_deployer_permission_set_tofu_modules.md)
-6. [Apply Bloom Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
+6. [Apply Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
 
 This guide requires certain resource details and ARNs to be noted for future steps. The guide will
 call-out specific values to copy into a notes doc with bolded instructions like **Note the ...**.

--- a/infra/aws_deployment_guide/1_create_aws_accounts.md
+++ b/infra/aws_deployment_guide/1_create_aws_accounts.md
@@ -1,14 +1,14 @@
 # Create AWS Accounts
 
-This directory contains instructions for deploying Bloom dev and prod environments to an AWS
+This directory contains instructions for deploying dev and prod environments to an AWS
 organization. The guide is broken down into a series of files that should be followed in order:
 
 1. [Create AWS Accounts](./1_create_aws_accounts.md) (you are here)
 2. [IAM Identity Center Configuration](./2_iam_identity_center_configuration.md)
 3. [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md)
-4. [Fork the Bloom Repo](./4_fork_bloom_repo.md)
+4. [Fork the Repo](./4_fork_bloom_repo.md)
 5. [Apply Deployer Permission Set Tofu Modules](./5_apply_deployer_permission_set_tofu_modules.md)
-6. [Apply Bloom Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
+6. [Apply Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
 
 The steps in this file will create the following resources:
 

--- a/infra/aws_deployment_guide/2_iam_identity_center_configuration.md
+++ b/infra/aws_deployment_guide/2_iam_identity_center_configuration.md
@@ -1,14 +1,14 @@
 # IAM Identity Center Configuration
 
-This directory contains instructions for deploying Bloom dev and prod environments to an AWS
+This directory contains instructions for deploying dev and prod environments to an AWS
 organization. The guide is broken down into a series of files that should be followed in order:
 
 1. [Create AWS Accounts](./1_create_aws_accounts.md)
 2. [IAM Identity Center Configuration](./2_iam_identity_center_configuration.md) (you are here)
 3. [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md)
-4. [Fork the Bloom Repo](./4_fork_bloom_repo.md)
+4. [Fork the Repo](./4_fork_bloom_repo.md)
 5. [Apply Deployer Permission Set Tofu Modules](./5_apply_deployer_permission_set_tofu_modules.md)
-6. [Apply Bloom Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
+6. [Apply Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
 
 The steps in this file create the following resources:
 
@@ -108,13 +108,13 @@ graph TB
 1. Create Users in the organization's IAM Identity Center instance.
 2. Create Groups in the organization's IAM Identity Center instance and add users to the groups.
 3. Create Permission sets in the organization's IAM Identity Center instance and assign the
-   Permission sets to the organization management account and the dev and prod Bloom accounts.
-4. List and read roles in the organization management account and the dev and prod Bloom accounts.
+   Permission sets to the organization management account and the dev and prod accounts.
+4. List and read roles in the organization management account and the dev and prod accounts.
 
 ## Before these steps
 
 1. Complete the steps in the [Create AWS Accounts](./1_create_aws_accounts.md). The AWS account
-   numbers for the dev and prod Bloom accounts will be needed.
+   numbers for the dev and prod accounts will be needed.
 2. Open the organization management account and go to the 'IAM Identity Center > Settings'
    page. **Note the IAM Identity Center Instance ARN, Region, and the AWS access portal URL**.
 
@@ -122,14 +122,14 @@ graph TB
 
 ### 1. Create IAM Identity Center Users and Groups
 
-1. Create an IAM Identity Center user for every person who will be interacting with the Bloom
+1. Create an IAM Identity Center user for every person who will be interacting with the
    deployments, if they do not already have a user.
 2. Create a `bloom-dev-deployers` IAM Identity Center group. Add the users who should have access to
-   manage the dev Bloom deployment.
+   manage the dev deployment.
 3. Create a `bloom-prod-iam-admins` IAM Identity Center group. Add the users who should have access
    to manage the `bloom-prod-deployers` permission set policy.
 4. Create a `bloom-prod-deployers` IAM Identity Center group. Add the users who should have access
-   to manage the prod Bloom deployment.
+   to manage the prod deployment.
 
 Optionally, create a `bloom-dev-iam-admins` if the group of people who should have access to manage
 the `bloom-dev-deployer` permission set policy is different from the group of people should should
@@ -154,7 +154,7 @@ have the `bloom-dev-deployer` permissions.
 
       - `CHANGEME_IAM_IDENTITY_CENTER_INSTANCE_ARN` to the IAM Identity Center instance ARN in your
         notes.
-      - `CHANGEME_BLOOM_DEV_ACCOUNT_NUMBER` to the Bloom dev account number in your notes.
+      - `CHANGEME_BLOOM_DEV_ACCOUNT_NUMBER` to the dev account number in your notes.
       - `CHANGEME_DEV_DEPLOYER_PERMISSIONSET_ARN` to the ARN in your notes from step 2.1.4.
 
       ```
@@ -203,7 +203,7 @@ have the `bloom-dev-deployer` permissions.
 
       - `CHANGEME_IAM_IDENTITY_CENTER_INSTANCE_ARN` to the IAM Identity Center instance ARN in your
         notes.
-      - `CHANGEME_BLOOM_PROD_ACCOUNT_NUMBER` to the Bloom prod account number in your notes.
+      - `CHANGEME_BLOOM_PROD_ACCOUNT_NUMBER` to the prod account number in your notes.
       - `CHANGEME_PROD_DEPLOYER_PERMISSIONSET_ARN` to the ARN in your notes from step 2.3.4.
 
       ```
@@ -274,10 +274,10 @@ set was assigned to. These roles need access to a S3 bucket that will be created
    'AWSReservedSSO_bloom'. Two roles, 'AWSReservedSSO_bloom-dev-iam-admin_..' and
    'AWSReservedSSO_bloom-prod-iam-admin_..' should be returned. Go into each role detail page and
    **note the role ARN for each role**.
-2. In the dev Bloom account, go to the 'IAM > Roles' page. Search for 'AWSReservedSSO_bloom'. One
+2. In the dev account, go to the 'IAM > Roles' page. Search for 'AWSReservedSSO_bloom'. One
    role 'AWSReservedSSO_bloom-dev-deployer_..' should be returned. Go into each role detail page and
    **note the role ARN**.
-3. In the prod Bloom account, go to the 'IAM > Roles' page. Search for 'AWSReservedSSO_bloom'. One
+3. In the prod account, go to the 'IAM > Roles' page. Search for 'AWSReservedSSO_bloom'. One
    role 'AWSReservedSSO_bloom-prod-deployer_..' should be returned. Go into each role detail page
    and **note the role ARN**.
 
@@ -285,6 +285,6 @@ set was assigned to. These roles need access to a S3 bucket that will be created
 
 1. The organization management account should have assignments for the bloom-dev-iam-admin and
    bloom-prod-iam-admin permission sets.
-2. The dev Bloom account should have the bloom-dev-deployers permission set assigned.
-3. The prod Bloom account should have the bloom-prod-deployers permission set assigned.
+2. The dev account should have the bloom-dev-deployers permission set assigned.
+3. The prod account should have the bloom-prod-deployers permission set assigned.
 4. Your notes should have the ARNs for 4 AWS-generated roles.

--- a/infra/aws_deployment_guide/3_create_tofu_state_s3_bucket.md
+++ b/infra/aws_deployment_guide/3_create_tofu_state_s3_bucket.md
@@ -1,14 +1,14 @@
 # Create OpenTofu State S3 Bucket
 
-This directory contains instructions for deploying Bloom dev and prod environments to an AWS
+This directory contains instructions for deploying dev and prod environments to an AWS
 organization. The guide is broken down into a series of files that should be followed in order:
 
 1. [Create AWS Accounts](./1_create_aws_accounts.md)
 2. [IAM Identity Center Configuration](./2_iam_identity_center_configuration.md)
 3. [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md) (you are here)
-4. [Fork the Bloom Repo](./4_fork_bloom_repo.md)
+4. [Fork the Repo](./4_fork_bloom_repo.md)
 5. [Apply Deployer Permission Set Tofu Modules](./5_apply_deployer_permission_set_tofu_modules.md)
-6. [Apply Bloom Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
+6. [Apply Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
 
 The steps in this file create the following resources:
 
@@ -26,7 +26,7 @@ graph TB
       subgraph MA[AWS Management Account]
           direction TB
 
-          S3[Bloom Tofu State Files<br/>AWS S3 Bucket]
+          S3[Tofu State Files<br/>AWS S3 Bucket]
       end
   end
 
@@ -67,25 +67,23 @@ graph TB
 
 1. Complete the steps in the [IAM Identity Center
    Configuration](./2_iam_identity_center_configuration.md). The ARNs for the AWS-generated Roles in
-   the organization management account and the dev and prod Bloom accounts will be needed.
+   the organization management account and the dev and prod accounts will be needed.
 
 ## Steps
 
 ### 1. Create a S3 Bucket to store the OpenTofu state files
 
 An AWS S3 bucket is required to store OpenTofu state files. State files record the results of each
-apply command. The S3 bucket can be created in any suitable AWS account in your organization. For
-example, the S3 bucket used by the Bloom Core deployments is in Exygy's organization management
-account.
+apply command. The S3 bucket can be created in any suitable AWS account in your organization (e.g.
+the organization management account).
 
 Create a S3 bucket:
 
 1. In the 'General configuration' section:
    1. Select the 'General purpose' Bucket type.
    2. Enter a descriptive bucket name. S3 bucket names must be globally unique so different names
-      may have to be tried before finding a name that is unused. For example, the S3 bucket used by
-      the Bloom Core deployments is named 'bloom-core-tofu-state-files'. **Note the bucket name and
-      the AWS region it is created in**.
+      may have to be tried before finding a name that is unused (e.g.
+      `my-org-tofu-state-files`). **Note the bucket name and the AWS region it is created in**.
 2. In the 'Object Ownership' section, select the 'ACLs disabled (recommended)' option.
 3. In the 'Block Public Access settings for this bucket' section, select the 'Block all public
   access' option.
@@ -107,10 +105,10 @@ The AWS-generated roles need access to the S3 bucket. On the 'Permissions' tab o
      `AWSReservedSSO_bloom-prod-iam-admin_..` AWS-generated role in the organization management
      account in your notes.
    - `CHANGEME_DEV_DEPLOYER_GENERATED_ROLE_ARN` to the ARN of the
-     `AWSReservedSSO_bloom-dev-deployer_..` AWS-generated role in the dev Bloom account in your
+     `AWSReservedSSO_bloom-dev-deployer_..` AWS-generated role in the dev account in your
      notes.
    - `CHANGEME_PROD_DEPLOYER_GENERATED_ROLE_ARN` to the ARN of the
-     `AWSReservedSSO_bloom-prod-deployer_..` AWS-generated role in the prod Bloom account in your
+     `AWSReservedSSO_bloom-prod-deployer_..` AWS-generated role in the prod account in your
      notes.
 
    ```

--- a/infra/aws_deployment_guide/4_fork_bloom_repo.md
+++ b/infra/aws_deployment_guide/4_fork_bloom_repo.md
@@ -1,41 +1,41 @@
-# Fork the Bloom Repo
+# Fork the Repo
 
-This directory contains instructions for deploying Bloom dev and prod environments to an AWS
+This directory contains instructions for deploying dev and prod environments to an AWS
 organization. The guide is broken down into a series of files that should be followed in order:
 
 1. [Create AWS Accounts](./1_create_aws_accounts.md)
 2. [IAM Identity Center Configuration](./2_iam_identity_center_configuration.md)
 3. [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md)
-4. [Fork the Bloom Repo](./4_fork_bloom_repo.md) (you are here)
+4. [Fork the Repo](./4_fork_bloom_repo.md) (you are here)
 5. [Apply Deployer Permission Set Tofu Modules](./5_apply_deployer_permission_set_tofu_modules.md)
-6. [Apply Bloom Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
+6. [Apply Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
 
-WARNING: these instructions are not up-to-date with the current process and will be updated soon
-TODO(https://github.com/bloom-housing/bloom/issues/5760). If you are deploying Bloom before these
-instructions are updated, please reach out to avritt.rohwer@exygy.com for details on how to proceed.
+> **Note:** These instructions originate from the upstream Bloom Housing project and may not be
+> fully up-to-date. If you are deploying from this fork, review the steps below and adapt them to
+> your organization's setup.
 
 ## Before these steps
 
 1. Complete the steps in [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md). The
    following notes from previous steps will be needed:
-   1. AWS account numbers for the dev and prod Bloom accounts.
+   1. AWS account numbers for the dev and prod accounts.
    2. S3 bucket name and region for the OpenTofu state file bucket.
    3. IAM Identity Center Instance ARN, region, and AWS access portal URL.
    4. Permission set ARNs for `bloom-dev-deployer` and `bloom-prod-deployer`.
-2. Decide where you would like to host your Bloom fork. GitHub will work out-of-the-box. If choosing
+2. Decide where you would like to host your fork. GitHub will work out-of-the-box. If choosing
    another provider, you will need to bring your own method for building docker images from the
    repo.
-3. Pick an AWS region to deploy dev and prod Bloom to.
-4. Pick DNS domains for the dev and prod Bloom deployments. You must be able to add CNAME records
+3. Pick an AWS region to deploy dev and prod environments to.
+4. Pick DNS domains for the dev and prod deployments. You must be able to add CNAME records
    for the chosen domains.
 
 ## Steps
 
-1. Fork https://github.com/bloom-housing/bloom. After forking, GitHub should
-   trigger the 'Docker Image Build' action:
-   https://github.com/<YOUR_GITHUB_ORG>/bloom/actions/workflows/docker_image_build.yml. It will
-   build and push Bloom docker images to the GitHub container registry in your GitHub organization.
-2. Get the docker images for your fork's Bloom services. Go to your GitHub Organization's Packages
+1. Fork https://github.com/CivicTechWR/affordable-housing-portal (or the upstream
+   https://github.com/bloom-housing/bloom). After forking, GitHub should trigger the
+   'Docker Image Build' action. It will build and push docker images to the GitHub container
+   registry in your GitHub organization.
+2. Get the docker images for your fork's services. Go to your GitHub Organization's Packages
    page: https://github.com/orgs/<YOUR_GITHUB_ORG>/packages.
 
    1. Click on the 'api' container and **note the container name**.
@@ -107,12 +107,11 @@ instructions are updated, please reach out to avritt.rohwer@exygy.com for detail
    1. Click on the 'infra' container and **note the container name that corresponds to the git
       commit SHA of your infra updates commit**. It must be the infra container version that was
       build on or after the commit updating your forks infra/ directory. If you use an infra
-      container version that was build from a commit before your fork was updated, it will attempt
-      to deploy the Bloom Core infra/ config.
+      container version that was built from a commit before your fork was updated, it will attempt
+      to deploy the previous infra/ config.
 
 ## After these steps
 
-1. The main branch of your Bloom fork should be updated to have the details for your AWS deployments
-   and not the Bloom Core AWS deployment.
+1. The main branch of your fork should be updated to have the details for your AWS deployments.
 2. Your notes should have the infra docker container image version that was build from the commit
    updating your fork.

--- a/infra/aws_deployment_guide/5_apply_deployer_permission_set_tofu_modules.md
+++ b/infra/aws_deployment_guide/5_apply_deployer_permission_set_tofu_modules.md
@@ -1,15 +1,15 @@
 # Apply Deployer Permission Set OpenTofu Modules
 
-This directory contains instructions for deploying Bloom dev and prod environments to an AWS
+This directory contains instructions for deploying dev and prod environments to an AWS
 organization. The guide is broken down into a series of files that should be followed in order:
 
 1. [Create AWS Accounts](./1_create_aws_accounts.md)
 2. [IAM Identity Center Configuration](./2_iam_identity_center_configuration.md)
 3. [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md)
-4. [Fork the Bloom Repo](./4_fork_bloom_repo.md)
+4. [Fork the Repo](./4_fork_bloom_repo.md)
 5. [Apply Deployer Permission Set Tofu Modules](./5_apply_deployer_permission_set_tofu_modules.md)
    (you are here)
-6. [Apply Bloom Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
+6. [Apply Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md)
 
 The steps in this file create the following resources:
 
@@ -27,7 +27,7 @@ graph TB
       subgraph MA[AWS Management Account]
           direction TB
 
-          S3[Bloom Tofu State Files<br/>AWS S3 Bucket]
+          S3[Tofu State Files<br/>AWS S3 Bucket]
 
           subgraph IC[AWS IAM Identity Center]
               direction LR
@@ -82,7 +82,7 @@ graph TB
 
 ## Before these steps
 
-1. Complete the steps in [Fork the Bloom Repo](./4_fork_bloom_repo.md). The infra container image
+1. Complete the steps in [Fork the Repo](./4_fork_bloom_repo.md). The infra container image
    name build from your fork will be needed.
 
 ## Steps
@@ -90,13 +90,13 @@ graph TB
 1. Apply the dev deployer OpenTofu root module:
 
    ```bash
-   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/bloom/infra:gitsha-SOMESHA bloom_dev_deployer_permission_set_policy apply
+   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra:gitsha-SOMESHA bloom_dev_deployer_permission_set_policy apply
    ```
 
 2. Apply the prod deployer OpenTofu root module:
 
    ```bash
-   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/bloom/infra:gitsha-SOMESHA bloom_prod_deployer_permission_set_policy apply
+   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra:gitsha-SOMESHA bloom_prod_deployer_permission_set_policy apply
    ```
 
 ## After these steps

--- a/infra/aws_deployment_guide/6_apply_bloom_deployment_tofu_modules.md
+++ b/infra/aws_deployment_guide/6_apply_bloom_deployment_tofu_modules.md
@@ -1,14 +1,14 @@
-# Apply Bloom Deployment OpenTofu Modules
+# Apply Deployment OpenTofu Modules
 
-This directory contains instructions for deploying Bloom dev and prod environments to an AWS
+This directory contains instructions for deploying dev and prod environments to an AWS
 organization. The guide is broken down into a series of files that should be followed in order:
 
 1. [Create AWS Accounts](./1_create_aws_accounts.md)
 2. [IAM Identity Center Configuration](./2_iam_identity_center_configuration.md)
 3. [Create Tofu State S3 Bucket](./3_create_tofu_state_s3_bucket.md)
-4. [Fork the Bloom Repo](./4_fork_bloom_repo.md)
+4. [Fork the Repo](./4_fork_bloom_repo.md)
 5. [Apply Deployer Permission Set Tofu Modules](./5_apply_deployer_permission_set_tofu_modules.md)
-6. [Apply Bloom Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md) (you are here)
+6. [Apply Deployment Tofu Modules](./6_apply_bloom_deployment_tofu_modules.md) (you are here)
 
 The steps in this file create the following resources (the OpenTofu files in
 [bloom_deployment](../tofu_importable_modules/bloom_deployment) fully describe all resources that
@@ -28,7 +28,7 @@ graph TB
       subgraph MA[AWS Management Account]
           direction TB
 
-          S3[Bloom Tofu State Files<br/>AWS S3 Bucket]
+          S3[Tofu State Files<br/>AWS S3 Bucket]
       end
 
       subgraph DEV[bloom-dev Account]
@@ -105,7 +105,7 @@ graph TB
 1. Create the AWS managed certificate for your domain:
 
    ```bash
-   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/bloom/infra:gitsha-SOMESHA bloom_dev apply -exclude=module.bloom_deployment
+   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra:gitsha-SOMESHA bloom_dev apply -exclude=module.bloom_deployment
    ```
 
 2. Validate the AWS managed certificate:
@@ -116,8 +116,8 @@ graph TB
 
    Type | Name | Content
    ---|---|---
-   CNAME | _4b8c99d969da11b1e35c36786a74b6fe.core-dev.bloomhousing.dev. | _003be6eab99411307156f79225503c77.jkddzztszm.acm-validations.aws.
-   CNAME | _aa08a6efc0ba7025472371c5b7b44120.partners.core-dev.bloomhousing.dev. | _fc0aa55094ea4ea64f60830d3a008225.jkddzztszm.acm-validations.aws.
+   CNAME | _4b8c99d969da11b1e35c36786a74b6fe.dev.<YOUR_DOMAIN>. | _003be6eab99411307156f79225503c77.jkddzztszm.acm-validations.aws.
+   CNAME | _aa08a6efc0ba7025472371c5b7b44120.partners.dev.<YOUR_DOMAIN>. | _fc0aa55094ea4ea64f60830d3a008225.jkddzztszm.acm-validations.aws.
 
    ```
    Outputs:
@@ -132,14 +132,14 @@ graph TB
      }
      "validation_dns_recods" = toset([
        {
-         "domain_name" = "core-dev.bloomhousing.dev"
-         "resource_record_name" = "_4b8c99d969da11b1e35c36786a74b6fe.core-dev.bloomhousing.dev."
+         "domain_name" = "dev.<YOUR_DOMAIN>"
+         "resource_record_name" = "_4b8c99d969da11b1e35c36786a74b6fe.dev.<YOUR_DOMAIN>."
          "resource_record_type" = "CNAME"
          "resource_record_value" = "_003be6eab99411307156f79225503c77.jkddzztszm.acm-validations.aws."
        },
        {
-         "domain_name" = "partners.core-dev.bloomhousing.dev"
-         "resource_record_name" = "_aa08a6efc0ba7025472371c5b7b44120.partners.core-dev.bloomhousing.dev."
+         "domain_name" = "partners.dev.<YOUR_DOMAIN>"
+         "resource_record_name" = "_aa08a6efc0ba7025472371c5b7b44120.partners.dev.<YOUR_DOMAIN>."
          "resource_record_type" = "CNAME"
          "resource_record_value" = "_fc0aa55094ea4ea64f60830d3a008225.jkddzztszm.acm-validations.aws."
        },
@@ -147,10 +147,10 @@ graph TB
    }
    ```
 
-3. Deploy Bloom:
+3. Deploy the application:
 
    ```bash
-   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/bloom/infra:gitsha-SOMESHA bloom_dev apply
+   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra:gitsha-SOMESHA bloom_dev apply
    ```
 
    The output will include a `aws_lb_dns_name`. DNS CNAME records
@@ -159,13 +159,13 @@ graph TB
 
    Type | Name | Content
    ---|---|---
-   CNAME | core-dev | bloom-1787634238.us-west-2.elb.amazonaws.com
-   CNAME | partners.core-dev | bloom-1787634238.us-west-2.elb.amazonaws.com
+   CNAME | dev | app-1787634238.us-west-2.elb.amazonaws.com
+   CNAME | partners.dev | app-1787634238.us-west-2.elb.amazonaws.com
 
    ```
    Outputs:
 
-   aws_lb_dns_name = "bloom-1787634238.us-west-2.elb.amazonaws.com"
+   aws_lb_dns_name = "app-1787634238.us-west-2.elb.amazonaws.com"
    ```
 
 ### 2. Deploy prod
@@ -173,7 +173,7 @@ graph TB
 1. Create the AWS managed certificate for your domain:
 
    ```bash
-   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/bloom/infra:gitsha-SOMESHA bloom_prod apply -exclude=module.bloom_deployment
+   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra:gitsha-SOMESHA bloom_prod apply -exclude=module.bloom_deployment
    ```
 
 2. Validate the AWS managed certificate:
@@ -184,8 +184,8 @@ graph TB
 
    Type | Name | Content
    ---|---|---
-   CNAME | _BLAH.core-prod.bloomhousing.dev. | _BLAH.jkddzztszm.acm-validations.aws.
-   CNAME | _BLAH.partners.core-prod.bloomhousing.dev. | _BLAH.jkddzztszm.acm-validations.aws.
+   CNAME | _BLAH.prod.<YOUR_DOMAIN>. | _BLAH.jkddzztszm.acm-validations.aws.
+   CNAME | _BLAH.partners.prod.<YOUR_DOMAIN>. | _BLAH.jkddzztszm.acm-validations.aws.
 
    ```
    Outputs:
@@ -200,14 +200,14 @@ graph TB
      }
      "validation_dns_recods" = toset([
        {
-         "domain_name" = "core-prod.bloomhousing.dev"
-         "resource_record_name" = "_BLAH.core-prod.bloomhousing.dev."
+         "domain_name" = "prod.<YOUR_DOMAIN>"
+         "resource_record_name" = "_BLAH.prod.<YOUR_DOMAIN>."
          "resource_record_type" = "CNAME"
          "resource_record_value" = "_BLAH.jkddzztszm.acm-validations.aws."
        },
        {
-         "domain_name" = "partners.core-prod.bloomhousing.dev"
-         "resource_record_name" = "_BLAH.partners.core-prod.bloomhousing.dev."
+         "domain_name" = "partners.prod.<YOUR_DOMAIN>"
+         "resource_record_name" = "_BLAH.partners.prod.<YOUR_DOMAIN>."
          "resource_record_type" = "CNAME"
          "resource_record_value" = "_BLAH.jkddzztszm.acm-validations.aws."
        },
@@ -215,10 +215,10 @@ graph TB
    }
    ```
 
-3. Deploy the Bloom services:
+3. Deploy the services:
 
    ```bash
-   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/bloom/infra:gitsha-SOMESHA bloom_prod apply
+   docker run --rm -it ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra:gitsha-SOMESHA bloom_prod apply
    ```
 
    The output will include a `aws_lb_dns_name`. DNS CNAME records
@@ -227,17 +227,17 @@ graph TB
 
    Type | Name | Content
    ---|---|---
-   CNAME | core-prod | bloom-1787634238.us-west-2.elb.amazonaws.com
-   CNAME | partners.core-prod | bloom-1787634238.us-west-2.elb.amazonaws.com
+   CNAME | prod | app-1787634238.us-west-2.elb.amazonaws.com
+   CNAME | partners.prod | app-1787634238.us-west-2.elb.amazonaws.com
 
    ```
    Outputs:
 
-   aws_lb_dns_name = "bloom-1787634238.us-west-2.elb.amazonaws.com"
+   aws_lb_dns_name = "app-1787634238.us-west-2.elb.amazonaws.com"
    ```
 
 ## After these steps
 
-1. Your dev Bloom deployment should be accessible:
+1. Your dev deployment should be accessible:
    - public site: `https://<YOUR_DOMAIN>
    - partners site: `https://partners.<YOUR_DOMAIN>

--- a/infra/docker-entrypoint.py
+++ b/infra/docker-entrypoint.py
@@ -3,7 +3,7 @@
 # At current time of writing: 3.9.24
 #
 # To get the version for a particular image tag:
-# `docker container run --rm -it --entrypoint python3 ghcr.io/bloom-housing/bloom/infra:<tag> --version`
+# `docker container run --rm -it --entrypoint python3 ghcr.io/<YOUR_GITHUB_ORG>/affordable-housing-portal/infra:<tag> --version`
 #
 # Formatted with yapf https://github.com/google/yapf with args:
 # `--style='{based_on_style:google,SPLIT_BEFORE_FIRST_ARGUMENT:true,COLUMN_LIMIT=100}'`
@@ -41,7 +41,7 @@ def run_subprocess(cmd, cwd=None, always_exit=False):
 
 def main():
     # Valid root modules and their AWS CLI profile names:
-    # TODO(https://github.com/bloom-housing/bloom/issues/5760): make this dynamic.
+    # TODO: make this dynamic (upstream: bloom-housing/bloom#5760).
     mod_to_aws_profile = {
         "bloom_dev": "bloom-dev-deployer",
         "bloom_dev_deployer_permission_set_policy": "bloom-dev-iam-admin",
@@ -51,7 +51,7 @@ def main():
 
     p = argparse.ArgumentParser(
         prog="docker-entrypoint.py",
-        description="CLI entrypoint for working with Bloom OpenTofu root modules.",
+        description="CLI entrypoint for working with OpenTofu root modules.",
         allow_abbrev=True)
 
     p.add_argument(


### PR DESCRIPTION
## Changes

Update documentation across the project to reflect fork-specific naming and reduce references to "Bloom" branding:

### Documentation Updates
- **Analytics.md**: Changed "Bloom reference apps" to "front-end apps"
- **Authentication.md**: Updated service references from `backend/core` to `api`, fixed malformed URL, updated component imports
- **DeployAppsNetlify.md**: Added upstream project note, improved clarity and removed Bloom-specific references
- **DeployServicesHeroku.md**: Added upstream project note, updated service references
- **Styling2ndGen.md**: Removed Bloom branding references while keeping design tokens prefix, added upstream reference note

### Infrastructure Documentation
- **DEVELOPMENT.md**: Updated container registry references and alias examples from `bloom-housing/bloom` to fork-specific format
- **Dockerfile.dev**: Updated container prompts and comments to be generic
- **AWS Deployment Guide**: 
  - Updated all file titles to remove "Bloom" branding
  - Added upstream project notes to key deployment guides
  - Updated container registry references to use `<YOUR_GITHUB_ORG>` placeholder
  - Replaced hardcoded domain examples with generic placeholders
  - Updated account/resource naming to be more generic while noting upstream naming convention
  - Updated DNS CNAME examples to use generic names (e.g., `dev` instead of `core-dev`)
- **docker-entrypoint.py**: Updated container registry reference and generic comments

### Summary
These changes make the documentation more adaptable to forks while preserving references to the upstream Bloom Housing project where appropriate.