### PR TITLE
Fix draft autosave for in-progress contact emails

### DIFF
--- a/app/listing-form/api.ts
+++ b/app/listing-form/api.ts
@@ -62,7 +62,7 @@ export function mapListingFormToAutosaveUpdateInput(
   assignTrimmedString(address, "province", data.province);
   assignTrimmedString(address, "postalCode", data.postalCode);
   assignTrimmedString(contact, "name", data.contactName);
-  assignTrimmedString(contact, "email", data.contactEmail);
+  assignAutosaveContactEmail(contact, data.contactEmail);
   assignTrimmedString(contact, "phone", data.contactPhone);
   assignClearableTrimmedString(patch, "unitNumber", data.unitNumber);
   assignTrimmedString(patch, "propertyType", data.propertyType);
@@ -256,6 +256,24 @@ function assignClearableTrimmedString(
 
   const normalized = normalizeOptionalString(value);
   target[key] = normalized ?? null;
+}
+
+function assignAutosaveContactEmail(target: Record<string, unknown>, value: string | undefined) {
+  const normalized = normalizeOptionalString(value);
+
+  if (!normalized) {
+    return;
+  }
+
+  const result = updateListingSchema.safeParse({
+    contact: {
+      email: normalized,
+    },
+  });
+
+  if (result.success && result.data.contact?.email) {
+    target.email = result.data.contact.email;
+  }
 }
 
 function shouldClearOptionalString(value: string | undefined) {

--- a/app/listing-form/api.unit.test.ts
+++ b/app/listing-form/api.unit.test.ts
@@ -251,6 +251,36 @@ describe("mapListingFormToCreateListingInput", () => {
     });
   });
 
+  it("omits invalid in-progress contact emails from autosave payloads", () => {
+    expect(
+      mapListingFormToAutosaveUpdateInput({
+        ...CREATE_FORM_DEFAULTS,
+        title: "Draft title",
+        contactName: "Leasing Office",
+        contactEmail: "leasing@",
+        contactPhone: "519-555-0100",
+        monthlyRentCents: 0,
+      }),
+    ).toEqual({
+      title: "Draft title",
+      contact: {
+        name: "Leasing Office",
+        phone: "519-555-0100",
+      },
+      accessibilityFeatures: [],
+      images: [],
+      status: "draft",
+      units: [
+        {
+          bedrooms: 0,
+          bathrooms: 0,
+          rent: 0,
+        },
+      ],
+      utilitiesIncluded: [],
+    });
+  });
+
   it("preserves explicit unit number clearing on publish updates", () => {
     const rawInput: ListingFormInput = {
       ...validFormData,


### PR DESCRIPTION
## Summary
- omit invalid in-progress contact emails from draft autosave payloads
- keep partial contact autosave working for name and phone fields
- add a regression test for typing an incomplete email

## Tests
- npm test -- --runTestsByPath app/listing-form/api.unit.test.ts
- npm run lint
- npm run typecheck
- npm run build