### PR TITLE
chore: override inherited issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+<!-- No repository-specific pull request template -->


### PR DESCRIPTION
## Summary
Override the organization-wide issue and pull request templates for this repository with blank repo-local defaults.

## Changes
- Add `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: true`
- Add `.github/pull_request_template.md` with a minimal placeholder comment so the org-level PR template is not used

## Why
This repo currently inherits issue forms and the PR template from `CivicTechWR/.github`. These repo-local files disable those inherited templates for this specific repository.

## Testing
- `git commit` hooks passed, including `tsc --noEmit`
- `git push` hook passed, including `next build`

## Notes
I cleared stale local `.next` output before retrying the commit because the repo's TypeScript config includes `.next/dev/types/**/*.ts`, and an outdated generated file caused an unrelated typecheck failure.