### PR TITLE
feat: add mobile header menu and breadcrumbs

### DIFF
--- a/components/site-header/HeaderBreadcrumbs.tsx
+++ b/components/site-header/HeaderBreadcrumbs.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+const uuidSegmentPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const segmentLabelMap: Record<string, string> = {
+  admin: "Admin",
+  invite: "Invite",
+  listings: "Listings",
+  preview: "Preview",
+  "admin-invite": "Admin Invite",
+  "sign-in": "Sign In",
+};
+
+function formatSegment(segment: string) {
+  if (uuidSegmentPattern.test(segment)) {
+    return "Details";
+  }
+
+  const knownLabel = segmentLabelMap[segment];
+
+  if (knownLabel) {
+    return knownLabel;
+  }
+
+  return segment
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function HeaderBreadcrumbs() {
+  const pathname = usePathname();
+  const segments = pathname.split("/").filter(Boolean);
+  const breadcrumbItems = segments.length > 0 ? segments.map(formatSegment) : ["Home"];
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol className="flex flex-wrap items-center gap-2 text-sm text-primary-foreground/80">
+        {breadcrumbItems.map((item, index) => (
+          <li key={`${item}-${index}`} className="flex items-center gap-2">
+            {index > 0 ? <span aria-hidden="true">&gt;</span> : null}
+            <span
+              aria-current={index === breadcrumbItems.length - 1 ? "page" : undefined}
+              className={
+                index === breadcrumbItems.length - 1 ? "font-medium text-primary-foreground" : ""
+              }
+            >
+              {item}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/components/site-header/HeaderMobileMenu.tsx
+++ b/components/site-header/HeaderMobileMenu.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { UserIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { signOutFromHeader } from "@/components/site-header/actions";
+
+type HeaderMobileMenuProps = {
+  isSignedIn: boolean;
+  isAdmin: boolean;
+  user: {
+    email?: string | null;
+    name?: string | null;
+  } | null;
+};
+
+const mobileMenuItemClass =
+  "flex w-full items-center justify-between rounded-2xl bg-primary-foreground/10 px-4 py-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary-foreground/20";
+
+export function HeaderMobileMenu({ isSignedIn, isAdmin, user }: HeaderMobileMenuProps) {
+  const pathname = usePathname();
+  const menuId = useId();
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
+  return (
+    <div className="absolute right-0 lg:hidden">
+      <button
+        type="button"
+        aria-controls={menuId}
+        aria-expanded={isOpen}
+        aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+        className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-primary-foreground/16 text-primary-foreground transition-colors hover:bg-primary-foreground/24"
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <span className="sr-only">{isOpen ? "Close navigation menu" : "Open navigation menu"}</span>
+        <span className="flex flex-col gap-1">
+          <span className="block h-0.5 w-4 rounded-full bg-current" />
+          <span className="block h-0.5 w-4 rounded-full bg-current" />
+          <span className="block h-0.5 w-4 rounded-full bg-current" />
+        </span>
+      </button>
+
+      {isOpen ? (
+        <div
+          id={menuId}
+          className="absolute right-0 top-[calc(100%+0.75rem)] z-20 w-[min(18rem,calc(100vw-2rem))] rounded-3xl border border-primary-foreground/15 bg-primary p-3 shadow-xl shadow-slate-950/20"
+        >
+          <nav aria-label="Mobile navigation" className="space-y-2">
+            <Link href="/listings" className={mobileMenuItemClass} onClick={() => setIsOpen(false)}>
+              <span>Browse Listings</span>
+            </Link>
+
+            {isSignedIn ? (
+              <>
+                {isAdmin ? (
+                  <Link
+                    href="/admin/custom-listing-fields"
+                    className={mobileMenuItemClass}
+                    onClick={() => setIsOpen(false)}
+                  >
+                    <span>Field Dashboard</span>
+                  </Link>
+                ) : null}
+
+                {user ? (
+                  <div className="flex items-center gap-3 rounded-2xl bg-primary-foreground/10 px-4 py-3 text-sm text-primary-foreground/90">
+                    <HugeiconsIcon icon={UserIcon} strokeWidth={2} size={16} />
+                    <span className="truncate font-medium">{user.name ?? user.email}</span>
+                  </div>
+                ) : null}
+
+                <form action={signOutFromHeader}>
+                  <button
+                    type="submit"
+                    className={mobileMenuItemClass}
+                    onClick={() => setIsOpen(false)}
+                  >
+                    <span>Sign out</span>
+                  </button>
+                </form>
+              </>
+            ) : (
+              <Link
+                href="/sign-in"
+                className={mobileMenuItemClass}
+                onClick={() => setIsOpen(false)}
+              >
+                <span>Sign in</span>
+              </Link>
+            )}
+          </nav>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/site-header/SiteHeader.tsx
+++ b/components/site-header/SiteHeader.tsx
@@ -3,6 +3,8 @@ import { UserIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { auth, signOut } from "@/auth";
+import { HeaderBreadcrumbs } from "@/components/site-header/HeaderBreadcrumbs";
+import { HeaderMobileMenu } from "@/components/site-header/HeaderMobileMenu";
 import { getOptionalSession } from "@/lib/auth/session";
 
 export async function SiteHeader() {
@@ -13,51 +15,63 @@ export async function SiteHeader() {
     "rounded-full bg-primary-foreground/20 px-4 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary-foreground/30";
 
   return (
-    <header
-      data-site-header="true"
-      className="relative flex h-14 items-center justify-center bg-primary px-6 shrink-0"
-    >
-      <Link href="/" className="text-lg font-semibold text-primary-foreground tracking-tight">
-        WR Housing Bridge
-      </Link>
-      <nav className="absolute right-6 flex items-center gap-2">
-        <Link href="/listings" className={navPillClass}>
-          Browse Listings
-        </Link>
-
-        {rawSession?.user ? (
-          <>
-            {optionalSession.authzUser?.role === "admin" ? (
-              <Link href="/admin/custom-listing-fields" className={navPillClass}>
-                Field Dashboard
-              </Link>
-            ) : null}
-
-            {session?.user ? (
-              <span className="inline-flex max-w-56 items-center gap-1.5 rounded-full bg-primary-foreground/20 px-3 py-1.5 text-sm font-medium text-primary-foreground">
-                <HugeiconsIcon icon={UserIcon} strokeWidth={2} size={16} />
-                <span className="truncate">{session.user.name ?? session.user.email}</span>
-              </span>
-            ) : null}
-
-            <form
-              action={async () => {
-                "use server";
-
-                await signOut({ redirectTo: "/" });
-              }}
-            >
-              <button type="submit" className={navPillClass}>
-                Sign out
-              </button>
-            </form>
-          </>
-        ) : (
-          <Link href="/sign-in" className={navPillClass}>
-            Sign in
+    <header data-site-header="true" className="bg-primary text-primary-foreground shrink-0">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6">
+        <div className="relative flex min-h-14 items-center justify-center py-2">
+          <Link href="/" className="text-lg font-semibold tracking-tight text-primary-foreground">
+            WR Housing Bridge
           </Link>
-        )}
-      </nav>
+
+          <nav className="absolute right-0 hidden items-center gap-2 lg:flex">
+            <Link href="/listings" className={navPillClass}>
+              Browse Listings
+            </Link>
+
+            {rawSession?.user ? (
+              <>
+                {optionalSession.authzUser?.role === "admin" ? (
+                  <Link href="/admin/custom-listing-fields" className={navPillClass}>
+                    Field Dashboard
+                  </Link>
+                ) : null}
+
+                {session?.user ? (
+                  <span className="inline-flex max-w-56 items-center gap-1.5 rounded-full bg-primary-foreground/20 px-3 py-1.5 text-sm font-medium text-primary-foreground">
+                    <HugeiconsIcon icon={UserIcon} strokeWidth={2} size={16} />
+                    <span className="truncate">{session.user.name ?? session.user.email}</span>
+                  </span>
+                ) : null}
+
+                <form
+                  action={async () => {
+                    "use server";
+
+                    await signOut({ redirectTo: "/" });
+                  }}
+                >
+                  <button type="submit" className={navPillClass}>
+                    Sign out
+                  </button>
+                </form>
+              </>
+            ) : (
+              <Link href="/sign-in" className={navPillClass}>
+                Sign in
+              </Link>
+            )}
+          </nav>
+
+          <HeaderMobileMenu
+            isSignedIn={Boolean(rawSession?.user)}
+            isAdmin={optionalSession.authzUser?.role === "admin"}
+            user={session?.user ?? null}
+          />
+        </div>
+
+        <div className="border-t border-primary-foreground/15 py-2.5">
+          <HeaderBreadcrumbs />
+        </div>
+      </div>
     </header>
   );
 }

--- a/components/site-header/actions.ts
+++ b/components/site-header/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { signOut } from "@/auth";
+
+export async function signOutFromHeader() {
+  await signOut({ redirectTo: "/" });
+}


### PR DESCRIPTION
## Summary
- add a breadcrumb row to the shared site header based on the current route
- collapse the existing header actions into a hamburger menu on small screens only
- keep the large-screen navigation and auth actions intact

## Testing
- npm run lint
- npm run build