### PR TITLE
chore: enforce pre-commit ci checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,4 @@
 node_modules/.bin/gitleaks-secret-scanner
+npm run lint
+npm run format:check
+npm run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 node_modules/.bin/gitleaks-secret-scanner
 npm run lint
 npm run format:check
-npm run build
+npm run typecheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:secrets": "infisical run --env=dev -- next dev",
     "build": "next build",
     "build:secrets": "infisical run --env=dev -- next build",
+    "typecheck": "tsc --noEmit",
     "start": "next start",
     "start:secrets": "infisical run --env=dev -- next start",
     "lint": "oxlint . -c .oxlintrc.json",


### PR DESCRIPTION
## Summary
- extend the Husky pre-commit hook to run lint, format check, and typecheck in addition to the existing gitleaks scan
- block local commits unless the same non-test CI checks expected for PRs pass successfully
- keep tests out of pre-commit so iterative commits can still land during a work-in-progress branch