### PR TITLE
Remove jurisdiction assignment from users

### DIFF
--- a/api/prisma/migrations/20260320010000_remove_user_jurisdictions/migration.sql
+++ b/api/prisma/migrations/20260320010000_remove_user_jurisdictions/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "_JurisdictionsToUserAccounts" DROP CONSTRAINT "_JurisdictionsToUserAccounts_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_JurisdictionsToUserAccounts" DROP CONSTRAINT "_JurisdictionsToUserAccounts_B_fkey";
+
+-- DropTable
+DROP TABLE "_JurisdictionsToUserAccounts";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -806,7 +806,6 @@ model Jurisdictions {
   propertySnapshots      PropertySnapshot[]
   reservedCommunityTypes ReservedCommunityTypes[]
   translations           Translations[]
-  user_accounts          UserAccounts[]
   userAccountSnapshot    UserAccountSnapshot[]
 
   @@map("jurisdictions")
@@ -2070,7 +2069,6 @@ model UserAccounts {
   applicationFlaggedSet     ApplicationFlaggedSet[]
   applications              Applications[]
   favoriteListings          Listings[]              @relation("favorite_listings")
-  jurisdictions             Jurisdictions[]
   lastUpdatedListingsByUser Listings[]              @relation("last_updated_by_user")
   listings                  Listings[]
   requestedChangesListings  Listings[]              @relation("requested_changes_user")

--- a/api/prisma/seed-dev.ts
+++ b/api/prisma/seed-dev.ts
@@ -57,7 +57,6 @@ export const devSeeding = async (
       roles: { isAdmin: true },
       email: 'admin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [jurisdiction.id],
       acceptedTerms: true,
       password: 'abcdef',
     }),
@@ -66,7 +65,6 @@ export const devSeeding = async (
     data: await userFactory({
       email: 'public-user@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [jurisdiction.id],
       password: 'abcdef',
     }),
   });
@@ -75,7 +73,6 @@ export const devSeeding = async (
       roles: { isJurisdictionalAdmin: true },
       email: 'jurisdiction-admin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [jurisdiction.id],
       acceptedTerms: true,
     }),
   });
@@ -84,7 +81,6 @@ export const devSeeding = async (
       roles: { isLimitedJurisdictionalAdmin: true },
       email: 'limited-jurisdiction-admin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [jurisdiction.id],
       acceptedTerms: true,
     }),
   });
@@ -92,7 +88,6 @@ export const devSeeding = async (
     data: await userFactory({
       roles: { isSupportAdmin: true },
       email: 'support-admin@example.com',
-      jurisdictionIds: [jurisdiction.id],
       confirmedAt: new Date(),
       acceptedTerms: true,
     }),

--- a/api/prisma/seed-helpers/user-factory.ts
+++ b/api/prisma/seed-helpers/user-factory.ts
@@ -8,7 +8,6 @@ export const userFactory = async (optionalParams?: {
   email?: string;
   favoriteListings?: string[];
   firstName?: string;
-  jurisdictionIds?: string[];
   lastName?: string;
   listings?: string[];
   mfaEnabled?: boolean;
@@ -45,15 +44,6 @@ export const userFactory = async (optionalParams?: {
     ? {
         connect: optionalParams.favoriteListings.map((listing) => {
           return { id: listing };
-        }),
-      }
-    : undefined,
-  jurisdictions: optionalParams?.jurisdictionIds
-    ? {
-        connect: optionalParams?.jurisdictionIds.map((jurisdiction) => {
-          return {
-            id: jurisdiction,
-          };
         }),
       }
     : undefined,

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -170,7 +170,7 @@ export const stagingSeed = async (
     }),
   });
   // Basic configuration jurisdiction
-  const bridgeBayJurisdiction = await prismaClient.jurisdictions.create({
+  await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Bridge Bay', {
       publicSiteBaseURL: publicSiteBaseURL,
       featureFlags: [
@@ -188,7 +188,7 @@ export const stagingSeed = async (
     }),
   });
   // Jurisdiction with no feature flags enabled
-  const nadaHill = await prismaClient.jurisdictions.create({
+  await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Nada Hill', {
       publicSiteBaseURL: publicSiteBaseURL,
       featureFlags: [],
@@ -334,13 +334,6 @@ export const stagingSeed = async (
       roles: { isSuperAdmin: true, isAdmin: true },
       email: 'superadmin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [
-        mainJurisdiction.id,
-        lakeviewJurisdiction.id,
-        bridgeBayJurisdiction.id,
-        nadaHill.id,
-        angelopolisJurisdiction.id,
-      ],
       acceptedTerms: true,
       password: 'abcdef',
     }),
@@ -351,13 +344,6 @@ export const stagingSeed = async (
       roles: { isAdmin: true },
       email: 'admin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [
-        mainJurisdiction.id,
-        lakeviewJurisdiction.id,
-        bridgeBayJurisdiction.id,
-        nadaHill.id,
-        angelopolisJurisdiction.id,
-      ],
       acceptedTerms: true,
       password: 'abcdef',
     }),
@@ -369,13 +355,6 @@ export const stagingSeed = async (
       email: 'support-admin@example.com',
       confirmedAt: new Date(),
       acceptedTerms: true,
-      jurisdictionIds: [
-        mainJurisdiction.id,
-        lakeviewJurisdiction.id,
-        bridgeBayJurisdiction.id,
-        nadaHill.id,
-        angelopolisJurisdiction.id,
-      ],
     }),
   });
   // create a jurisdictional admin
@@ -384,7 +363,6 @@ export const stagingSeed = async (
       roles: { isJurisdictionalAdmin: true },
       email: 'jurisdiction-admin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [mainJurisdiction.id],
       acceptedTerms: true,
     }),
   });
@@ -394,7 +372,6 @@ export const stagingSeed = async (
       roles: { isLimitedJurisdictionalAdmin: true },
       email: 'limited-jurisdiction-admin@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [mainJurisdiction.id],
       acceptedTerms: true,
     }),
   });
@@ -404,7 +381,6 @@ export const stagingSeed = async (
       roles: { isPartner: true },
       email: 'partner@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [mainJurisdiction.id],
       acceptedTerms: true,
     }),
   });
@@ -413,7 +389,6 @@ export const stagingSeed = async (
       roles: { isAdmin: true },
       email: 'unverified@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [mainJurisdiction.id],
       acceptedTerms: false,
     }),
   });
@@ -422,7 +397,6 @@ export const stagingSeed = async (
       roles: { isAdmin: true },
       email: 'mfauser@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [mainJurisdiction.id],
       acceptedTerms: true,
       mfaEnabled: true,
       singleUseCode: '12345',
@@ -432,7 +406,6 @@ export const stagingSeed = async (
     data: await userFactory({
       email: 'public-user@example.com',
       confirmedAt: new Date(),
-      jurisdictionIds: [mainJurisdiction.id],
       password: 'abcdef',
     }),
   });
@@ -445,13 +418,6 @@ export const stagingSeed = async (
       },
       email: `partner-user@example.com`,
       confirmedAt: new Date(),
-      jurisdictionIds: [
-        mainJurisdiction.id,
-        lakeviewJurisdiction.id,
-        bridgeBayJurisdiction.id,
-        nadaHill.id,
-        angelopolisJurisdiction.id,
-      ],
       acceptedTerms: true,
     }),
   });
@@ -1332,7 +1298,6 @@ export const stagingSeed = async (
             .toLowerCase()
             .replaceAll(' ', '-')}@example.com`,
           confirmedAt: new Date(),
-          jurisdictionIds: [savedListing.jurisdictionId],
           acceptedTerms: true,
           listings: [savedListing.id],
         }),

--- a/api/src/dtos/users/user-create.dto.ts
+++ b/api/src/dtos/users/user-create.dto.ts
@@ -1,20 +1,12 @@
 import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
-import { Expose, Type } from 'class-transformer';
-import {
-  IsArray,
-  IsEmail,
-  IsString,
-  Matches,
-  MaxLength,
-  ValidateNested,
-} from 'class-validator';
+import { Expose } from 'class-transformer';
+import { IsEmail, IsString, Matches, MaxLength } from 'class-validator';
 import { UserUpdate } from './user-update.dto';
 
 import { EnforceLowerCase } from '../../decorators/enforce-lower-case.decorator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 import { passwordRegex } from '../../utilities/password-regex';
 import { Match } from '../../decorators/match-decorator';
-import { IdDTO } from '../shared/id.dto';
 
 export class UserCreate extends OmitType(UserUpdate, [
   'id',
@@ -22,7 +14,6 @@ export class UserCreate extends OmitType(UserUpdate, [
   'password',
   'currentPassword',
   'email',
-  'jurisdictions',
 ]) {
   @Expose()
   @ApiProperty()
@@ -52,11 +43,4 @@ export class UserCreate extends OmitType(UserUpdate, [
   @Match('email', { groups: [ValidationsGroupsEnum.default] })
   @EnforceLowerCase()
   emailConfirmation?: string;
-
-  @Expose()
-  @Type(() => IdDTO)
-  @IsArray({ groups: [ValidationsGroupsEnum.default] })
-  @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
-  @ApiPropertyOptional({ type: IdDTO, isArray: true })
-  jurisdictions?: IdDTO[];
 }

--- a/api/src/dtos/users/user-invite.dto.ts
+++ b/api/src/dtos/users/user-invite.dto.ts
@@ -1,16 +1,10 @@
 import { ApiProperty, OmitType } from '@nestjs/swagger';
-import { Expose, Type } from 'class-transformer';
-import {
-  ArrayMinSize,
-  IsArray,
-  IsEmail,
-  ValidateNested,
-} from 'class-validator';
+import { Expose } from 'class-transformer';
+import { IsEmail } from 'class-validator';
 import { UserUpdate } from './user-update.dto';
 
 import { EnforceLowerCase } from '../../decorators/enforce-lower-case.decorator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
-import { IdDTO } from '../shared/id.dto';
 
 export class UserInvite extends OmitType(UserUpdate, [
   'id',
@@ -18,19 +12,10 @@ export class UserInvite extends OmitType(UserUpdate, [
   'currentPassword',
   'email',
   'agreedToTermsOfService',
-  'jurisdictions',
 ]) {
   @Expose()
   @ApiProperty()
   @IsEmail({}, { groups: [ValidationsGroupsEnum.default] })
   @EnforceLowerCase()
   email: string;
-
-  @Expose()
-  @Type(() => IdDTO)
-  @IsArray({ groups: [ValidationsGroupsEnum.default] })
-  @ArrayMinSize(1, { groups: [ValidationsGroupsEnum.default] })
-  @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
-  @ApiProperty({ type: IdDTO, isArray: true })
-  jurisdictions: IdDTO[];
 }

--- a/api/src/dtos/users/user-update.dto.ts
+++ b/api/src/dtos/users/user-update.dto.ts
@@ -1,7 +1,6 @@
 import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
-import { Expose, Type } from 'class-transformer';
+import { Expose } from 'class-transformer';
 import {
-  IsArray,
   IsEmail,
   IsNotEmpty,
   IsString,
@@ -14,7 +13,6 @@ import { User } from './user.dto';
 import { EnforceLowerCase } from '../../decorators/enforce-lower-case.decorator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 import { passwordRegex } from '../../utilities/password-regex';
-import { IdDTO } from '../shared/id.dto';
 
 export class UserUpdate extends OmitType(User, [
   'createdAt',
@@ -65,10 +63,4 @@ export class UserUpdate extends OmitType(User, [
   @MaxLength(256, { groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional()
   appUrl?: string;
-
-  @Expose()
-  @Type(() => IdDTO)
-  @IsArray({ groups: [ValidationsGroupsEnum.default] })
-  @ApiPropertyOptional({ type: IdDTO, isArray: true })
-  jurisdictions: IdDTO[];
 }

--- a/api/src/passports/jwt.strategy.ts
+++ b/api/src/passports/jwt.strategy.ts
@@ -34,16 +34,6 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
       include: {
         listings: true,
         userRoles: true,
-        jurisdictions: {
-          include: {
-            featureFlags: {
-              select: {
-                name: true,
-                active: true,
-              },
-            },
-          },
-        },
       },
       where: {
         id: userId,
@@ -70,7 +60,21 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
       `);
     }
 
-    const user = mapTo(User, rawUser);
+    const siteJurisdiction = await this.prisma.jurisdictions.findFirst({
+      include: {
+        featureFlags: {
+          select: {
+            name: true,
+            active: true,
+          },
+        },
+      },
+    });
+
+    const user = mapTo(User, {
+      ...rawUser,
+      jurisdictions: siteJurisdiction ? [siteJurisdiction] : [],
+    });
     return user;
   }
 

