### PR TITLE
fix: restore login keyboard flow

### DIFF
--- a/shared-helpers/src/views/sign-in/FormSignIn.module.scss
+++ b/shared-helpers/src/views/sign-in/FormSignIn.module.scss
@@ -1,5 +1,10 @@
+.forgot-password-container {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .forgot-password {
-  float: inline-end;
+  display: inline-flex;
   font-size: var(--seeds-font-size-sm);
   text-decoration-line: underline;
   color: var(--seeds-color-blue-900);

--- a/shared-helpers/src/views/sign-in/FormSignInDefault.tsx
+++ b/shared-helpers/src/views/sign-in/FormSignInDefault.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { useRouter } from "next/router"
 import type { UseFormMethods } from "react-hook-form"
-import { Field, Form, NavigationContext, t } from "@bloom-housing/ui-components"
+import { Field, NavigationContext, t } from "@bloom-housing/ui-components"
 import { Button } from "@bloom-housing/ui-seeds"
 import { getListingRedirectUrl } from "../../utilities/getListingRedirectUrl"
 import styles from "./FormSignIn.module.scss"
@@ -37,7 +37,7 @@ const FormSignInDefault = ({
   const forgetPasswordURL = getListingRedirectUrl(listingIdRedirect, "/forgot-password")
 
   return (
-    <Form id="sign-in" onSubmit={handleSubmit(onSubmit, onError)}>
+    <form id="sign-in" onSubmit={handleSubmit(onSubmit, onError)} noValidate>
       <Field
         className={styles["sign-in-email-input"]}
         name="email"
@@ -49,11 +49,6 @@ const FormSignInDefault = ({
         register={register}
         dataTestId="sign-in-email-field"
       />
-      <aside>
-        <LinkComponent href={forgetPasswordURL} className={styles["forgot-password"]}>
-          {t("authentication.signIn.forgotPassword")}
-        </LinkComponent>
-      </aside>
       <Field
         className={styles["sign-in-password-input"]}
         name="password"
@@ -66,6 +61,11 @@ const FormSignInDefault = ({
         type={"password"}
         dataTestId="sign-in-password-field"
       />
+      <aside className={styles["forgot-password-container"]}>
+        <LinkComponent href={forgetPasswordURL} className={styles["forgot-password"]}>
+          {t("authentication.signIn.forgotPassword")}
+        </LinkComponent>
+      </aside>
       <div className={styles["sign-in-action"]}>
         <Button
           type="submit"
@@ -76,7 +76,7 @@ const FormSignInDefault = ({
           {t("nav.signIn")}
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/shared-helpers/src/views/sign-in/FormSignInPwdless.tsx
+++ b/shared-helpers/src/views/sign-in/FormSignInPwdless.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react"
 import { useRouter } from "next/router"
 import type { UseFormMethods } from "react-hook-form"
-import { Field, Form, NavigationContext, t } from "@bloom-housing/ui-components"
+import { Field, NavigationContext, t } from "@bloom-housing/ui-components"
 import { Button } from "@bloom-housing/ui-seeds"
 import { getListingRedirectUrl } from "../../utilities/getListingRedirectUrl"
 import styles from "./FormSignIn.module.scss"
@@ -41,7 +41,7 @@ const FormSignInPwdless = ({
   const forgetPasswordURL = getListingRedirectUrl(listingIdRedirect, "/forgot-password")
 
   return (
-    <Form id="sign-in" onSubmit={handleSubmit(onSubmit, onError)}>
+    <form id="sign-in" onSubmit={handleSubmit(onSubmit, onError)} noValidate>
       <Field
         className={styles["sign-in-email-input"]}
         name="email"
@@ -57,11 +57,6 @@ const FormSignInPwdless = ({
 
       {!useCode && (
         <>
-          <aside>
-            <LinkComponent href={forgetPasswordURL} className={styles["forgot-password"]}>
-              {t("authentication.signIn.forgotPassword")}
-            </LinkComponent>
-          </aside>
           <Field
             className={styles["sign-in-password-input"]}
             name="password"
@@ -74,6 +69,11 @@ const FormSignInPwdless = ({
             type={"password"}
             dataTestId="sign-in-password-field"
           />
+          <aside className={styles["forgot-password-container"]}>
+            <LinkComponent href={forgetPasswordURL} className={styles["forgot-password"]}>
+              {t("authentication.signIn.forgotPassword")}
+            </LinkComponent>
+          </aside>
         </>
       )}
       <div className={styles["sign-in-action"]}>
@@ -87,13 +87,13 @@ const FormSignInPwdless = ({
         </Button>
       </div>
       <div className={styles["sign-in-action"]}>
-        <Button variant={"text"} onClick={() => setUseCode(!useCode)}>
+        <Button type="button" variant={"text"} onClick={() => setUseCode(!useCode)}>
           {useCode
             ? t("authentication.signIn.pwdless.usePassword")
             : t("authentication.signIn.pwdless.useCode")}
         </Button>
       </div>
-    </Form>
+    </form>
   )
 }
 

--- a/sites/partners/__tests__/pages/sign-in.test.tsx
+++ b/sites/partners/__tests__/pages/sign-in.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { render, fireEvent, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { useRouter } from "next/router"
 import { MessageContext, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserService, MfaType } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
@@ -116,6 +117,69 @@ describe("Partners Sign In Page", () => {
         )
         expect(mockRouter.push).toHaveBeenCalledWith("/")
       })
+    })
+
+    it("submits the sign-in form when enter is pressed in the password field", async () => {
+      const user = userEvent.setup()
+      const mockLogin = jest.fn().mockResolvedValue({ firstName: "Partner", id: "user-123" })
+      const mockRouter = { query: {}, push: jest.fn() }
+      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+      const { getByLabelText } = render(
+        <AuthContext.Provider
+          value={{
+            initialStateLoaded: true,
+            profile: undefined,
+            login: mockLogin,
+            doJurisdictionsHaveFeatureFlagOn: mockDoJurisdictionsHaveFeatureFlagOn,
+          }}
+        >
+          <MessageContext.Provider value={TOAST_MESSAGE}>
+            <SignIn />
+          </MessageContext.Provider>
+        </AuthContext.Provider>
+      )
+
+      await user.type(getByLabelText("Email"), "partner@example.com")
+      await user.type(getByLabelText("Password"), "password123{Enter}")
+
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith(
+          "partner@example.com",
+          "password123",
+          undefined,
+          undefined,
+          true,
+          undefined
+        )
+      })
+    })
+
+    it("tabs from email to password before forgot password", async () => {
+      const user = userEvent.setup()
+      const { getByLabelText, getByRole } = render(
+        <AuthContext.Provider
+          value={{
+            initialStateLoaded: true,
+            profile: undefined,
+            doJurisdictionsHaveFeatureFlagOn: mockDoJurisdictionsHaveFeatureFlagOn,
+          }}
+        >
+          <MessageContext.Provider value={TOAST_MESSAGE}>
+            <SignIn />
+          </MessageContext.Provider>
+        </AuthContext.Provider>
+      )
+
+      const emailInput = getByLabelText("Email")
+      const passwordInput = getByLabelText("Password")
+      const forgotPasswordLink = getByRole("link", { name: /forgot password/i })
+
+      await user.click(emailInput)
+      await user.tab()
+      expect(passwordInput).toHaveFocus()
+      await user.tab()
+      expect(forgotPasswordLink).toHaveFocus()
     })
 
     it("shows error when email is missing", async () => {

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { render, fireEvent, waitFor, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { useRouter } from "next/router"
 import { MessageContext, AuthContext } from "@bloom-housing/shared-helpers"
 import { jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
@@ -90,6 +91,57 @@ describe("Sign In Page", () => {
         variant: "success",
       })
     })
+  })
+
+  it("submits the sign-in form when enter is pressed in the password field", async () => {
+    const user = userEvent.setup()
+    const mockUser = { firstName: "User", id: "user-123" }
+    const mockLogin = jest.fn().mockResolvedValue(mockUser)
+    const mockRouter = { query: {}, push: jest.fn() }
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    const { getByLabelText } = render(
+      <AuthContext.Provider
+        value={{
+          initialStateLoaded: true,
+          profile: undefined,
+          login: mockLogin,
+        }}
+      >
+        <MessageContext.Provider value={TOAST_MESSAGE}>
+          <SignInComponent jurisdiction={jurisdiction} />
+        </MessageContext.Provider>
+      </AuthContext.Provider>
+    )
+
+    await user.type(getByLabelText("Email"), "user@example.com")
+    await user.type(getByLabelText("Password"), "password123{Enter}")
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith(
+        "user@example.com",
+        "password123",
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+    })
+  })
+
+  it("tabs from email to password before forgot password", async () => {
+    const user = userEvent.setup()
+    const { getByLabelText, getByRole } = renderSignInPage()
+
+    const emailInput = getByLabelText("Email")
+    const passwordInput = getByLabelText("Password")
+    const forgotPasswordLink = getByRole("link", { name: /forgot password/i })
+
+    await user.click(emailInput)
+    await user.tab()
+    expect(passwordInput).toHaveFocus()
+    await user.tab()
+    expect(forgotPasswordLink).toHaveFocus()
   })
 
   describe("Field validation errors", () => {
@@ -274,6 +326,7 @@ describe("Passwordless Sign In page", () => {
   })
 
   it("logs in with password after clicking 'Use your password instead' button", async () => {
+    const user = userEvent.setup()
     const mockLogin = jest.fn().mockResolvedValue({ firstName: "User" })
     const mockAddToast = jest.fn()
     const mockRouter = { query: {}, push: jest.fn() }
@@ -292,11 +345,9 @@ describe("Passwordless Sign In page", () => {
       </AuthContext.Provider>
     )
 
-    fireEvent.click(getByRole("button", { name: "Use your password instead" }))
-
-    fireEvent.change(getByLabelText("Email"), { target: { value: "user@example.com" } })
-    fireEvent.change(getByLabelText("Password"), { target: { value: "password123" } })
-    fireEvent.click(getByRole("button", { name: /sign in/i }))
+    await user.click(getByRole("button", { name: "Use your password instead" }))
+    await user.type(getByLabelText("Email"), "user@example.com")
+    await user.type(getByLabelText("Password"), "password123{Enter}")
 
     await waitFor(() => {
       expect(mockLogin).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- restore native enter-to-submit behavior for the shared sign-in forms used by the public and partner portals
- reorder the shared password login form so tab navigation goes from email to password before the forgot password link
- add regression tests for enter-submit and tab order in both portal sign-in pages

## Testing
- `cd sites/public && yarn test:unit --runTestsByPath __tests__/pages/sign-in.test.tsx`
- `cd sites/partners && yarn test:unit --runTestsByPath __tests__/pages/sign-in.test.tsx`