### PR TITLE
Restore Infisical secret injection scripts

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,4 @@
+{
+  "workspaceId": "2980a086-4367-4a1a-aafd-d1f5d4879253",
+  "defaultEnvironment": "dev"
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:secrets": "infisical run --env=dev -- next dev",
     "build": "next build",
+    "build:secrets": "infisical run --env=dev -- next build",
     "start": "next start",
+    "start:secrets": "infisical run --env=dev -- next start",
     "lint": "oxlint . -c .oxlintrc.json",
     "lint:fix": "oxlint . -c .oxlintrc.json --fix",
     "format": "oxfmt . -c .oxfmtrc.json",


### PR DESCRIPTION
## Summary
- Re-adds `.infisical.json` with the original workspace ID and `dev` default environment
- Adds `:secrets` script variants (`dev:secrets`, `build:secrets`, `start:secrets`) that wrap commands with `infisical run --env=dev --`

These were removed during the project rewrite and are needed for local development with managed secrets.

## Test plan
- [x] Run `npm run dev:secrets` and verify Infisical injects environment variables