### PR TITLE
fix(listings): restore map layout and listing popup links

### DIFF
--- a/app/listings/listings.tsx
+++ b/app/listings/listings.tsx
@@ -16,6 +16,7 @@ import type { ListingSummary } from "@/shared/schemas/listings";
 export default function ListingsDashboard() {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [displayMode, setDisplayMode] = useState<DisplayMode>(DisplayMode.LIST);
+  const isSplitView = displayMode === DisplayMode.MAP_LIST;
   const listings: ListingSummary[] = [
     {
       id: "11111111-1111-4111-8111-111111111111",
@@ -60,8 +61,8 @@ export default function ListingsDashboard() {
   );
 
   return (
-    <div className="flex h-full flex-col">
-      <header className="flex h-16 items-center border-b bg-background px-4 shrink-0">
+    <div className="flex min-h-[calc(100vh-3.5rem)] flex-col">
+      <header className="flex h-16 shrink-0 items-center border-b bg-background px-4">
         <ListingFilterSearchBar
           searchInputProps={searchInputProps}
           priceRangeProps={priceRangeProps}
@@ -79,7 +80,7 @@ export default function ListingsDashboard() {
         />
         <FilterButton {...filterButtonProps} />
       </header>
-      <main className="flex flex-1 overflow-hidden">
+      <main className="flex min-h-0 flex-1 overflow-hidden">
         {displayMode !== DisplayMode.MAP ? (
           <ListingsPanel
             listings={listings}
@@ -89,7 +90,9 @@ export default function ListingsDashboard() {
           />
         ) : null}
         {[DisplayMode.MAP, DisplayMode.MAP_LIST].includes(displayMode) && (
-          <MapView listings={listings} />
+          <div className={`min-w-0 flex-1 ${isSplitView ? "lg:basis-1/2" : ""}`}>
+            <MapView listings={listings} />
+          </div>
         )}
         {isFilterOpen && (
           <ListingFilters

--- a/components/listings-panel/ListingsPanel.tsx
+++ b/components/listings-panel/ListingsPanel.tsx
@@ -25,7 +25,11 @@ export function ListingsPanel({
 }: ListingsPanelProps) {
   return (
     <div
-      className={`flex flex-col h-full bg-background min-w-[300px] sm:min-w-[330px] lg:min-w-[360px] ${displayMode === DisplayMode.LIST ? "flex-1" : ""}`}
+      className={`flex h-full flex-col bg-background ${
+        displayMode === DisplayMode.LIST
+          ? "flex-1"
+          : "min-w-[300px] sm:min-w-[330px] lg:min-w-0 lg:basis-1/2"
+      }`}
     >
       <ListingsPanelHeader
         listings={listings}

--- a/components/map-view/mapView.tsx
+++ b/components/map-view/mapView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useCallback, useMemo } from "react";
 import { Map, Marker, Popup } from "@vis.gl/react-maplibre";
 import type { Listing } from "@/components/listing-card-list/listingsCardList";
@@ -22,7 +23,7 @@ export function MapView({ listings }: { listings: Listing[] }) {
   }, []);
 
   return (
-    <div className="relative h-full w-full">
+    <div className="relative h-full min-h-0 w-full flex-1">
       <Map
         mapStyle={OPENFREEMAP_STYLE}
         initialViewState={DEFAULT_VIEW}
@@ -63,9 +64,12 @@ export function MapView({ listings }: { listings: Listing[] }) {
               <div className="text-lg font-bold text-blue-600">
                 ${selectedListing.price.toLocaleString()}
               </div>
-              <div className="text-sm font-semibold">
+              <Link
+                href={`/listings/${selectedListing.id}`}
+                className="text-sm font-semibold text-foreground transition-colors hover:text-blue-600 hover:underline"
+              >
                 {selectedListing.address}, {selectedListing.city}
-              </div>
+              </Link>
               <div className="mt-1 flex gap-2 text-xs text-muted-foreground">
                 <span>
                   <strong>{selectedListing.beds}</strong> bed


### PR DESCRIPTION
## Summary
- restore the listings map layout after the UI overhaul by giving the dashboard and map panel reliable height and sizing behavior again
- make split view render as an even 50/50 layout on large screens so the map and listings panel share the available space
- link the map popup address to the existing listing details route so users can open the full listing from the map

## Verification
- npm run typecheck
- npm run build