### PR TITLE
Add Docker deployment for AHP rewrite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.next
+api
+node_modules
+npm-debug.log*
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22.14.0-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends openssl curl bash ca-certificates \
+    && curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
+    && apt-get install -y --no-install-recommends infisical \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+ENV NODE_ENV=production
+ENV PORT=3100
+
+EXPOSE 3100
+
+CMD ["sh", "-c", "infisical run --env=prod --projectId=2980a086-4367-4a1a-aafd-d1f5d4879253 -- sh -c 'npm run start -- --hostname 0.0.0.0 --port ${PORT}'"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  ahp:
+    container_name: ahp
+    build: .
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      INFISICAL_TOKEN: ${INFISICAL_TOKEN}
+      PORT: ${PORT:-3100}


### PR DESCRIPTION
## Summary
- add a root Dockerfile for the rewritten Next.js app that installs Infisical and starts the app with production secrets on port 3100
- add a root docker-compose service named `ahp` so the rewrite can be deployed without the legacy `api/` service config
- exclude `.next`, `node_modules`, env files, and the legacy `api/` directory from the Docker build context

## Testing
- built the image and started the `ahp` container on `civictech`
- verified `http://127.0.0.1:3100/` returns `200 OK`