### PR TITLE
misc fixes

### DIFF
--- a/app/listing-form/useListingForm.ts
+++ b/app/listing-form/useListingForm.ts
@@ -40,7 +40,7 @@ export function useListingForm(initialListingId?: string) {
     data: initialData,
     isLoading: isFetching,
     isError: isFetchError,
-  } = useGetListingQuery(activeListingId);
+  } = useGetListingQuery(initialListingId);
   const { createDraftListing, isLoading: isCreatingDraft } = useCreateDraftListingQuery();
   const { editListing, isLoading: isEditing } = useEditListingQuery();
   const autosavePayload = mapListingFormToAutosaveUpdateInput(
@@ -63,13 +63,10 @@ export function useListingForm(initialListingId?: string) {
   const shouldWarnOnNavigateAway =
     isPublishedEditMode && form.formState.isDirty && !form.formState.isSubmitting;
 
-  const activateDraftListing = useCallback(
-    (listingId: string) => {
-      setActiveListingId(listingId);
-      router.replace(`/listing-form/${listingId}`);
-    },
-    [router],
-  );
+  const activateDraftListing = useCallback((listingId: string) => {
+    setActiveListingId(listingId);
+    window.history.replaceState(null, "", `/listing-form/${listingId}`);
+  }, []);
 
   const createDraftListingId = useCallback(async (): Promise<string> => {
     if (activeListingId) {

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -2,9 +2,11 @@ import { redirect } from "next/navigation";
 
 import { auth } from "@/auth";
 import { SignInForm } from "@/components/auth/SignInForm";
+import { getOptionalSession } from "@/lib/auth/session";
 
 export default async function SignInPage() {
-  const session = await auth();
+  const rawSession = await auth();
+  const { session } = await getOptionalSession(rawSession);
 
   if (session?.user) {
     redirect("/");

--- a/components/listing-form-images/ListingFormImages.tsx
+++ b/components/listing-form-images/ListingFormImages.tsx
@@ -144,7 +144,7 @@ export function ListingFormImages({
                   multiple
                   accept={acceptedImageTypes}
                   onChange={(event) => handleImageUpload(event, images, field.onChange)}
-                  disabled={isUploading || !listingId}
+                  disabled={isUploading}
                 />
               </FormControl>
               <FormDescription>

--- a/components/site-header/SiteHeader.tsx
+++ b/components/site-header/SiteHeader.tsx
@@ -10,6 +10,7 @@ export async function SiteHeader() {
   const rawSession = await auth();
   const optionalSession = await getOptionalSession(rawSession);
   const session = optionalSession.session;
+  const isSignedIn = Boolean(session?.user);
   const canCreateListing =
     optionalSession.authzUser?.role === "admin" || optionalSession.authzUser?.role === "partner";
   const navPillClass =
@@ -24,7 +25,7 @@ export async function SiteHeader() {
           </Link>
 
           <nav className="absolute right-0 hidden items-center gap-2 lg:flex">
-            {rawSession?.user ? (
+            {isSignedIn ? (
               <>
                 {canCreateListing ? (
                   <>
@@ -55,7 +56,7 @@ export async function SiteHeader() {
           </nav>
 
           <HeaderMobileMenu
-            isSignedIn={Boolean(rawSession?.user)}
+            isSignedIn={isSignedIn}
             isAdmin={optionalSession.authzUser?.role === "admin"}
             canCreateListing={canCreateListing}
             user={session?.user ?? null}


### PR DESCRIPTION
## Summary
- restore the top-right SiteHeader pills when a raw auth session exists but the authorized session payload is unavailable
- allow the sign-in page to render instead of redirecting home when only a stale raw session cookie exists
- keep listing draft activation in-place by updating the URL without reloading the listing form route
- allow listing images to be selected before a draft exists so the picker matches its helper text

## Commits
- `fix(header): restore top-right account pills`
- `fix(auth): allow sign-in with stale sessions`
- `fix(listing-form): keep draft activation in-place`
- `fix(listing-form): allow images before draft creation`

## Verification
- `npm run typecheck`
- `next build` (via push hook)