--- a/api/src/passports/mfa.strategy.ts
+++ b/api/src/passports/mfa.strategy.ts
@@ -46,7 +46,6 @@ export class MfaStrategy extends PassportStrategy(Strategy, 'mfa') {
       include: {
         userRoles: true,
         listings: true,
-        jurisdictions: true,
       },
       where: {
         email: dto.email,
@@ -96,7 +95,20 @@ export class MfaStrategy extends PassportStrategy(Strategy, 'mfa') {
     if (!rawUser.mfaEnabled) {
       // if user is not an mfaEnabled user
       await this.updateStoredUser(null, null, null, 0, rawUser.id);
-      return mapTo(User, rawUser);
+      const siteJurisdiction = await this.prisma.jurisdictions.findFirst({
+        include: {
+          featureFlags: {
+            select: {
+              name: true,
+              active: true,
+            },
+          },
+        },
+      });
+      return mapTo(User, {
+        ...rawUser,
+        jurisdictions: siteJurisdiction ? [siteJurisdiction] : [],
+      });
     }
 
     let authSuccess = true;
@@ -162,7 +174,20 @@ export class MfaStrategy extends PassportStrategy(Strategy, 'mfa') {
       rawUser.failedLoginAttemptsCount,
       rawUser.id,
     );
-    return mapTo(User, rawUser);
+    const siteJurisdiction = await this.prisma.jurisdictions.findFirst({
+      include: {
+        featureFlags: {
+          select: {
+            name: true,
+            active: true,
+          },
+        },
+      },
+    });
+    return mapTo(User, {
+      ...rawUser,
+      jurisdictions: siteJurisdiction ? [siteJurisdiction] : [],
+    });
   }
 
   async updateFailedLoginCount(count: number, userId: string): Promise<void> {

--- a/api/src/passports/single-use-code.strategy.ts
+++ b/api/src/passports/single-use-code.strategy.ts
@@ -74,7 +74,6 @@ export class SingleUseCodeStrategy extends PassportStrategy(
       include: {
         userRoles: true,
         listings: true,
-        jurisdictions: true,
       },
       where: {
         email: dto.email,
@@ -150,7 +149,20 @@ export class SingleUseCodeStrategy extends PassportStrategy(
       rawUser.failedLoginAttemptsCount,
       rawUser.id,
     );
-    return mapTo(User, rawUser);
+    const siteJurisdiction = await this.prisma.jurisdictions.findFirst({
+      include: {
+        featureFlags: {
+          select: {
+            name: true,
+            active: true,
+          },
+        },
+      },
+    });
+    return mapTo(User, {
+      ...rawUser,
+      jurisdictions: siteJurisdiction ? [siteJurisdiction] : [],
+    });
   }
 
   async updateFailedLoginCount(count: number, userId: string): Promise<void> {

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -178,7 +178,8 @@ export class EmailService {
         jurisdictionName: jurisdictionName,
       });
     }
-    return null;
+
+    return await this.jurisdictionService.findSingleton();
   }
 
   private async getEmailToSendFrom(

--- a/api/src/services/jurisdiction.service.ts
+++ b/api/src/services/jurisdiction.service.ts
@@ -85,6 +85,26 @@ export class JurisdictionService {
     return mapTo(Jurisdiction, rawJurisdiction);
   }
 
+  /**
+   * Returns the first jurisdiction row to use as the singleton site configuration.
+   *
+   * @returns The singleton jurisdiction record.
+   * @throws {NotFoundException} If no jurisdiction rows exist.
+   */
+  async findSingleton(): Promise<Jurisdiction> {
+    const rawJurisdiction = await this.prisma.jurisdictions.findFirst({
+      include: view,
+    });
+
+    if (!rawJurisdiction) {
+      throw new NotFoundException(
+        'site configuration was requested but not found',
+      );
+    }
+
+    return mapTo(Jurisdiction, rawJurisdiction);
+  }
+
   /*
     this will create a jurisdiction
   */

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -303,8 +303,9 @@ export class ListingService implements OnModuleInit {
   public async getUserEmailInfo(
     userRoles: UserRoleEnum | UserRoleEnum[],
     listingId?: string,
-    jurisId?: string,
+    _jurisId?: string,
   ): Promise<{ emails: string[] }> {
+    void _jurisId;
     // determine where clause(s)
     const userRolesWhere: Prisma.UserAccountsWhereInput[] = [];
     if (userRoles.includes(UserRoleEnum.admin))
@@ -319,13 +320,11 @@ export class ListingService implements OnModuleInit {
     if (userRoles.includes(UserRoleEnum.jurisdictionAdmin)) {
       userRolesWhere.push({
         userRoles: { isJurisdictionalAdmin: true },
-        jurisdictions: { some: { id: jurisId } },
       });
     }
     if (userRoles.includes(UserRoleEnum.limitedJurisdictionAdmin)) {
       userRolesWhere.push({
         userRoles: { isLimitedJurisdictionalAdmin: true },
-        jurisdictions: { some: { id: jurisId } },
       });
     }
 

--- a/api/src/services/permission.service.ts
+++ b/api/src/services/permission.service.ts
@@ -5,7 +5,6 @@ import { UserRoleEnum } from '../enums/permissions/user-role-enum';
 import { User } from '../dtos/users/user.dto';
 import { PrismaService } from './prisma.service';
 import { permissionActions } from '../enums/permissions/permission-actions-enum';
-import { Jurisdiction } from '../dtos/jurisdictions/jurisdiction.dto';
 import Listing from '../dtos/listings/listing.dto';
 
 export type permissionCheckingObj = {
@@ -41,31 +40,27 @@ export class PermissionService {
     );
 
     if (user) {
-      const userJurisdictions = user.jurisdictions ?? [];
       e = await this.addUserPermissions(e, user);
 
       if (type === 'user' && obj?.id) {
         const accessedUser = await this.prisma.userAccounts.findUnique({
           select: {
             id: true,
-            jurisdictions: {
-              where: {
-                id: {
-                  in: userJurisdictions.map((juris) => juris.id),
-                },
-              },
-            },
-            listings: true,
-            userRoles: true,
           },
           where: {
             id: obj.id,
           },
         });
-        obj.jurisdictionId =
-          accessedUser?.jurisdictions.map(
-            (jurisdiction) => jurisdiction.id,
-          )[0] || '';
+
+        if (accessedUser) {
+          const singletonJurisdiction =
+            await this.prisma.jurisdictions.findFirst({
+              select: {
+                id: true,
+              },
+            });
+          obj.jurisdictionId = singletonJurisdiction?.id || '';
+        }
       }
     }
     return await e.enforce(user ? user.id : 'anonymous', type, action, obj);
@@ -76,8 +71,13 @@ export class PermissionService {
     Casbin doesn't support our permissioning requirements for jurisdictionalAdmin or partners so we custom build the permission set here
   */
   async addUserPermissions(enforcer: Enforcer, user: User): Promise<Enforcer> {
-    const userJurisdictions = user.jurisdictions ?? [];
+    const singletonJurisdiction = await this.prisma.jurisdictions.findFirst({
+      select: {
+        id: true,
+      },
+    });
     const userListings = user.listings ?? [];
+    const userJurisdictionId = singletonJurisdiction?.id;
 
     await enforcer.addRoleForUser(user.id, UserRoleEnum.user);
 
@@ -88,69 +88,63 @@ export class PermissionService {
     } else if (user.userRoles?.isJurisdictionalAdmin) {
       await enforcer.addRoleForUser(user.id, UserRoleEnum.jurisdictionAdmin);
 
-      await Promise.all(
-        userJurisdictions.map(async (adminInJurisdiction: Jurisdiction) => {
-          await enforcer.addPermissionForUser(
-            user.id,
-            'application',
-            `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
-            `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
-          );
-          await enforcer.addPermissionForUser(
-            user.id,
-            'listing',
-            `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
-            `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
-          );
-          await enforcer.addPermissionForUser(
-            user.id,
-            'multiselectQuestion',
-            `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
-            `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
-          );
-          await enforcer.addPermissionForUser(
-            user.id,
-            'properties',
-            `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
-            `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
-          );
-          await enforcer.addPermissionForUser(
-            user.id,
-            'user',
-            `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
-            `(${permissionActions.read}|${permissionActions.invitePartner}|${permissionActions.inviteJurisdictionalAdmin}|${permissionActions.update}|${permissionActions.delete})`,
-          );
-        }),
-      );
+      if (userJurisdictionId) {
+        await enforcer.addPermissionForUser(
+          user.id,
+          'application',
+          `r.obj.jurisdictionId == '${userJurisdictionId}'`,
+          `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
+        );
+        await enforcer.addPermissionForUser(
+          user.id,
+          'listing',
+          `r.obj.jurisdictionId == '${userJurisdictionId}'`,
+          `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
+        );
+        await enforcer.addPermissionForUser(
+          user.id,
+          'multiselectQuestion',
+          `r.obj.jurisdictionId == '${userJurisdictionId}'`,
+          `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
+        );
+        await enforcer.addPermissionForUser(
+          user.id,
+          'properties',
+          `r.obj.jurisdictionId == '${userJurisdictionId}'`,
+          `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
+        );
+        await enforcer.addPermissionForUser(
+          user.id,
+          'user',
+          `r.obj.jurisdictionId == '${userJurisdictionId}'`,
+          `(${permissionActions.read}|${permissionActions.invitePartner}|${permissionActions.inviteJurisdictionalAdmin}|${permissionActions.update}|${permissionActions.delete})`,
+        );
+      }
     } else if (user.userRoles?.isLimitedJurisdictionalAdmin) {
       await enforcer.addRoleForUser(
         user.id,
         UserRoleEnum.limitedJurisdictionAdmin,
       );
 
-      await Promise.all(
-        userJurisdictions.map(async (adminInJurisdiction: Jurisdiction) => {
-          await enforcer.addPermissionForUser(
-            user.id,
-            'listing',
-            `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
-            `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
-          );
-        }),
-      );
+      if (userJurisdictionId) {
+        await enforcer.addPermissionForUser(
+          user.id,
+          'listing',
+          `r.obj.jurisdictionId == '${userJurisdictionId}'`,
+          `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
+        );
+      }
     } else if (user.userRoles?.isPartner) {
       await enforcer.addRoleForUser(user.id, UserRoleEnum.partner);
 
-      await Promise.all(
-        userJurisdictions.map(async (jurisdiction: Jurisdiction) => {
-          await enforcer.addPermissionForUser(
-            user.id,
-            'listing',
-            `r.obj.jurisdictionId == '${jurisdiction.id}'`,
-            `(${permissionActions.create})`,
-          );
-        }),
-      );
+      if (userJurisdictionId) {
+        await enforcer.addPermissionForUser(
+          user.id,
+          'listing',
+          `r.obj.jurisdictionId == '${userJurisdictionId}'`,
+          `(${permissionActions.create})`,
+        );
+      }
 
       await Promise.all(
         userListings.map(async (listing: Listing) => {

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -38,6 +38,7 @@ import { SuccessDTO } from '../dtos/shared/success.dto';
 import { EmailAndAppUrl } from '../dtos/users/email-and-app-url.dto';
 import { ConfirmationRequest } from '../dtos/users/confirmation-request.dto';
 import { IdDTO } from '../dtos/shared/id.dto';
+import { Jurisdiction } from '../dtos/jurisdictions/jurisdiction.dto';
 import { UserInvite } from '../dtos/users/user-invite.dto';
 import { UserCreate } from '../dtos/users/user-create.dto';
 import { EmailService } from './email.service';
@@ -61,7 +62,6 @@ import { ApplicationService } from './application.service';
 
 const views: Partial<Record<UserViews, Prisma.UserAccountsInclude>> = {
   base: {
-    jurisdictions: true,
     userRoles: true,
   },
 };
@@ -117,6 +117,75 @@ export class UserService {
     );
   }
 
+  /**
+   * Loads the singleton jurisdiction used as the implicit site context for users.
+   *
+   * @returns An array containing the singleton jurisdiction, or an empty array when none exists.
+   */
+  private async getProjectedJurisdictions(): Promise<Jurisdiction[]> {
+    const siteJurisdiction = await this.prisma.jurisdictions.findFirst({
+      include: {
+        featureFlags: true,
+      },
+    });
+
+    return siteJurisdiction ? mapTo(Jurisdiction, [siteJurisdiction]) : [];
+  }
+
+  /**
+   * Reattaches the singleton jurisdiction to a user-shaped object for compatibility.
+   *
+   * @param rawUser - The raw user record to decorate.
+   * @returns The user record with a synthetic `jurisdictions` array, or `null` when no user was provided.
+   */
+  private async attachProjectedJurisdictionsToUser<T extends object>(
+    rawUser: T | null,
+  ): Promise<(T & { jurisdictions: Jurisdiction[] }) | null> {
+    if (!rawUser) {
+      return null;
+    }
+
+    const existingJurisdictions = (
+      rawUser as { jurisdictions?: Jurisdiction[] }
+    ).jurisdictions;
+    if (existingJurisdictions) {
+      return rawUser as T & { jurisdictions: Jurisdiction[] };
+    }
+
+    const jurisdictions = await this.getProjectedJurisdictions();
+
+    return {
+      ...rawUser,
+      jurisdictions,
+    };
+  }
+
+  /**
+   * Reattaches the singleton jurisdiction to multiple user-shaped objects for compatibility.
+   *
+   * @param rawUsers - The raw user records to decorate.
+   * @returns The user records with a synthetic `jurisdictions` array on each item.
+   */
+  private async attachProjectedJurisdictionsToUsers<T extends object>(
+    rawUsers: T[],
+  ): Promise<Array<T & { jurisdictions: Jurisdiction[] }>> {
+    if (
+      rawUsers.every(
+        (rawUser) =>
+          !!(rawUser as { jurisdictions?: Jurisdiction[] }).jurisdictions,
+      )
+    ) {
+      return rawUsers as Array<T & { jurisdictions: Jurisdiction[] }>;
+    }
+
+    const jurisdictions = await this.getProjectedJurisdictions();
+
+    return rawUsers.map((rawUser) => ({
+      ...rawUser,
+      jurisdictions,
+    }));
+  }
+
   /*
     this will get a set of users given the params passed in
     Only users with a user role of admin or jurisdictional admin can get the list of available users.
@@ -148,7 +217,10 @@ export class UserService {
       where: whereClause,
     });
 
-    const users = mapTo(User, rawUsers);
+    const users = mapTo(
+      User,
+      await this.attachProjectedJurisdictionsToUsers(rawUsers),
+    );
 
     const paginationInfo = buildPaginationMetaInfo(params, count, users.length);
 
@@ -182,32 +254,14 @@ export class UserService {
       UserViews.full,
     );
 
-    if (dto.jurisdictions?.length) {
-      // if the incoming dto has jurisdictions make sure the user has access to update users in that jurisdiction
-      await Promise.all(
-        dto.jurisdictions.map(async (jurisdiction) => {
-          await this.permissionService.canOrThrow(
-            requestingUser,
-            'user',
-            permissionActions.update,
-            {
-              id: dto.id,
-              jurisdictionId: jurisdiction.id,
-            },
-          );
-        }),
-      );
-    } else {
-      // if the incoming dto has no jurisdictions make sure the user has access to update the user
-      await this.permissionService.canOrThrow(
-        requestingUser,
-        'userProfile',
-        permissionActions.update,
-        {
-          id: dto.id,
-        },
-      );
-    }
+    await this.permissionService.canOrThrow(
+      requestingUser,
+      'user',
+      permissionActions.update,
+      {
+        id: dto.id,
+      },
+    );
 
     let passwordHash: string;
     let passwordUpdatedAt: Date;
@@ -243,9 +297,7 @@ export class UserService {
       );
 
       await this.emailService.changeEmail(
-        dto.jurisdictions && dto.jurisdictions[0]
-          ? dto.jurisdictions[0].name
-          : jurisdictionName,
+        storedUser.jurisdictions?.[0]?.name || jurisdictionName,
         mapTo(User, storedUser),
         dto.appUrl,
         confirmationUrl,
@@ -275,27 +327,13 @@ export class UserService {
       }
     }
 
-    // disconnect existing connected listings/jurisdictions
+    // disconnect existing connected listings
     if (storedUser.listings?.length) {
       await this.prisma.userAccounts.update({
         data: {
           listings: {
             disconnect: storedUser.listings.map((listing) => ({
               id: listing.id,
-            })),
-          },
-        },
-        where: {
-          id: dto.id,
-        },
-      });
-    }
-    if (storedUser.jurisdictions?.length) {
-      await this.prisma.userAccounts.update({
-        data: {
-          jurisdictions: {
-            disconnect: storedUser.jurisdictions.map((jurisdiction) => ({
-              id: jurisdiction.id,
             })),
           },
         },
@@ -324,20 +362,13 @@ export class UserService {
               connect: dto.listings.map((listing) => ({ id: listing.id })),
             }
           : undefined,
-        jurisdictions: dto.jurisdictions
-          ? {
-              connect: dto.jurisdictions.map((jurisdiction) => ({
-                id: jurisdiction.id,
-              })),
-            }
-          : undefined,
       },
       where: {
         id: dto.id,
       },
     });
 
-    return mapTo(User, res);
+    return mapTo(User, await this.attachProjectedJurisdictionsToUser(res));
   }
 
   /*
@@ -565,10 +596,13 @@ export class UserService {
         email: dto.email,
       },
     });
+    const projectedExistingUser = await this.attachProjectedJurisdictionsToUser(
+      existingUser,
+    );
 
-    if (existingUser) {
+    if (projectedExistingUser) {
       // if attempting to recreate an existing user
-      if (!existingUser.userRoles && 'userRoles' in dto) {
+      if (!projectedExistingUser.userRoles && 'userRoles' in dto) {
         // existing user && public user && user will get roles -> trying to grant partner access to a public user
         const res = await this.prisma.userAccounts.update({
           include: views.full,
@@ -582,46 +616,53 @@ export class UserService {
               connect: dto.listings.map((listing) => ({ id: listing.id })),
             },
             confirmationToken:
-              existingUser.confirmationToken ||
-              this.createConfirmationToken(existingUser.id, existingUser.email),
+              projectedExistingUser.confirmationToken ||
+              this.createConfirmationToken(
+                projectedExistingUser.id,
+                projectedExistingUser.email,
+              ),
             confirmedAt: null,
           },
           where: {
-            id: existingUser.id,
+            id: projectedExistingUser.id,
           },
         });
-        return mapTo(User, res);
+        return mapTo(User, await this.attachProjectedJurisdictionsToUser(res));
       } else if (
-        existingUser?.userRoles?.isPartner &&
+        projectedExistingUser.userRoles?.isPartner &&
         'userRoles' in dto &&
-        dto?.userRoles?.isPartner &&
-        this.jurisdictionMismatch(dto.jurisdictions, existingUser.jurisdictions)
+        dto.userRoles?.isPartner
       ) {
-        // recreating a partner with jurisdiction mismatch -> giving partner a new jurisdiction
-        const jursidictions = existingUser.jurisdictions
-          .map((juris) => ({ id: juris.id }))
-          .concat(dto.jurisdictions);
+        const existingListings = projectedExistingUser.listings ?? [];
+        const incomingListings = dto.listings ?? [];
+        const hasNewListings = incomingListings.some(
+          (listing) =>
+            !existingListings.some(
+              (existingListing) => existingListing.id === listing.id,
+            ),
+        );
 
-        const listings = existingUser.listings
-          .map((juris) => ({ id: juris.id }))
-          .concat(dto.listings);
+        if (!hasNewListings) {
+          throw new ConflictException('emailInUse');
+        }
+
+        const listings = existingListings
+          .map((listing) => ({ id: listing.id }))
+          .concat(incomingListings);
 
         const res = await this.prisma.userAccounts.update({
           include: views.full,
           data: {
-            jurisdictions: {
-              connect: jursidictions.map((juris) => ({ id: juris.id })),
-            },
             listings: {
               connect: listings.map((listing) => ({ id: listing.id })),
             },
           },
           where: {
-            id: existingUser.id,
+            id: projectedExistingUser.id,
           },
         });
 
-        return mapTo(User, res);
+        return mapTo(User, await this.attachProjectedJurisdictionsToUser(res));
       } else {
         // existing user && ((partner user -> trying to recreate user) || (public user -> trying to recreate a public user))
         throw new ConflictException('emailInUse');
@@ -637,30 +678,6 @@ export class UserService {
       passwordHash = await passwordToHash((dto as UserCreate).password);
     }
 
-    let jurisdictions:
-      | {
-          jurisdictions: Prisma.JurisdictionsCreateNestedManyWithoutUser_accountsInput;
-        }
-      | Record<string, never> = dto.jurisdictions
-      ? {
-          jurisdictions: {
-            connect: dto.jurisdictions.map((juris) => ({
-              id: juris.id,
-            })),
-          },
-        }
-      : {};
-
-    if (!forPartners && jurisdictionName) {
-      jurisdictions = {
-        jurisdictions: {
-          connect: {
-            name: jurisdictionName,
-          },
-        },
-      };
-    }
-
     let newUser = await this.prisma.userAccounts.create({
       data: {
         passwordHash: passwordHash,
@@ -672,7 +689,6 @@ export class UserService {
         phoneNumber: dto.phoneNumber,
         language: dto.language,
         mfaEnabled: forPartners,
-        ...jurisdictions,
         userRoles:
           'userRoles' in dto
             ? {
@@ -707,11 +723,7 @@ export class UserService {
 
     // Public user that needs email
     if (!forPartners && sendWelcomeEmail) {
-      const fullJurisdiction = await this.prisma.jurisdictions.findFirst({
-        where: {
-          name: jurisdictionName as string,
-        },
-      });
+      const fullJurisdiction = await this.prisma.jurisdictions.findFirst();
 
       if (fullJurisdiction?.allowSingleUseCodeLogin) {
         this.requestSingleUseCode(dto, req);
@@ -721,8 +733,8 @@ export class UserService {
           confirmationToken,
         );
         await this.emailService.welcome(
-          jurisdictionName,
-          mapTo(User, newUser),
+          jurisdictionName || fullJurisdiction?.name,
+          mapTo(User, await this.attachProjectedJurisdictionsToUser(newUser)),
           dto.appUrl,
           confirmationUrl,
         );
@@ -733,8 +745,8 @@ export class UserService {
         confirmationToken,
       );
       await this.emailService.invitePartnerUser(
-        dto.jurisdictions,
-        mapTo(User, newUser),
+        [],
+        mapTo(User, await this.attachProjectedJurisdictionsToUser(newUser)),
         this.configService.get('PARTNERS_PORTAL_URL'),
         confirmationUrl,
       );
@@ -744,7 +756,7 @@ export class UserService {
       await this.connectUserWithExistingApplications(newUser.email, newUser.id);
     }
 
-    return mapTo(User, newUser);
+    return mapTo(User, await this.attachProjectedJurisdictionsToUser(newUser));
   }
 
   /*
@@ -784,15 +796,9 @@ export class UserService {
     takes in a userId or email to find by, and a boolean to indicate if joins should be included
   */
   async findUserOrError(findBy: findByOptions, view?: UserViews) {
-    const where: Prisma.UserAccountsWhereUniqueInput = {
-      id: undefined,
-      email: undefined,
-    };
-    if (findBy.userId) {
-      where.id = findBy.userId;
-    } else if (findBy.email) {
-      where.email = findBy.email;
-    }
+    const where: Prisma.UserAccountsWhereUniqueInput = findBy.userId
+      ? { id: findBy.userId }
+      : { email: findBy.email };
     const rawUser = await this.prisma.userAccounts.findUnique({
       include: view ? views[view] : undefined,
       where,
@@ -808,7 +814,7 @@ export class UserService {
       throw new NotFoundException(`user ${str} was requested but not found`);
     }
 
-    return rawUser;
+    return await this.attachProjectedJurisdictionsToUser(rawUser);
   }
 
   async authorizeAction(
@@ -822,35 +828,19 @@ export class UserService {
       );
     }
 
-    if (!requestingUser.userRoles?.isJurisdictionalAdmin) {
-      // if its an admin, partner, or a user without roles
-      await this.permissionService.canOrThrow(requestingUser, 'user', action, {
-        id: targetUser.id,
-      });
-    } else if (targetUser.userRoles?.isAdmin) {
+    if (
+      requestingUser.userRoles?.isJurisdictionalAdmin &&
+      targetUser.userRoles?.isAdmin
+    ) {
       // if its a jurisdictional admin trying to perform an action on an admin user
       throw new ForbiddenException(
         `a jurisdictional admin is attempting to ${action} an admin user`,
       );
-    } else {
-      // jurisdictional admins should only be allowed to perform an action on a user if they share a jurisdiction
-      const requesterJurisdictions = requestingUser.jurisdictions?.map(
-        (juris) => juris.id,
-      );
-      const targetJurisdictions = targetUser.jurisdictions?.map(
-        (juris) => juris.id,
-      );
-
-      if (
-        !requesterJurisdictions.some((juris) =>
-          targetJurisdictions.includes(juris),
-        )
-      ) {
-        throw new ForbiddenException(
-          `a jurisdictional admin is attempting to ${action} a user they do not share a jurisdiction with`,
-        );
-      }
     }
+
+    await this.permissionService.canOrThrow(requestingUser, 'user', action, {
+      id: targetUser.id,
+    });
   }
 
   /*
@@ -877,27 +867,6 @@ export class UserService {
   */
   getPartnersConfirmationUrl(appUrl: string, confirmationToken: string) {
     return `${appUrl}/users/confirm?token=${confirmationToken}`;
-  }
-
-  /*
-    verify that there is a jurisdictional difference between the incoming user and the existing user
-  */
-  jurisdictionMismatch(
-    incomingJurisdictions: IdDTO[],
-    existingJurisdictions: IdDTO[],
-  ): boolean {
-    return (
-      incomingJurisdictions.reduce((misMatched, jurisdiction) => {
-        if (
-          !existingJurisdictions?.some(
-            (existingJuris) => existingJuris.id === jurisdiction.id,
-          )
-        ) {
-          misMatched.push(jurisdiction.id);
-        }
-        return misMatched;
-      }, []).length > 0
-    );
   }
 
   containsInvalidCharacters(value: string): boolean {
@@ -931,9 +900,6 @@ export class UserService {
   ): Promise<SuccessDTO> {
     const user = await this.prisma.userAccounts.findFirst({
       where: { email: dto.email },
-      include: {
-        jurisdictions: true,
-      },
     });
     if (!user) {
       return { success: true };
@@ -989,7 +955,7 @@ export class UserService {
     });
 
     await this.emailService.sendSingleUseCode(
-      mapTo(User, user),
+      mapTo(User, await this.attachProjectedJurisdictionsToUser(user)),
       singleUseCode,
       juris.name,
     );
@@ -1008,7 +974,7 @@ export class UserService {
       UserViews.favorites,
     );
 
-    return mapTo(IdDTO, rawUser.favoriteListings);
+    return mapTo(IdDTO, rawUser.favoriteListings) as IdDTO[];
   }
 
   async modifyFavoriteListings(dto: UserFavoriteListing, requestingUser: User) {
@@ -1048,7 +1014,10 @@ export class UserService {
       },
     });
 
-    return mapTo(User, rawResults);
+    return mapTo(
+      User,
+      await this.attachProjectedJurisdictionsToUser(rawResults),
+    );
   }
 
   private async deleteUserAndRelatedInfo(
@@ -1162,9 +1131,6 @@ export class UserService {
         .subtract(warnDateNumber, 'days')
         .toDate();
       const users = await this.prisma.userAccounts.findMany({
-        include: {
-          jurisdictions: true,
-        },
         where: {
           lastLoginAt: { lte: warnDate },
           userRoles: null,
@@ -1174,7 +1140,9 @@ export class UserService {
       this.logger.warn(`warning ${users.length} users of account deletion`);
       for (const user of users) {
         try {
-          await this.emailService.warnOfAccountRemoval(mapTo(User, user));
+          await this.emailService.warnOfAccountRemoval(
+            mapTo(User, await this.attachProjectedJurisdictionsToUser(user)),
+          );
           await this.prisma.userAccounts.update({
             data: { wasWarnedOfDeletion: true },
             where: { id: user.id },

--- a/api/src/utilities/build-user-where.ts
+++ b/api/src/utilities/build-user-where.ts
@@ -121,15 +121,6 @@ export const buildWhereClause = (
             },
           ],
         });
-        filters.push({
-          jurisdictions: {
-            some: {
-              id: {
-                in: user?.jurisdictions?.map((juris) => juris.id),
-              },
-            },
-          },
-        });
       }
     } else if ('isPortalUser' in filter) {
       filters.push({

--- a/api/test/unit/passports/jwt.strategy.spec.ts
+++ b/api/test/unit/passports/jwt.strategy.spec.ts
@@ -19,6 +19,13 @@ describe('Testing jwt strategy', () => {
     prisma = module.get<PrismaService>(PrismaService);
   });
 
+  beforeEach(() => {
+    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+      id: 'jurisdiction-id',
+      featureFlags: [],
+    });
+  });
+
   it('should fail because user does not exist', async () => {
     const id = randomUUID();
     const token = sign(
@@ -44,16 +51,6 @@ describe('Testing jwt strategy', () => {
       include: {
         userRoles: true,
         listings: true,
-        jurisdictions: {
-          include: {
-            featureFlags: {
-              select: {
-                active: true,
-                name: true,
-              },
-            },
-          },
-        },
       },
       where: {
         id,
@@ -92,16 +89,6 @@ describe('Testing jwt strategy', () => {
       include: {
         userRoles: true,
         listings: true,
-        jurisdictions: {
-          include: {
-            featureFlags: {
-              select: {
-                active: true,
-                name: true,
-              },
-            },
-          },
-        },
       },
       where: {
         id,
@@ -146,16 +133,6 @@ describe('Testing jwt strategy', () => {
       include: {
         userRoles: true,
         listings: true,
-        jurisdictions: {
-          include: {
-            featureFlags: {
-              select: {
-                active: true,
-                name: true,
-              },
-            },
-          },
-        },
       },
       where: {
         id,
@@ -204,16 +181,6 @@ describe('Testing jwt strategy', () => {
       include: {
         userRoles: true,
         listings: true,
-        jurisdictions: {
-          include: {
-            featureFlags: {
-              select: {
-                active: true,
-                name: true,
-              },
-            },
-          },
-        },
       },
       where: {
         id,

--- a/api/test/unit/services/permission.service.spec.ts
+++ b/api/test/unit/services/permission.service.spec.ts
@@ -19,6 +19,12 @@ describe('Testing permission service', () => {
     prisma = module.get<PrismaService>(PrismaService);
   });
 
+  beforeEach(() => {
+    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+      id: 'juris id',
+    });
+  });
+
   it('should add admin user role for user', async () => {
     const e = await newEnforcer(
       path.join(
@@ -263,7 +269,7 @@ describe('Testing permission service', () => {
         'listing',
         permissionActions.create,
         {
-          jurisdictionId: 'juris id 1',
+          jurisdictionId: 'juris id',
         },
       ),
     ).toEqual(true);
@@ -274,7 +280,7 @@ describe('Testing permission service', () => {
         'listing',
         permissionActions.create,
         {
-          jurisdictionId: 'juris id 2',
+          jurisdictionId: 'juris id',
         },
       ),
     ).toEqual(true);
@@ -431,15 +437,6 @@ describe('Testing permission service', () => {
       },
       select: {
         id: true,
-        listings: true,
-        jurisdictions: {
-          where: {
-            id: {
-              in: ['juris id'],
-            },
-          },
-        },
-        userRoles: true,
       },
     });
   });

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -30,6 +30,11 @@ describe('Testing user service', () => {
   let prisma: PrismaService;
   let emailService: EmailService;
   let applicationService: ApplicationService;
+  const singletonJurisdiction = {
+    id: 'singleton-jurisdiction-id',
+    name: 'Test Jurisdiction',
+    featureFlags: [],
+  };
 
   const mockUser = (position: number, date: Date) => {
     return {
@@ -133,6 +138,12 @@ describe('Testing user service', () => {
     applicationService = module.get<ApplicationService>(ApplicationService);
   });
 
+  beforeEach(() => {
+    prisma.jurisdictions.findFirst = jest
+      .fn()
+      .mockResolvedValue(singletonJurisdiction);
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -157,7 +168,6 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findMany).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -208,7 +218,6 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findMany).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -313,7 +322,6 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findMany).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -380,7 +388,6 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findMany).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -410,7 +417,6 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -435,7 +441,6 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -498,24 +503,6 @@ describe('Testing user service', () => {
     });
   });
 
-  describe('jurisdictionMismatch', () => {
-    it('should verify that there is a jurisdiciton mismatch', () => {
-      const res = service.jurisdictionMismatch(
-        [{ id: 'id a' }],
-        [{ id: 'id 1' }],
-      );
-      expect(res).toEqual(true);
-    });
-
-    it('should verify that there is not a jurisdiciton mismatch', () => {
-      const res = service.jurisdictionMismatch(
-        [{ id: 'id a' }, { id: 'id b' }],
-        [{ id: 'id b' }, { id: 'id a' }],
-      );
-      expect(res).toEqual(false);
-    });
-  });
-
   describe('findUserOrError', () => {
     it('should find user by id and include joins', async () => {
       const id = randomUUID();
@@ -523,10 +510,14 @@ describe('Testing user service', () => {
         id,
       });
       const res = await service.findUserOrError({ userId: id }, UserViews.full);
-      expect(res).toEqual({ id });
+      expect(res).toMatchObject({
+        id,
+        jurisdictions: [
+          expect.objectContaining({ id: singletonJurisdiction.id }),
+        ],
+      });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -548,10 +539,14 @@ describe('Testing user service', () => {
         id,
       });
       const res = await service.findUserOrError({ userId: id }, UserViews.base);
-      expect(res).toEqual({ id });
+      expect(res).toMatchObject({
+        id,
+        jurisdictions: [
+          expect.objectContaining({ id: singletonJurisdiction.id }),
+        ],
+      });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           userRoles: true,
         },
         where: {
@@ -569,10 +564,14 @@ describe('Testing user service', () => {
         { email: email },
         UserViews.full,
       );
-      expect(res).toEqual({ email });
+      expect(res).toMatchObject({
+        email,
+        jurisdictions: [
+          expect.objectContaining({ id: singletonJurisdiction.id }),
+        ],
+      });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -594,7 +593,12 @@ describe('Testing user service', () => {
         id,
       });
       const res = await service.findUserOrError({ userId: id });
-      expect(res).toEqual({ id });
+      expect(res).toMatchObject({
+        id,
+        jurisdictions: [
+          expect.objectContaining({ id: singletonJurisdiction.id }),
+        ],
+      });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         where: {
           id,
@@ -608,7 +612,12 @@ describe('Testing user service', () => {
         email,
       });
       const res = await service.findUserOrError({ email: email });
-      expect(res).toEqual({ email });
+      expect(res).toMatchObject({
+        email,
+        jurisdictions: [
+          expect.objectContaining({ id: singletonJurisdiction.id }),
+        ],
+      });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         where: {
           email,
@@ -847,7 +856,6 @@ describe('Testing user service', () => {
       await service.forgotPassword({ email, appUrl: 'http://localhost:3000' });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -893,7 +901,6 @@ describe('Testing user service', () => {
       });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -931,7 +938,6 @@ describe('Testing user service', () => {
       });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -976,7 +982,6 @@ describe('Testing user service', () => {
       });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1007,7 +1012,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1046,7 +1050,6 @@ describe('Testing user service', () => {
       await service.resendConfirmation({ email }, true);
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1090,7 +1093,6 @@ describe('Testing user service', () => {
       await service.resendConfirmation({ email }, false);
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1133,7 +1135,6 @@ describe('Testing user service', () => {
       await service.resendConfirmation({ email }, false);
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1164,7 +1165,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1207,7 +1207,6 @@ describe('Testing user service', () => {
           id,
         },
         include: {
-          jurisdictions: true,
           userRoles: true,
         },
       });
@@ -1254,7 +1253,6 @@ describe('Testing user service', () => {
           id,
         },
         include: {
-          jurisdictions: true,
           userRoles: true,
         },
       });
@@ -1301,7 +1299,6 @@ describe('Testing user service', () => {
           id,
         },
         include: {
-          jurisdictions: true,
           userRoles: true,
         },
       });
@@ -1339,7 +1336,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1353,30 +1349,28 @@ describe('Testing user service', () => {
           id,
         },
       });
-      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
-        data: {
-          firstName: 'first name',
-          lastName: 'last name',
-          jurisdictions: {
-            connect: [{ id: jurisId }],
-          },
-          agreedToTermsOfService: true,
-        },
-        include: {
-          jurisdictions: true,
-          listings: true,
-          userRoles: true,
-          favoriteListings: {
-            select: {
-              id: true,
-              name: true,
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            firstName: 'first name',
+            lastName: 'last name',
+            agreedToTermsOfService: true,
+          }),
+          include: {
+            listings: true,
+            userRoles: true,
+            favoriteListings: {
+              select: {
+                id: true,
+                name: true,
+              },
             },
           },
-        },
-        where: {
-          id,
-        },
-      });
+          where: {
+            id,
+          },
+        }),
+      );
       expect(canOrThrowMock).toHaveBeenCalledWith(
         {
           id: 'requestingUser id',
@@ -1386,7 +1380,6 @@ describe('Testing user service', () => {
         permissionActions.update,
         {
           id,
-          jurisdictionId: jurisId,
         },
       );
     });
@@ -1422,7 +1415,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1436,32 +1428,30 @@ describe('Testing user service', () => {
           id,
         },
       });
-      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
-        data: {
-          firstName: 'first name',
-          lastName: 'last name',
-          jurisdictions: {
-            connect: [{ id: jurisId }],
-          },
-          passwordHash: expect.anything(),
-          passwordUpdatedAt: expect.anything(),
-          agreedToTermsOfService: true,
-        },
-        include: {
-          jurisdictions: true,
-          listings: true,
-          userRoles: true,
-          favoriteListings: {
-            select: {
-              id: true,
-              name: true,
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            firstName: 'first name',
+            lastName: 'last name',
+            passwordHash: expect.any(String),
+            passwordUpdatedAt: expect.any(Date),
+            agreedToTermsOfService: true,
+          }),
+          include: {
+            listings: true,
+            userRoles: true,
+            favoriteListings: {
+              select: {
+                id: true,
+                name: true,
+              },
             },
           },
-        },
-        where: {
-          id,
-        },
-      });
+          where: {
+            id,
+          },
+        }),
+      );
       expect(canOrThrowMock).toHaveBeenCalledWith(
         {
           id: 'requestingUser id',
@@ -1471,7 +1461,6 @@ describe('Testing user service', () => {
         permissionActions.update,
         {
           id,
-          jurisdictionId: jurisId,
         },
       );
     });
@@ -1509,7 +1498,6 @@ describe('Testing user service', () => {
       ).rejects.toThrowError(`userID ${id}: request missing currentPassword`);
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1533,7 +1521,6 @@ describe('Testing user service', () => {
         permissionActions.update,
         {
           id,
-          jurisdictionId: jurisId,
         },
       );
     });
@@ -1574,7 +1561,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1598,7 +1584,6 @@ describe('Testing user service', () => {
         permissionActions.update,
         {
           id,
-          jurisdictionId: jurisId,
         },
       );
     });
@@ -1633,7 +1618,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1647,31 +1631,29 @@ describe('Testing user service', () => {
           id,
         },
       });
-      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
-        data: {
-          firstName: 'first name',
-          lastName: 'last name',
-          jurisdictions: {
-            connect: [{ id: jurisId }],
-          },
-          confirmationToken: expect.anything(),
-          agreedToTermsOfService: true,
-        },
-        include: {
-          jurisdictions: true,
-          listings: true,
-          userRoles: true,
-          favoriteListings: {
-            select: {
-              id: true,
-              name: true,
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            firstName: 'first name',
+            lastName: 'last name',
+            confirmationToken: expect.any(String),
+            agreedToTermsOfService: true,
+          }),
+          include: {
+            listings: true,
+            userRoles: true,
+            favoriteListings: {
+              select: {
+                id: true,
+                name: true,
+              },
             },
           },
-        },
-        where: {
-          id,
-        },
-      });
+          where: {
+            id,
+          },
+        }),
+      );
       expect(emailService.changeEmail).toHaveBeenCalled();
       expect(canOrThrowMock).toHaveBeenCalledWith(
         {
@@ -1682,7 +1664,6 @@ describe('Testing user service', () => {
         permissionActions.update,
         {
           id,
-          jurisdictionId: jurisId,
         },
       );
     });
@@ -1719,7 +1700,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1734,7 +1714,7 @@ describe('Testing user service', () => {
         },
       });
       expect(prisma.userAccounts.update).toHaveBeenCalledTimes(2);
-      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
+      expect(prisma.userAccounts.update).toHaveBeenNthCalledWith(1, {
         data: {
           listings: {
             disconnect: [
@@ -1751,40 +1731,32 @@ describe('Testing user service', () => {
           id,
         },
       });
-      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
-        data: {
-          firstName: 'first name',
-          lastName: 'last name',
-          jurisdictions: {
-            connect: [{ id: jurisId }],
-          },
-          listings: {
-            connect: [
-              {
-                id: listingA,
+      expect(prisma.userAccounts.update).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            firstName: 'first name',
+            lastName: 'last name',
+            listings: {
+              connect: [{ id: listingA }, { id: listingC }],
+            },
+            agreedToTermsOfService: true,
+          }),
+          include: {
+            listings: true,
+            userRoles: true,
+            favoriteListings: {
+              select: {
+                id: true,
+                name: true,
               },
-              {
-                id: listingC,
-              },
-            ],
-          },
-          agreedToTermsOfService: true,
-        },
-        include: {
-          jurisdictions: true,
-          listings: true,
-          userRoles: true,
-          favoriteListings: {
-            select: {
-              id: true,
-              name: true,
             },
           },
-        },
-        where: {
-          id,
-        },
-      });
+          where: {
+            id,
+          },
+        }),
+      );
       expect(canOrThrowMock).toHaveBeenCalledWith(
         {
           id: 'requestingUser id',
@@ -1794,7 +1766,6 @@ describe('Testing user service', () => {
         permissionActions.update,
         {
           id,
-          jurisdictionId: jurisId,
         },
       );
     });
@@ -1824,7 +1795,6 @@ describe('Testing user service', () => {
       ).rejects.toThrowError(`user id: ${id} was requested but not found`);
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1881,7 +1851,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1897,14 +1866,16 @@ describe('Testing user service', () => {
       });
       expect(prisma.userAccounts.create).toHaveBeenCalledWith({
         data: {
-          passwordHash: expect.anything(),
+          passwordHash: expect.any(String),
           email: 'partnerUser@email.com',
           firstName: 'Partner User firstName',
+          middleName: undefined,
           lastName: 'Partner User lastName',
+          dob: undefined,
+          phoneNumber: undefined,
+          language: undefined,
           mfaEnabled: true,
-          jurisdictions: {
-            connect: [{ id: jurisId }],
-          },
+          listings: undefined,
           userRoles: {
             create: {
               isAdmin: true,
@@ -1961,7 +1932,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -1977,7 +1947,6 @@ describe('Testing user service', () => {
       });
       expect(prisma.userAccounts.update).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -2026,6 +1995,7 @@ describe('Testing user service', () => {
         userRoles: {
           isPartner: true,
         },
+        listings: [{ id: 'listing id' }],
         jurisdictions: [{ id: jurisId }],
       });
       prisma.userAccounts.update = jest.fn().mockResolvedValue(null);
@@ -2057,7 +2027,6 @@ describe('Testing user service', () => {
       ).rejects.toThrowError('emailInUse');
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -2126,7 +2095,6 @@ describe('Testing user service', () => {
       );
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -2143,7 +2111,7 @@ describe('Testing user service', () => {
       expect(prisma.userAccounts.create).toHaveBeenCalledWith({
         data: {
           dob: undefined,
-          passwordHash: expect.anything(),
+          passwordHash: expect.any(String),
           phoneNumber: undefined,
           userRoles: undefined,
           email: 'publicUser@email.com',
@@ -2153,14 +2121,10 @@ describe('Testing user service', () => {
           listings: undefined,
           middleName: undefined,
           mfaEnabled: false,
-          jurisdictions: {
-            connect: { name: 'juris 1' },
-          },
         },
       });
       expect(prisma.userAccounts.update).toHaveBeenCalledWith({
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -2338,9 +2302,6 @@ describe('Testing user service', () => {
         where: {
           email: 'example@exygy.com',
         },
-        include: {
-          jurisdictions: true,
-        },
       });
       expect(prisma.userAccounts.update).not.toHaveBeenCalled();
       expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
@@ -2384,9 +2345,6 @@ describe('Testing user service', () => {
         where: {
           email: 'example@exygy.com',
         },
-        include: {
-          jurisdictions: true,
-        },
       });
       expect(prisma.jurisdictions.findFirst).not.toHaveBeenCalled();
       expect(prisma.userAccounts.update).not.toHaveBeenCalled();
@@ -2418,9 +2376,6 @@ describe('Testing user service', () => {
       expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
         where: {
           email: 'example@exygy.com',
-        },
-        include: {
-          jurisdictions: true,
         },
       });
       expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
@@ -2470,9 +2425,6 @@ describe('Testing user service', () => {
         where: {
           email: 'example@exygy.com',
         },
-        include: {
-          jurisdictions: true,
-        },
       });
       expect(prisma.jurisdictions.findFirst).not.toHaveBeenCalled();
       expect(prisma.userAccounts.update).not.toHaveBeenCalled();
@@ -2509,9 +2461,6 @@ describe('Testing user service', () => {
       expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
         where: {
           email: 'example@exygy.com',
-        },
-        include: {
-          jurisdictions: true,
         },
       });
       expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
@@ -2569,9 +2518,6 @@ describe('Testing user service', () => {
       expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
         where: {
           email: 'example@exygy.com',
-        },
-        include: {
-          jurisdictions: true,
         },
       });
       expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
@@ -2635,7 +2581,6 @@ describe('Testing user service', () => {
           },
         },
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -2684,7 +2629,6 @@ describe('Testing user service', () => {
           },
         },
         include: {
-          jurisdictions: true,
           listings: true,
           userRoles: true,
           favoriteListings: {
@@ -2825,9 +2769,6 @@ describe('Testing user service', () => {
       emailService.warnOfAccountRemoval = jest.fn();
       const response = await service.warnUserOfDeletionCronJob();
       expect(prisma.userAccounts.findMany).toBeCalledWith({
-        include: {
-          jurisdictions: true,
-        },
         where: {
           lastLoginAt: { lte: new Date('2022-12-23T12:25:00.000Z') },
           userRoles: null,
@@ -2850,8 +2791,12 @@ describe('Testing user service', () => {
           id: 'id2',
         },
       });
-      expect(emailService.warnOfAccountRemoval).toBeCalledWith({ id: 'id1' });
-      expect(emailService.warnOfAccountRemoval).toBeCalledWith({ id: 'id2' });
+      expect(emailService.warnOfAccountRemoval).toBeCalledWith(
+        expect.objectContaining({ id: 'id1' }),
+      );
+      expect(emailService.warnOfAccountRemoval).toBeCalledWith(
+        expect.objectContaining({ id: 'id2' }),
+      );
       expect(response).toEqual({ success: true });
     });
     it('should not update user if email failed', async () => {
@@ -2871,9 +2816,6 @@ describe('Testing user service', () => {
         .mockRejectedValue('error sending email');
       const response = await service.warnUserOfDeletionCronJob();
       expect(prisma.userAccounts.findMany).toBeCalledWith({
-        include: {
-          jurisdictions: true,
-        },
         where: {
           lastLoginAt: { lte: new Date('2022-12-23T12:25:00.000Z') },
           userRoles: null,

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -8685,9 +8685,6 @@ export interface UserCreate {
 
   /**  */
   emailConfirmation?: string
-
-  /**  */
-  jurisdictions?: IdDTO[]
 }
 
 export interface UserDeleteDTO {
@@ -8734,9 +8731,6 @@ export interface UserInvite {
 
   /**  */
   email: string
-
-  /**  */
-  jurisdictions: IdDTO[]
 }
 
 export interface RequestSingleUseCode {
@@ -8805,9 +8799,6 @@ export interface UserUpdate {
 
   /**  */
   appUrl?: string
-
-  /**  */
-  jurisdictions?: IdDTO[]
 }
 
 export interface Login {

--- a/shared-helpers/src/utilities/token.ts
+++ b/shared-helpers/src/utilities/token.ts
@@ -1,4 +1,4 @@
-import jwtDecode from "jwt-decode"
+import { jwtDecode } from "jwt-decode"
 
 export const ACCESS_TOKEN_LOCAL_STORAGE_KEY = "@bht"
 

--- a/sites/partners/__tests__/components/users/FormUserManage.test.tsx
+++ b/sites/partners/__tests__/components/users/FormUserManage.test.tsx
@@ -1,16 +1,15 @@
 import React from "react"
-import { screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { t } from "@bloom-housing/ui-components"
+import { AuthContext, MessageContext } from "@bloom-housing/shared-helpers"
 import {
   FeatureFlagEnum,
   Listing,
   User,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { t } from "@bloom-housing/ui-components"
 import { FormUserManage } from "../../../src/components/users/FormUserManage"
-import { mockNextRouter, render } from "../../testUtils"
-import userEvent from "@testing-library/user-event"
-import { setupServer } from "msw/lib/node"
-import { rest } from "msw"
+import { mockNextRouter } from "../../testUtils"
 
 const mockUser: User = {
   id: "123",
@@ -33,600 +32,313 @@ const adminUser: User = {
   userRoles: { isAdmin: true },
 }
 
-const server = setupServer()
+const listingOptions = [
+  { id: "id1", name: "listing1", jurisdictions: { id: "jurisdiction1" } } as Listing,
+  { id: "id2", name: "listing2", jurisdictions: { id: "jurisdiction1" } } as Listing,
+  { id: "id3", name: "listing3", jurisdictions: { id: "jurisdiction1" } } as Listing,
+]
 
-beforeAll(() => server.listen())
+const createFeatureFlagReader = (profile: User) => {
+  return (
+    featureFlag: string,
+    jurisdiction?: string,
+    onlyIfAllJurisdictionsHaveItEnabled?: boolean
+  ) => {
+    const matchingJurisdictions = jurisdiction
+      ? profile.jurisdictions?.filter((item) => item.id === jurisdiction)
+      : profile.jurisdictions
 
-afterEach(() => {
-  server.resetHandlers()
-  window.sessionStorage.clear()
-})
+    if (!matchingJurisdictions?.length) return false
 
-afterAll(() => server.close())
+    const results = matchingJurisdictions.map((item) =>
+      item.featureFlags?.some((flag) => flag.name === featureFlag && flag.active)
+    )
 
-describe("<FormUserManage>", () => {
-  beforeAll(() => {
-    mockNextRouter()
-  })
-  describe("Add user", () => {
-    describe("with jurisdictional admins enabled", () => {
-      describe("as admin", () => {
-        const adminUserWithJurisdictions = {
-          ...adminUser,
-          jurisdictions: [
-            { id: "jurisdiction1", name: "jurisdictionWithJurisdictionAdmin", featureFlags: [] },
-            { id: "jurisdiction2", name: "jurisdictionWithJurisdictionAdmin2", featureFlags: [] },
-          ],
-        }
-        it("should invite an admin user", async () => {
-          // Watch the invite call to make sure it's called
-          const requestSpy = jest.fn()
-          server.events.on("request:start", (request) => {
-            if (request.method === "POST" && request.url.href.includes("invite")) {
-              requestSpy(request.body)
-            }
-          })
-          server.use(
-            rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-              return res(ctx.json(adminUserWithJurisdictions))
-            }),
-            rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-              return res(ctx.json({ success: true }))
-            })
-          )
-          const onCancel = jest.fn()
-          const onDrawerClose = jest.fn()
-          document.cookie = "access-token-available=True"
+    return onlyIfAllJurisdictionsHaveItEnabled ? results.every(Boolean) : results.some(Boolean)
+  }
+}
 
-          render(
-            <FormUserManage
-              isOpen={true}
-              title={t("users.addUser")}
-              mode={"add"}
-              listings={[]}
-              onCancel={onCancel}
-              onDrawerClose={onDrawerClose}
-            />
-          )
+const renderWithContext = ({
+  profile = adminUser,
+  user = undefined,
+  listings = [],
+  mode = "add",
+  title = t(mode === "add" ? "users.addUser" : "users.editUser"),
+}: {
+  profile?: User
+  user?: User
+  listings?: Listing[]
+  mode?: "add" | "edit"
+  title?: string
+} = {}) => {
+  const invite = jest.fn().mockResolvedValue({ success: true })
+  const update = jest.fn().mockResolvedValue({ success: true })
+  const resendPartnerConfirmation = jest.fn().mockResolvedValue({ success: true })
+  const remove = jest.fn().mockResolvedValue({ success: true })
+  const addToast = jest.fn()
+  const onCancel = jest.fn()
+  const onDrawerClose = jest.fn()
 
-          await waitFor(() => screen.getByText("Administrator"))
-          expect(screen.getByText("Add user")).toBeInTheDocument()
-          expect(screen.getByText("User details")).toBeInTheDocument()
-          expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument()
-          expect(screen.getByRole("textbox", { name: "First name" })).toBeInTheDocument()
-          expect(screen.getByRole("textbox", { name: "Last name" })).toBeInTheDocument()
-          expect(screen.getByRole("textbox", { name: "Email" })).toBeInTheDocument()
-          // "Role" select should have all three role option
-          expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Jurisdictional admin" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-          expect(screen.getByRole("button", { name: "Invite" })).toBeInTheDocument()
-          await userEvent.type(screen.getByRole("textbox", { name: "First name" }), "firstName")
-          await userEvent.type(screen.getByRole("textbox", { name: "Last name" }), "lastName")
-          await userEvent.type(screen.getByRole("textbox", { name: "Email" }), "email@example.com")
-          await userEvent.selectOptions(
-            screen.getByRole("combobox", { name: "Role" }),
-            screen.getByRole("option", { name: "Administrator" })
-          )
-          await userEvent.click(screen.getByRole("button", { name: "Invite" }))
-          await waitFor(() => {
-            expect(requestSpy).toHaveBeenCalledWith({
-              firstName: "firstName",
-              lastName: "lastName",
-              email: "email@example.com",
-              userRoles: {
-                isAdmin: true,
-                isPartner: false,
-                isJurisdictionalAdmin: false,
-                isLimitedJurisdictionalAdmin: false,
-                isSupportAdmin: false,
-              },
-              listings: [],
-              jurisdictions: [{ id: "jurisdiction1" }, { id: "jurisdiction2" }],
-              agreedToTermsOfService: false,
-            })
-          })
-          await waitFor(() => expect(onDrawerClose).toBeCalled())
-        })
-
-        it("should invite a jurisdictional admin user", async () => {
-          // Watch the invite call to make sure it's called
-          const requestSpy = jest.fn()
-          server.events.on("request:start", (request) => {
-            if (request.method === "POST" && request.url.href.includes("invite")) {
-              requestSpy(request.body)
-            }
-          })
-          server.use(
-            rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-              return res(ctx.json(adminUserWithJurisdictions))
-            }),
-            rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-              return res(ctx.json({ success: true }))
-            })
-          )
-          const onCancel = jest.fn()
-          const onDrawerClose = jest.fn()
-          document.cookie = "access-token-available=True"
-
-          render(
-            <FormUserManage
-              isOpen={true}
-              title={t("users.addUser")}
-              mode={"add"}
-              listings={[]}
-              onCancel={onCancel}
-              onDrawerClose={onDrawerClose}
-            />
-          )
-
-          await waitFor(() => screen.getByText("Jurisdictional admin"))
-          // "Role" select should have all three role option
-          expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Jurisdictional admin" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-          await userEvent.type(screen.getByRole("textbox", { name: "First name" }), "firstName")
-          await userEvent.type(screen.getByRole("textbox", { name: "Last name" }), "lastName")
-          await userEvent.type(screen.getByRole("textbox", { name: "Email" }), "eamil@example.com")
-          await userEvent.selectOptions(
-            screen.getByRole("combobox", { name: "Role" }),
-            screen.getByRole("option", { name: "Jurisdictional admin" })
-          )
-          await userEvent.click(screen.getByRole("button", { name: "Invite" }))
-          expect(screen.getByText("This field is required"))
-          // Should display both jurisdiction options
-          expect(
-            screen.getByRole("option", { name: "jurisdictionWithJurisdictionAdmin" })
-          ).toBeInTheDocument()
-          expect(
-            screen.getByRole("option", { name: "jurisdictionWithJurisdictionAdmin2" })
-          ).toBeInTheDocument()
-          await userEvent.selectOptions(
-            screen.getByRole("combobox", { name: "Jurisdiction" }),
-            screen.getByRole("option", { name: "jurisdictionWithJurisdictionAdmin" })
-          )
-          await userEvent.click(screen.getByRole("button", { name: "Invite" }))
-          await waitFor(() => {
-            expect(requestSpy).toHaveBeenCalledWith({
-              firstName: "firstName",
-              lastName: "lastName",
-              email: "eamil@example.com",
-              userRoles: {
-                isAdmin: false,
-                isPartner: false,
-                isJurisdictionalAdmin: true,
-                isLimitedJurisdictionalAdmin: false,
-                isSupportAdmin: false,
-              },
-              listings: [],
-              jurisdictions: [{ id: "jurisdiction1" }],
-              agreedToTermsOfService: false,
-            })
-          })
-          await waitFor(() => expect(onDrawerClose).toBeCalled())
-        })
-
-        it("should invite a partner user", async () => {
-          // Watch the invite call to make sure it's called
-          const requestSpy = jest.fn()
-          server.events.on("request:start", (request) => {
-            if (request.method === "POST" && request.url.href.includes("invite")) {
-              requestSpy(request.body)
-            }
-          })
-          server.use(
-            rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-              return res(ctx.json(adminUserWithJurisdictions))
-            }),
-            rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-              return res(ctx.json({ success: true }))
-            })
-          )
-          const onCancel = jest.fn()
-          const onDrawerClose = jest.fn()
-          document.cookie = "access-token-available=True"
-
-          render(
-            <FormUserManage
-              isOpen={true}
-              title={t("users.addUser")}
-              mode={"add"}
-              listings={[
-                { id: "id1", name: "listing1", jurisdictions: { id: "jurisdiction1" } } as Listing,
-                { id: "id2", name: "listing2", jurisdictions: { id: "jurisdiction1" } } as Listing,
-                { id: "id3", name: "listing3", jurisdictions: { id: "jurisdiction1" } } as Listing,
-              ]}
-              onCancel={onCancel}
-              onDrawerClose={onDrawerClose}
-            />
-          )
-
-          await waitFor(() => screen.getByText("Jurisdictional admin"))
-          // "Role" select should have all three role option
-          expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Jurisdictional admin" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-          await userEvent.type(screen.getByRole("textbox", { name: "First name" }), "firstName")
-          await userEvent.type(screen.getByRole("textbox", { name: "Last name" }), "lastName")
-          await userEvent.type(screen.getByRole("textbox", { name: "Email" }), "email@example.com")
-          await userEvent.selectOptions(
-            screen.getByRole("combobox", { name: "Role" }),
-            screen.getByRole("option", { name: "Partner" })
-          )
-          await userEvent.click(screen.getByRole("button", { name: "Invite" }))
-          expect(screen.getByText("This field is required"))
-          // Should display both jurisdiction options as checkboxes
-          expect(
-            screen.getByRole("checkbox", { name: "jurisdictionWithJurisdictionAdmin" })
-          ).toBeInTheDocument()
-          expect(
-            screen.getByRole("checkbox", { name: "jurisdictionWithJurisdictionAdmin2" })
-          ).toBeInTheDocument()
-          await userEvent.click(
-            screen.getByRole("checkbox", { name: "jurisdictionWithJurisdictionAdmin" })
-          )
-          await waitFor(() => screen.getByText("jurisdictionWithJurisdictionAdmin listings"))
-          await userEvent.click(screen.getByRole("checkbox", { name: "listing1" }))
-          await userEvent.click(screen.getByRole("checkbox", { name: "listing3" }))
-          await userEvent.click(screen.getByRole("button", { name: "Invite" }))
-          await waitFor(() => {
-            expect(requestSpy).toHaveBeenCalledWith({
-              firstName: "firstName",
-              lastName: "lastName",
-              email: "email@example.com",
-              userRoles: {
-                isAdmin: false,
-                isPartner: true,
-                isJurisdictionalAdmin: false,
-                isLimitedJurisdictionalAdmin: false,
-                isSupportAdmin: false,
-              },
-              listings: [{ id: "id1" }, { id: "id3" }],
-              jurisdictions: [{ id: "jurisdiction1" }],
-              agreedToTermsOfService: false,
-            })
-          })
-          await waitFor(() => expect(onDrawerClose).toBeCalled())
-        })
-      })
-      describe("as jurisdictional admin", () => {
-        const jurisAdminUserWithJurisdictions = {
-          ...mockUser,
-          userRoles: { isJurisdictionalAdmin: true },
-          jurisdictions: [
-            { id: "jurisdiction1", name: "jurisdictionWithJurisdictionAdmin", featureFlags: [] },
-          ],
-        }
-        it("should only be able to select jurisdictional admin or partner", async () => {
-          server.use(
-            rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-              return res(ctx.json(jurisAdminUserWithJurisdictions))
-            }),
-            rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-              return res(ctx.json({ success: true }))
-            })
-          )
-          const onCancel = jest.fn()
-          const onDrawerClose = jest.fn()
-          document.cookie = "access-token-available=True"
-
-          render(
-            <FormUserManage
-              isOpen={true}
-              title={t("users.addUser")}
-              mode={"add"}
-              listings={[]}
-              onCancel={onCancel}
-              onDrawerClose={onDrawerClose}
-            />
-          )
-          await waitFor(() => screen.getByText("Jurisdictional admin"))
-          expect(screen.queryByRole("option", { name: "Administrator" })).not.toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Jurisdictional admin" })).toBeInTheDocument()
-          expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-        })
-      })
-    })
-
-    describe("with jurisdictional admins disabled", () => {
-      it("should show jurisdictional admin, but only for one jurisdiction", async () => {
-        const adminUserWithJurisdictionsAndOneDisabled = {
-          ...adminUser,
-          jurisdictions: [
-            {
-              id: "jurisdiction1",
-              name: "jurisdictionWithJurisdictionAdmin",
-              featureFlags: [{ name: FeatureFlagEnum.disableJurisdictionalAdmin, active: true }],
-            },
-            { id: "jurisdiction2", name: "jurisdictionWithJurisdictionAdmin2", featureFlags: [] },
-          ],
-        }
-        server.use(
-          rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-            return res(ctx.json(adminUserWithJurisdictionsAndOneDisabled))
-          }),
-          rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-            return res(ctx.json({ success: true }))
-          })
-        )
-        const onCancel = jest.fn()
-        const onDrawerClose = jest.fn()
-        document.cookie = "access-token-available=True"
-
-        render(
-          <FormUserManage
-            isOpen={true}
-            title={t("users.addUser")}
-            mode={"add"}
-            listings={[]}
-            onCancel={onCancel}
-            onDrawerClose={onDrawerClose}
-          />
-        )
-
-        await waitFor(() => screen.getByText("Administrator"))
-        expect(screen.getByText("Add user")).toBeInTheDocument()
-        expect(screen.getByText("User details")).toBeInTheDocument()
-        // "Role" select should have all three role option
-        expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Jurisdictional admin" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-        expect(screen.getByRole("button", { name: "Invite" })).toBeInTheDocument()
-        await userEvent.selectOptions(
-          screen.getByRole("combobox", { name: "Role" }),
-          screen.getByRole("option", { name: "Jurisdictional admin" })
-        )
-        expect(
-          screen.getByRole("option", { name: "jurisdictionWithJurisdictionAdmin2" })
-        ).toBeInTheDocument()
-        expect(
-          screen.queryAllByRole("option", { name: "jurisdictionWithJurisdictionAdmin" })
-        ).toHaveLength(0)
-      })
-
-      it("should not show jurisdictional admin if all have it disabled", async () => {
-        const adminUserWithJurisdictionsAndAllDisabled = {
-          ...adminUser,
-          jurisdictions: [
-            {
-              id: "jurisdiction1",
-              name: "jurisdictionWithJurisdictionAdmin",
-              featureFlags: [{ name: FeatureFlagEnum.disableJurisdictionalAdmin, active: true }],
-            },
-            {
-              id: "jurisdiction2",
-              name: "jurisdictionWithJurisdictionAdmin2",
-              featureFlags: [{ name: FeatureFlagEnum.disableJurisdictionalAdmin, active: true }],
-            },
-          ],
-        }
-        server.use(
-          rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-            return res(ctx.json(adminUserWithJurisdictionsAndAllDisabled))
-          }),
-          rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-            return res(ctx.json({ success: true }))
-          })
-        )
-        const onCancel = jest.fn()
-        const onDrawerClose = jest.fn()
-        document.cookie = "access-token-available=True"
-
-        render(
-          <FormUserManage
-            isOpen={true}
-            title={t("users.addUser")}
-            mode={"add"}
-            listings={[]}
-            onCancel={onCancel}
-            onDrawerClose={onDrawerClose}
-          />
-        )
-
-        await waitFor(() => screen.getByText("Administrator"))
-        expect(screen.getByText("Add user")).toBeInTheDocument()
-        expect(screen.getByText("User details")).toBeInTheDocument()
-        // "Role" select should not have Jurisdictional admin
-        expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-        expect(
-          screen.queryByRole("option", { name: "Jurisdictional admin" })
-        ).not.toBeInTheDocument()
-      })
-    })
-
-    describe("enableSupportAdmin", () => {
-      it("should not show support admin role when feature flag not enabled", async () => {
-        const adminUserWithJurisdictionsAndAllDisabled = {
-          ...adminUser,
-          jurisdictions: [
-            {
-              id: "jurisdiction1",
-              name: "jurisdictionWithoutSupportAdmin",
-            },
-            {
-              id: "jurisdiction2",
-              name: "jurisdictionWithoutSupportAdmin2",
-            },
-          ],
-        }
-        server.use(
-          rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-            return res(ctx.json(adminUserWithJurisdictionsAndAllDisabled))
-          }),
-          rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-            return res(ctx.json({ success: true }))
-          })
-        )
-        const onCancel = jest.fn()
-        const onDrawerClose = jest.fn()
-        document.cookie = "access-token-available=True"
-
-        render(
-          <FormUserManage
-            isOpen={true}
-            title={t("users.addUser")}
-            mode={"add"}
-            listings={[]}
-            onCancel={onCancel}
-            onDrawerClose={onDrawerClose}
-          />
-        )
-
-        await waitFor(() => screen.getByText("Administrator"))
-        expect(screen.getByText("Add user")).toBeInTheDocument()
-        expect(screen.getByText("User details")).toBeInTheDocument()
-        // "Role" select should not have Support Admin
-        expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-        expect(screen.queryByRole("option", { name: "Admin (support)" })).not.toBeInTheDocument()
-      })
-
-      it("should show support admin role when feature flag enabled", async () => {
-        const adminUserWithJurisdictionsAndOneEnabled = {
-          ...adminUser,
-          jurisdictions: [
-            {
-              id: "jurisdiction1",
-              name: "jurisdictionWithSupportAdmin",
-            },
-            {
-              id: "jurisdiction2",
-              name: "jurisdictionWithSupportAdmin2",
-              featureFlags: [{ name: FeatureFlagEnum.enableSupportAdmin, active: true }],
-            },
-          ],
-        }
-        server.use(
-          rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-            return res(ctx.json(adminUserWithJurisdictionsAndOneEnabled))
-          }),
-          rest.post("http://localhost/api/adapter/user/invite", (_req, res, ctx) => {
-            return res(ctx.json({ success: true }))
-          })
-        )
-        const onCancel = jest.fn()
-        const onDrawerClose = jest.fn()
-        document.cookie = "access-token-available=True"
-
-        render(
-          <FormUserManage
-            isOpen={true}
-            title={t("users.addUser")}
-            mode={"add"}
-            listings={[]}
-            onCancel={onCancel}
-            onDrawerClose={onDrawerClose}
-          />
-        )
-
-        await waitFor(() => screen.getByText("Administrator"))
-        expect(screen.getByText("Add user")).toBeInTheDocument()
-        expect(screen.getByText("User details")).toBeInTheDocument()
-        // "Role" select should not Support Admin
-        expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-        expect(screen.queryByRole("option", { name: "Admin (support)" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-        expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe("Edit User", () => {
-    const adminUserWithJurisdictions = {
-      ...adminUser,
-      jurisdictions: [
-        { id: "jurisdiction1", name: "jurisdictionWithJurisdictionAdmin", featureFlags: [] },
-        { id: "jurisdiction2", name: "jurisdictionWithJurisdictionAdmin2", featureFlags: [] },
-      ],
-    }
-    it("should update a partner user and their listings", async () => {
-      // Watch the update call to make sure it's called
-      const requestSpy = jest.fn()
-      server.events.on("request:start", (request) => {
-        if (request.method === "PUT" && request.url.href.includes("user/%7Bid%7D")) {
-          requestSpy(request.body)
-        }
-      })
-      server.use(
-        rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-          return res(ctx.json(adminUserWithJurisdictions))
-        }),
-        rest.put("http://localhost/api/adapter/user/%7Bid%7D", (_req, res, ctx) => {
-          return res(ctx.json({ success: true }))
-        })
-      )
-      const onCancel = jest.fn()
-      const onDrawerClose = jest.fn()
-      document.cookie = "access-token-available=True"
-
-      render(
+  render(
+    <MessageContext.Provider value={{ addToast, toastMessagesRef: { current: [] } }}>
+      <AuthContext.Provider
+        value={{
+          profile,
+          userService: {
+            invite,
+            update,
+            resendPartnerConfirmation,
+            delete: remove,
+          } as never,
+          doJurisdictionsHaveFeatureFlagOn: createFeatureFlagReader(profile),
+        }}
+      >
         <FormUserManage
           isOpen={true}
-          title={t("users.editUser")}
-          mode={"edit"}
-          user={
-            {
-              id: "existingUserId",
-              firstName: "existingFirstName",
-              lastName: "existingLastName",
-              email: "existingEmail@email.com",
-              userRoles: { isPartner: true },
-              jurisdictions: [{ id: "jurisdiction1" }],
-              listings: [
-                { id: "id1", name: "listing1" },
-                { id: "id2", name: "listing2" },
-              ],
-            } as User
-          }
-          listings={[
-            { id: "id1", name: "listing1", jurisdictions: { id: "jurisdiction1" } } as Listing,
-            { id: "id2", name: "listing2", jurisdictions: { id: "jurisdiction1" } } as Listing,
-            { id: "id3", name: "listing3", jurisdictions: { id: "jurisdiction1" } } as Listing,
-          ]}
+          title={title}
+          mode={mode}
+          user={user}
+          listings={listings}
           onCancel={onCancel}
           onDrawerClose={onDrawerClose}
         />
-      )
+      </AuthContext.Provider>
+    </MessageContext.Provider>
+  )
 
-      await waitFor(() => screen.getByText("Administrator"))
-      expect(screen.getByText("Edit user")).toBeInTheDocument()
-      expect(screen.getByText("User details")).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument()
-      expect(screen.getByRole("textbox", { name: "First name" })).toBeInTheDocument()
-      expect(screen.getByRole("textbox", { name: "Last name" })).toBeInTheDocument()
-      expect(screen.getByRole("textbox", { name: "Email" })).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Resend invite" })).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument()
-      // "Role" select should have all three role option
-      expect(screen.getByRole("combobox", { name: "Role" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "Jurisdictional admin" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
-      // Jurisdiction options
-      expect(
-        screen.getByRole("checkbox", { name: "jurisdictionWithJurisdictionAdmin" })
-      ).toBeInTheDocument()
-      expect(
-        screen.getByRole("checkbox", { name: "jurisdictionWithJurisdictionAdmin2" })
-      ).toBeInTheDocument()
-      // Listing options with the correct listings preselected
-      expect(screen.getByRole("checkbox", { name: "listing1", checked: true })).toBeInTheDocument()
-      expect(screen.getByRole("checkbox", { name: "listing2", checked: true })).toBeInTheDocument()
-      expect(screen.getByRole("checkbox", { name: "listing3", checked: false })).toBeInTheDocument()
-      // Select and unselect listings
-      await userEvent.click(screen.getByRole("checkbox", { name: "listing3" }))
-      await userEvent.click(screen.getByRole("checkbox", { name: "listing2" }))
-      await userEvent.click(screen.getByRole("button", { name: "Save" }))
-      await waitFor(() => {
-        expect(requestSpy).toHaveBeenCalledWith({
+  return {
+    addToast,
+    invite,
+    update,
+    resendPartnerConfirmation,
+    remove,
+    onCancel,
+    onDrawerClose,
+  }
+}
+
+beforeAll(() => {
+  mockNextRouter()
+})
+
+afterEach(() => {
+  document.cookie = "access-token-available=True; expires=Thu, 01 Jan 1970 00:00:00 GMT"
+})
+
+describe("<FormUserManage>", () => {
+  it("should invite an admin user without sending jurisdictions", async () => {
+    const { invite, onDrawerClose } = renderWithContext({
+      profile: {
+        ...adminUser,
+        jurisdictions: [{ id: "jurisdiction1", name: "Jurisdiction 1", featureFlags: [] }],
+      },
+    })
+
+    await userEvent.type(screen.getByRole("textbox", { name: "First name" }), "firstName")
+    await userEvent.type(screen.getByRole("textbox", { name: "Last name" }), "lastName")
+    await userEvent.type(screen.getByRole("textbox", { name: "Email" }), "email@example.com")
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Role" }),
+      screen.getByRole("option", { name: "Administrator" })
+    )
+    await userEvent.click(screen.getByRole("button", { name: "Invite" }))
+
+    await waitFor(() =>
+      expect(invite).toHaveBeenCalledWith({
+        body: {
+          firstName: "firstName",
+          lastName: "lastName",
+          email: "email@example.com",
+          userRoles: {
+            isAdmin: true,
+            isPartner: false,
+            isJurisdictionalAdmin: false,
+            isLimitedJurisdictionalAdmin: false,
+            isSupportAdmin: false,
+            userId: undefined,
+          },
+          listings: [],
+          agreedToTermsOfService: false,
+        },
+      })
+    )
+    await waitFor(() => expect(onDrawerClose).toBeCalled())
+  })
+
+  it("should invite a jurisdictional admin without a jurisdiction selector", async () => {
+    const { invite, onDrawerClose } = renderWithContext({
+      profile: {
+        ...adminUser,
+        jurisdictions: [{ id: "jurisdiction1", name: "Jurisdiction 1", featureFlags: [] }],
+      },
+    })
+
+    await userEvent.type(screen.getByRole("textbox", { name: "First name" }), "firstName")
+    await userEvent.type(screen.getByRole("textbox", { name: "Last name" }), "lastName")
+    await userEvent.type(screen.getByRole("textbox", { name: "Email" }), "email@example.com")
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Role" }),
+      screen.getByRole("option", { name: "Jurisdictional admin" })
+    )
+
+    expect(screen.queryByRole("combobox", { name: "Jurisdiction" })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: "Invite" }))
+
+    await waitFor(() =>
+      expect(invite).toHaveBeenCalledWith({
+        body: {
+          firstName: "firstName",
+          lastName: "lastName",
+          email: "email@example.com",
+          userRoles: {
+            isAdmin: false,
+            isPartner: false,
+            isJurisdictionalAdmin: true,
+            isLimitedJurisdictionalAdmin: false,
+            isSupportAdmin: false,
+            userId: undefined,
+          },
+          listings: [],
+          agreedToTermsOfService: false,
+        },
+      })
+    )
+    await waitFor(() => expect(onDrawerClose).toBeCalled())
+  })
+
+  it("should require partner listing selection and submit listing-only payload", async () => {
+    const { invite, onDrawerClose } = renderWithContext({
+      profile: {
+        ...adminUser,
+        jurisdictions: [{ id: "jurisdiction1", name: "Jurisdiction 1", featureFlags: [] }],
+      },
+      listings: listingOptions,
+    })
+
+    await userEvent.type(screen.getByRole("textbox", { name: "First name" }), "firstName")
+    await userEvent.type(screen.getByRole("textbox", { name: "Last name" }), "lastName")
+    await userEvent.type(screen.getByRole("textbox", { name: "Email" }), "email@example.com")
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Role" }),
+      screen.getByRole("option", { name: "Partner" })
+    )
+    await userEvent.click(screen.getByRole("button", { name: "Invite" }))
+
+    expect(screen.getByText("This field is required")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "listing1" }))
+    await userEvent.click(screen.getByRole("checkbox", { name: "listing3" }))
+    await userEvent.click(screen.getByRole("button", { name: "Invite" }))
+
+    await waitFor(() =>
+      expect(invite).toHaveBeenCalledWith({
+        body: {
+          firstName: "firstName",
+          lastName: "lastName",
+          email: "email@example.com",
+          userRoles: {
+            isAdmin: false,
+            isPartner: true,
+            isJurisdictionalAdmin: false,
+            isLimitedJurisdictionalAdmin: false,
+            isSupportAdmin: false,
+            userId: undefined,
+          },
+          listings: [{ id: "id1" }, { id: "id3" }],
+          agreedToTermsOfService: false,
+        },
+      })
+    )
+    await waitFor(() => expect(onDrawerClose).toBeCalled())
+  })
+
+  it("should hide the administrator role for jurisdictional admins", () => {
+    renderWithContext({
+      profile: {
+        ...mockUser,
+        userRoles: { isJurisdictionalAdmin: true },
+        jurisdictions: [{ id: "jurisdiction1", name: "Jurisdiction 1", featureFlags: [] }],
+      },
+    })
+
+    expect(screen.queryByRole("option", { name: "Administrator" })).not.toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Jurisdictional admin" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
+  })
+
+  it("should hide jurisdictional admin when disabled across all jurisdictions", () => {
+    renderWithContext({
+      profile: {
+        ...adminUser,
+        jurisdictions: [
+          {
+            id: "jurisdiction1",
+            name: "Jurisdiction 1",
+            featureFlags: [{ name: FeatureFlagEnum.disableJurisdictionalAdmin, active: true }],
+          },
+          {
+            id: "jurisdiction2",
+            name: "Jurisdiction 2",
+            featureFlags: [{ name: FeatureFlagEnum.disableJurisdictionalAdmin, active: true }],
+          },
+        ],
+      },
+    })
+
+    expect(screen.queryByRole("option", { name: "Jurisdictional admin" })).not.toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Administrator" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Partner" })).toBeInTheDocument()
+  })
+
+  it("should show support admin when enabled in any jurisdiction", () => {
+    renderWithContext({
+      profile: {
+        ...adminUser,
+        jurisdictions: [
+          { id: "jurisdiction1", name: "Jurisdiction 1", featureFlags: [] },
+          {
+            id: "jurisdiction2",
+            name: "Jurisdiction 2",
+            featureFlags: [{ name: FeatureFlagEnum.enableSupportAdmin, active: true }],
+          },
+        ],
+      },
+    })
+
+    expect(screen.getByRole("option", { name: "Admin (support)" })).toBeInTheDocument()
+  })
+
+  it("should update a partner user without sending jurisdictions", async () => {
+    const { update, onDrawerClose } = renderWithContext({
+      profile: {
+        ...adminUser,
+        jurisdictions: [{ id: "jurisdiction1", name: "Jurisdiction 1", featureFlags: [] }],
+      },
+      mode: "edit",
+      title: t("users.editUser"),
+      listings: listingOptions,
+      user: {
+        ...mockUser,
+        id: "existingUserId",
+        firstName: "existingFirstName",
+        lastName: "existingLastName",
+        email: "existingEmail@email.com",
+        userRoles: { isPartner: true },
+        listings: [
+          { id: "id1", name: "listing1" },
+          { id: "id2", name: "listing2" },
+        ],
+      },
+    })
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "listing3" }))
+    await userEvent.click(screen.getByRole("checkbox", { name: "listing2" }))
+    await userEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith({
+        body: {
           id: "existingUserId",
           firstName: "existingFirstName",
           lastName: "existingLastName",
@@ -637,140 +349,68 @@ describe("<FormUserManage>", () => {
             isJurisdictionalAdmin: false,
             isLimitedJurisdictionalAdmin: false,
             isSupportAdmin: false,
+            userId: undefined,
           },
           listings: [{ id: "id1" }, { id: "id3" }],
-          jurisdictions: [{ id: "jurisdiction1" }],
-          agreedToTermsOfService: false,
-        })
+          agreedToTermsOfService: true,
+        },
       })
-      await waitFor(() => expect(onDrawerClose).toBeCalled())
+    )
+    await waitFor(() => expect(onDrawerClose).toBeCalled())
+  })
+
+  it("should resend invite for an existing user", async () => {
+    const { resendPartnerConfirmation, onDrawerClose } = renderWithContext({
+      mode: "edit",
+      title: t("users.editUser"),
+      user: {
+        ...mockUser,
+        id: "existingUserId",
+        firstName: "existingFirstName",
+        lastName: "existingLastName",
+        email: "existingEmail@email.com",
+        userRoles: { isPartner: true },
+      },
     })
 
-    it("should resend invite", async () => {
-      // Watch the resend invite call to make sure it's called
-      const requestSpy = jest.fn()
-      server.events.on("request:start", (request) => {
-        if (request.method === "POST" && request.url.href.includes("resend-partner-confirmation")) {
-          requestSpy(request.body)
-        }
-      })
-      server.use(
-        rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-          return res(ctx.json(adminUserWithJurisdictions))
-        }),
-        rest.post(
-          "http://localhost/api/adapter/user/resend-partner-confirmation",
-          (_req, res, ctx) => {
-            return res(ctx.json({ success: true }))
-          }
-        )
-      )
-      const onCancel = jest.fn()
-      const onDrawerClose = jest.fn()
-      document.cookie = "access-token-available=True"
+    await userEvent.click(screen.getByRole("button", { name: "Resend invite" }))
 
-      render(
-        <FormUserManage
-          isOpen={true}
-          title={t("users.editUser")}
-          mode={"edit"}
-          user={
-            {
-              id: "existingUserId",
-              firstName: "existingFirstName",
-              lastName: "existingLastName",
-              email: "existingEmail@email.com",
-              userRoles: { isPartner: true },
-              jurisdictions: [{ id: "jurisdiction1" }],
-              listings: [
-                { id: "id1", name: "listing1" },
-                { id: "id2", name: "listing2" },
-              ],
-            } as User
-          }
-          listings={[
-            { id: "id1", name: "listing1", jurisdictions: { id: "jurisdiction1" } } as Listing,
-            { id: "id2", name: "listing2", jurisdictions: { id: "jurisdiction1" } } as Listing,
-            { id: "id3", name: "listing3", jurisdictions: { id: "jurisdiction1" } } as Listing,
-          ]}
-          onCancel={onCancel}
-          onDrawerClose={onDrawerClose}
-        />
-      )
-
-      await waitFor(() => screen.getByText("Administrator"))
-      // Select and unselect listings
-      await userEvent.click(screen.getByRole("button", { name: "Resend invite" }))
-      await waitFor(() => {
-        expect(requestSpy).toHaveBeenCalledWith({
-          appUrl: "http://localhost",
+    await waitFor(() =>
+      expect(resendPartnerConfirmation).toHaveBeenCalledWith({
+        body: {
           email: "existingEmail@email.com",
-        })
+          appUrl: "http://localhost",
+        },
       })
-      await waitFor(() => expect(onDrawerClose).toBeCalled())
+    )
+    await waitFor(() => expect(onDrawerClose).toBeCalled())
+  })
+
+  it("should delete a user", async () => {
+    const { remove, onDrawerClose } = renderWithContext({
+      mode: "edit",
+      title: t("users.editUser"),
+      user: {
+        ...mockUser,
+        id: "existingUserId",
+        firstName: "existingFirstName",
+        lastName: "existingLastName",
+        email: "existingEmail@email.com",
+        userRoles: { isPartner: true },
+      },
     })
 
-    it("should delete user", async () => {
-      // Watch the invite call to make sure it's called
-      const requestSpy = jest.fn()
-      server.events.on("request:start", (request) => {
-        if (request.method === "DELETE") {
-          requestSpy(request.body)
-        }
-      })
-      server.use(
-        rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-          return res(ctx.json(adminUserWithJurisdictions))
-        }),
-        rest.delete("http://localhost/api/adapter/user", (_req, res, ctx) => {
-          return res(ctx.json({ success: true }))
-        })
-      )
-      const onCancel = jest.fn()
-      const onDrawerClose = jest.fn()
-      document.cookie = "access-token-available=True"
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+    await waitFor(() => screen.getByText("Do you really want to delete this user?"))
+    await userEvent.click(screen.getAllByRole("button", { name: "Delete" })[1])
 
-      render(
-        <FormUserManage
-          isOpen={true}
-          title={t("users.editUser")}
-          mode={"edit"}
-          user={
-            {
-              id: "existingUserId",
-              firstName: "existingFirstName",
-              lastName: "existingLastName",
-              email: "existingEmail@email.com",
-              userRoles: { isPartner: true },
-              jurisdictions: [{ id: "jurisdiction1" }],
-              listings: [
-                { id: "id1", name: "listing1" },
-                { id: "id2", name: "listing2" },
-              ],
-            } as User
-          }
-          listings={[
-            { id: "id1", name: "listing1", jurisdictions: { id: "jurisdiction1" } } as Listing,
-            { id: "id2", name: "listing2", jurisdictions: { id: "jurisdiction1" } } as Listing,
-            { id: "id3", name: "listing3", jurisdictions: { id: "jurisdiction1" } } as Listing,
-          ]}
-          onCancel={onCancel}
-          onDrawerClose={onDrawerClose}
-        />
-      )
-
-      await waitFor(() => screen.getByText("Administrator"))
-      // Click first delete button
-      await userEvent.click(screen.getByRole("button", { name: "Delete" }))
-      await waitFor(() => screen.getByText("Do you really want to delete this user?"))
-      // Hit confirmation
-      await userEvent.click(screen.getAllByRole("button", { name: "Delete" })[1])
-      await waitFor(() => expect(onDrawerClose).toBeCalled())
-      await waitFor(() => {
-        expect(requestSpy).toHaveBeenCalledWith({
+    await waitFor(() =>
+      expect(remove).toHaveBeenCalledWith({
+        body: {
           id: "existingUserId",
-        })
+        },
       })
-    })
+    )
+    await waitFor(() => expect(onDrawerClose).toBeCalled())
   })
 })

--- a/sites/partners/src/components/users/FormUserManage.tsx
+++ b/sites/partners/src/components/users/FormUserManage.tsx
@@ -34,8 +34,6 @@ type FormUserManageValues = {
   email?: string
   userRoles?: string
   user_listings?: string[]
-  jurisdiction_all?: boolean
-  jurisdictions?: string[]
 }
 
 const determineUserRole = (roles: UserRole) => {
@@ -62,7 +60,6 @@ const FormUserManage = ({
 }: FormUserManageProps) => {
   const { userService, profile, doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
   const { addToast } = useContext(MessageContext)
-  const jurisdictionList = profile?.jurisdictions
 
   const [isDeleteModalActive, setDeleteModalActive] = useState<boolean>(false)
 
@@ -91,12 +88,6 @@ const FormUserManage = ({
       email: user.email,
       userRoles: determineUserRole(user.userRoles),
       user_listings: user.listings?.map((item) => item.id) ?? [],
-      jurisdiction_all: jurisdictionList?.length === user.jurisdictions.length,
-      jurisdictions: user.jurisdictions.map((elem) => elem.id),
-    }
-  } else if (profile?.userRoles?.isJurisdictionalAdmin) {
-    defaultValues = {
-      jurisdictions: [jurisdictionList[0].id],
     }
   }
 
@@ -104,73 +95,17 @@ const FormUserManage = ({
     defaultValues,
   })
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, errors, getValues, trigger, setValue } = methods
-
-  const jurisdictionOptions = useMemo(() => {
-    return (
-      jurisdictionList
-        ?.map((juris) => ({
-          id: juris.id,
-          label: juris.name,
-          value: juris.id,
-          inputProps: {
-            onChange: () => {
-              if (getValues("jurisdictions").length === jurisdictionList.length) {
-                setValue("jurisdiction_all", true)
-              } else {
-                setValue("jurisdiction_all", false)
-              }
-            },
-          },
-        }))
-        .sort((a, b) => (a.label < b.label ? -1 : 1)) || []
-    )
-  }, [jurisdictionList, getValues, setValue])
+  const { register, errors, getValues, trigger } = methods
 
   const listingsOptions = useMemo(() => {
-    const jurisdictionalizedListings = {}
-    jurisdictionList?.forEach((juris) => {
-      jurisdictionalizedListings[juris.id] = []
-    })
-    listings.sort((a, b) => a.name.localeCompare(b.name))
-    listings.forEach((listing) => {
-      if (jurisdictionalizedListings[listing.jurisdictions.id]) {
-        // if the user has access to the jurisdiction
-        jurisdictionalizedListings[listing.jurisdictions.id].push({
-          id: listing.id,
-          label: listing.name,
-          value: listing.id,
-        })
-      }
-    })
-
-    Object.keys(jurisdictionalizedListings).forEach((key) => {
-      const listingsInJurisdiction = jurisdictionalizedListings[key]
-      listingsInJurisdiction.forEach((listing) => {
-        listing.inputProps = {
-          onChange: () => {
-            let currValues = getValues("user_listings")
-            if (currValues && !Array.isArray(currValues)) {
-              currValues = [currValues]
-            } else if (!currValues) {
-              currValues = []
-            }
-
-            const temp = listingsInJurisdiction.every((elem) =>
-              currValues.some((search) => elem.id === search)
-            )
-
-            if (temp) {
-              setValue(`listings_all_${key}`, true)
-            } else {
-              setValue(`listings_all_${key}`, false)
-            }
-          },
-        }
-      })
-    })
-    return jurisdictionalizedListings
-  }, [getValues, listings, setValue, jurisdictionList])
+    return [...listings]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((listing) => ({
+        id: listing.id,
+        label: listing.name,
+        value: listing.id,
+      }))
+  }, [listings])
 
   const { mutate: sendInvite, isLoading: isSendInviteLoading } = useMutate()
   const { mutate: resendConfirmation, isLoading: isResendConfirmationLoading } = useMutate()
@@ -178,7 +113,7 @@ const FormUserManage = ({
   const { mutate: deleteUser, isLoading: isDeleteUserLoading } = useMutate()
 
   const createUserBody = useCallback(async () => {
-    const { firstName, lastName, email, userRoles, jurisdictions } = getValues()
+    const { firstName, lastName, email, userRoles } = getValues()
 
     /**
      * react-hook form returns:
@@ -216,29 +151,17 @@ const FormUserManage = ({
 
     const leasingAgentInListings = user_listings?.map((id) => ({ id })) || []
 
-    let selectedJurisdictions = []
-    if (Array.isArray(jurisdictions)) {
-      selectedJurisdictions = jurisdictions.map((elem) => ({
-        id: elem,
-      }))
-    } else if (jurisdictions) {
-      selectedJurisdictions = [{ id: jurisdictions }]
-    } else {
-      selectedJurisdictions = jurisdictionOptions.map((elem) => ({ id: elem.id }))
-    }
-
     const body = {
       firstName,
       lastName,
       email,
       userRoles: roles,
       listings: leasingAgentInListings,
-      jurisdictions: selectedJurisdictions,
       agreedToTermsOfService: user?.agreedToTermsOfService ?? false,
     }
 
     return body
-  }, [getValues, trigger, user?.agreedToTermsOfService, jurisdictionOptions])
+  }, [getValues, trigger, user?.agreedToTermsOfService])
 
   const onInvite = async () => {
     const body = await createUserBody()
@@ -419,10 +342,7 @@ const FormUserManage = ({
                       </Grid.Cell>
                     </Grid.Row>
                   </SectionWithGrid>
-                  <JurisdictionAndListingSelection
-                    jurisdictionOptions={jurisdictionOptions}
-                    listingsOptions={listingsOptions}
-                  />
+                  <JurisdictionAndListingSelection listingsOptions={listingsOptions} />
                 </Card.Section>
               </Card>
             </Form>

--- a/sites/partners/src/components/users/JurisdictionAndListingSelection.tsx
+++ b/sites/partners/src/components/users/JurisdictionAndListingSelection.tsx
@@ -1,197 +1,34 @@
-import React, { useContext } from "react"
+import React from "react"
 import { useFormContext } from "react-hook-form"
-import { t, Field, FieldGroup, Select } from "@bloom-housing/ui-components"
+import { t, FieldGroup } from "@bloom-housing/ui-components"
 import { Grid } from "@bloom-housing/ui-seeds"
-import { RoleOption, AuthContext } from "@bloom-housing/shared-helpers"
+import { RoleOption } from "@bloom-housing/shared-helpers"
 import SectionWithGrid from "../shared/SectionWithGrid"
-import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
-const JurisdictionAndListingSelection = ({ jurisdictionOptions, listingsOptions }) => {
+const JurisdictionAndListingSelection = ({ listingsOptions }) => {
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, errors, getValues, setValue, watch } = useFormContext()
-  const { profile, doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
+  const { register, errors, watch } = useFormContext()
   const selectedRoles = watch("userRoles")
-  const selectedJurisdictions = watch("jurisdictions")
+  if (selectedRoles !== RoleOption.Partner || !listingsOptions?.length) return null
 
-  /**
-   * Control listing checkboxes on select/deselect all listings option
-   */
-  const updateAllCheckboxes = (e: React.ChangeEvent<HTMLInputElement>, key: string) => {
-    const incomingListingIds = listingsOptions[key].map((option) => option.id)
-    let currentListingIds = getValues("user_listings")
-
-    if (e.target.checked) {
-      const allListingIds = incomingListingIds.reduce(
-        (accum, curr) => {
-          if (!accum.includes(curr)) {
-            // if we are adding listings, make sure we aren't double adding listings
-            accum.push(curr)
-          } else if (!e.target.checked && accum.includes(curr)) {
-            // if we are removing listings
-            accum = accum.filter((elem) => elem !== curr)
-          }
-          return accum
-        },
-        [...(currentListingIds || [])]
-      )
-      setValue("user_listings", allListingIds)
-    } else {
-      if (currentListingIds && !Array.isArray(currentListingIds)) {
-        currentListingIds = [currentListingIds]
-      } else if (!currentListingIds) {
-        currentListingIds = []
-      }
-      const allListingIds = currentListingIds.filter((elem) => !incomingListingIds.includes(elem))
-
-      setValue("user_listings", allListingIds.length === 0 ? null : allListingIds)
-    }
-  }
-
-  const updateAllJurisdictionCheckboxes = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.checked) {
-      setValue("jurisdictions", [])
-    } else {
-      const allJurisdictionIds = jurisdictionOptions.map((option) => option.id)
-      setValue("jurisdictions", allJurisdictionIds)
-    }
-  }
-
-  const ListingSection = (renderTitle = false) => {
-    return Object.keys(listingsOptions).map((key) => {
-      if (!selectedJurisdictions.includes(key)) {
-        return null
-      }
-      const jurisdictionLabel = jurisdictionOptions.find((elem) => elem.id === key)?.label
-      return (
-        <Grid.Cell key={`listings_${key}`}>
-          <SectionWithGrid
-            heading={
-              renderTitle
-                ? t("users.jurisdictionalizedListings", {
-                    jurisdiction: jurisdictionLabel,
-                  })
-                : ""
-            }
-          >
-            <Grid.Row>
-              <Grid.Cell>
-                <div aria-label={`${jurisdictionLabel} Listing Selection`}>
-                  <Field
-                    id={`listings_all_${key}`}
-                    name={`listings_all_${key}`}
-                    label={t("users.alljurisdictionalizedListings", {
-                      jurisdiction: jurisdictionLabel,
-                    })}
-                    register={register}
-                    type="checkbox"
-                    inputProps={{
-                      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                        updateAllCheckboxes(e, key),
-                    }}
-                    dataTestId={`listings-all-${jurisdictionLabel}`}
-                  />
-
-                  <FieldGroup
-                    name="user_listings"
-                    fields={listingsOptions[key]}
-                    type="checkbox"
-                    register={register}
-                    error={!!errors?.user_listings}
-                    errorMessage={t("errors.requiredFieldError")}
-                    validation={{ required: true }}
-                    dataTestId={`listings_${jurisdictionLabel}`}
-                  />
-                </div>
-              </Grid.Cell>
-            </Grid.Row>
-          </SectionWithGrid>
+  return (
+    <SectionWithGrid heading={t("nav.listings")}>
+      <Grid.Row columns={1}>
+        <Grid.Cell>
+          <FieldGroup
+            name="user_listings"
+            fields={listingsOptions}
+            type="checkbox"
+            register={register}
+            error={!!errors?.user_listings}
+            errorMessage={t("errors.requiredFieldError")}
+            validation={{ required: true }}
+            dataTestId={"user-listings"}
+          />
         </Grid.Cell>
-      )
-    })
-  }
-
-  if (profile?.userRoles?.isAdmin) {
-    if (
-      selectedRoles === RoleOption.JurisdictionalAdmin ||
-      selectedRoles === RoleOption.LimitedJurisdictionalAdmin
-    ) {
-      // if disableJurisdictionalAdmin is flagged on for a jurisdiction remove it from selectable options
-      const filteredJurisdictionOptions = jurisdictionOptions.filter(
-        (option) =>
-          !doJurisdictionsHaveFeatureFlagOn(FeatureFlagEnum.disableJurisdictionalAdmin, option.id)
-      )
-      return (
-        <SectionWithGrid heading={t("t.jurisdiction")}>
-          <Grid.Row columns={4}>
-            <Grid.Cell>
-              <Select
-                id="jurisdictions"
-                name="jurisdictions"
-                label={t("t.jurisdiction")}
-                placeholder={t("t.selectOne")}
-                register={register}
-                controlClassName="control"
-                keyPrefix="users"
-                options={filteredJurisdictionOptions}
-                error={!!errors?.jurisdictions}
-                errorMessage={t("errors.requiredFieldError")}
-                validation={{ required: true }}
-              />
-            </Grid.Cell>
-          </Grid.Row>
-        </SectionWithGrid>
-      )
-    } else if (selectedRoles === RoleOption.Partner) {
-      return (
-        <>
-          <SectionWithGrid heading={t("t.jurisdiction")}>
-            <Grid.Row columns={4}>
-              <Grid.Cell>
-                <Field
-                  id="jurisdiction_all"
-                  name="jurisdiction_all"
-                  dataTestId={"jurisdiction-all"}
-                  label={t("users.allJurisdictions")}
-                  register={register}
-                  type="checkbox"
-                  inputProps={{
-                    onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                      updateAllJurisdictionCheckboxes(e),
-                  }}
-                />
-
-                <FieldGroup
-                  name="jurisdictions"
-                  fields={jurisdictionOptions}
-                  type="checkbox"
-                  register={register}
-                  error={!!errors?.jurisdictions}
-                  errorMessage={t("errors.requiredFieldError")}
-                  validation={{ required: true }}
-                  dataTestId={"jurisdictions"}
-                />
-              </Grid.Cell>
-            </Grid.Row>
-          </SectionWithGrid>
-          {selectedJurisdictions && (
-            <Grid>
-              <Grid.Row>{ListingSection(true)}</Grid.Row>
-            </Grid>
-          )}
-        </>
-      )
-    }
-  } else if (profile?.userRoles?.isJurisdictionalAdmin) {
-    if (selectedRoles === RoleOption.Partner && selectedJurisdictions) {
-      return (
-        <SectionWithGrid heading={t("nav.listings")}>
-          <Grid.Row columns={1}>{ListingSection()}</Grid.Row>
-        </SectionWithGrid>
-      )
-    }
-  }
-
-  return null
+      </Grid.Row>
+    </SectionWithGrid>
+  )
 }
 
 export { JurisdictionAndListingSelection as default, JurisdictionAndListingSelection }

--- a/sites/public/src/pages/_app.tsx
+++ b/sites/public/src/pages/_app.tsx
@@ -7,9 +7,13 @@ import { GoogleReCaptchaProvider } from "react-google-recaptcha-v3"
 import {
   addTranslation,
   GenericRouter,
+  LinkProps as UICLinkProps,
   NavigationContext as UICNavigationContext,
 } from "@bloom-housing/ui-components"
-import { NavigationContext } from "@bloom-housing/ui-seeds/src/global/NavigationContext"
+import {
+  LinkProps as SeedsLinkProps,
+  NavigationContext,
+} from "@bloom-housing/ui-seeds/src/global/NavigationContext"
 import {
   blankApplication,
   LoggedInUserIdleTimeout,
@@ -121,11 +125,14 @@ function PublicApp({ Component, router, pageProps }: AppProps) {
     </ConfigProvider>
   )
 
+  const seedsLinkComponent = LinkComponent as React.FunctionComponent<SeedsLinkProps>
+  const uiComponentsLinkComponent = LinkComponent as React.FunctionComponent<UICLinkProps>
+
   return (
-    <NavigationContext.Provider value={{ LinkComponent }}>
+    <NavigationContext.Provider value={{ LinkComponent: seedsLinkComponent }}>
       <UICNavigationContext.Provider
         value={{
-          LinkComponent,
+          LinkComponent: uiComponentsLinkComponent,
           router: router as GenericRouter,
         }}
       >


### PR DESCRIPTION
Closes #181
## Summary
- remove the persisted user-to-jurisdiction relation from Prisma, DTOs, and user create/update/invite flows
- switch permission and auth compatibility paths to use the singleton jurisdiction when user-scoped jurisdiction data is needed
- simplify partners user management so invite/update payloads only send roles and listings

## Testing
- yarn lint
- yarn --cwd api build
- yarn --cwd api test --runTestsByPath test/unit/passports/jwt.strategy.spec.ts test/unit/services/user.service.spec.ts test/unit/services/permission.service.spec.ts
- yarn --cwd sites/partners test:unit --runTestsByPath __tests__/components/users/FormUserManage.test.tsx
- yarn --cwd sites/partners build
- yarn --cwd sites/public build