### PR TITLE
chore: replace deprecated Zod email method usage

### DIFF
--- a/lib/auth/validation.ts
+++ b/lib/auth/validation.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const emailSchema = z.string().trim().toLowerCase().email("Invalid email address.");
+export const emailSchema = z.string().trim().toLowerCase().pipe(z.email("Invalid email address."));
 
 export const passwordSchema = z
   .string()


### PR DESCRIPTION
## Summary
- replace deprecated `z.string().email(...)` call in auth validation
- preserve normalization by keeping `trim().toLowerCase()` and validating via `z.email(...)` through `pipe(...)`

## Validation
- npm run typecheck
