### PR TITLE
Fix sign-in callback redirects

### DIFF
--- a/app/sign-in/actions.ts
+++ b/app/sign-in/actions.ts
@@ -3,6 +3,7 @@
 import { AuthError } from "next-auth";
 
 import { signIn } from "@/auth";
+import { getSafeCallbackPath } from "@/lib/auth/callback-url";
 import { signInSchema } from "@/lib/auth/validation";
 
 type SignInState = {
@@ -26,7 +27,7 @@ export async function signInWithPassword(
     await signIn("credentials", {
       email: parsed.data.email,
       password: parsed.data.password,
-      redirectTo: "/",
+      redirectTo: getSafeCallbackPath(formData.get("callbackUrl")),
     });
   } catch (error) {
     if (error instanceof AuthError) {

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,18 +1,29 @@
 import { redirect } from "next/navigation";
 
 import { SignInForm } from "@/components/auth/SignInForm";
+import { getSafeCallbackPath } from "@/lib/auth/callback-url";
 import { getOptionalSession } from "@/lib/auth/session";
 
-export default async function SignInPage() {
-  const { session } = await getOptionalSession();
+type SignInPageProps = {
+  searchParams: Promise<{
+    callbackUrl?: string | string[];
+  }>;
+};
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+  const [{ session }, resolvedSearchParams] = await Promise.all([
+    getOptionalSession(),
+    searchParams,
+  ]);
+  const callbackPath = getSafeCallbackPath(resolvedSearchParams.callbackUrl);
 
   if (session?.user) {
-    redirect("/");
+    redirect(callbackPath);
   }
 
   return (
     <main className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top,_var(--color-muted)_0%,_transparent_45%),linear-gradient(180deg,_var(--color-background)_0%,_color-mix(in_oklab,var(--color-background),black_4%)_100%)] px-6 py-20">
-      <SignInForm />
+      <SignInForm callbackUrl={callbackPath} />
     </main>
   );
 }

--- a/auth.ts
+++ b/auth.ts
@@ -94,8 +94,7 @@ const authConfig = {
       const requiresAdminAccess =
         pathname.startsWith("/api/admin") || pathname.startsWith("/admin");
       const requiresListingWriteAccess =
-        (pathname.startsWith("/api/listings") && request.method !== "GET") ||
-        requiresListingAuthorAccess;
+        pathname.startsWith("/api/listings") && request.method !== "GET";
       const requiresSessionCheck =
         requiresListingAccess || requiresListingAuthorAccess || requiresAdminAccess;
 

--- a/auth.ts
+++ b/auth.ts
@@ -90,11 +90,14 @@ const authConfig = {
       const pathname = request.nextUrl.pathname;
       const requiresListingAccess =
         pathname.startsWith("/listings") || pathname.startsWith("/api/listings");
+      const requiresListingAuthorAccess = pathname.startsWith("/listing-form");
       const requiresAdminAccess =
         pathname.startsWith("/api/admin") || pathname.startsWith("/admin");
       const requiresListingWriteAccess =
-        pathname.startsWith("/api/listings") && request.method !== "GET";
-      const requiresSessionCheck = requiresListingAccess || requiresAdminAccess;
+        (pathname.startsWith("/api/listings") && request.method !== "GET") ||
+        requiresListingAuthorAccess;
+      const requiresSessionCheck =
+        requiresListingAccess || requiresListingAuthorAccess || requiresAdminAccess;
 
       if (!currentAuth?.user?.id) {
         return !requiresSessionCheck;

--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -18,11 +18,16 @@ const initialState = {
   error: "",
 };
 
-export function SignInForm() {
+type SignInFormProps = {
+  callbackUrl: string;
+};
+
+export function SignInForm({ callbackUrl }: SignInFormProps) {
   const [state, action, pending] = useActionState(signInWithPassword, initialState);
 
   return (
     <form action={action}>
+      <input type="hidden" name="callbackUrl" value={callbackUrl} />
       <Card className="w-full max-w-md border border-border/80 shadow-xl shadow-black/5">
         <CardHeader className="border-b border-border/60">
           <CardTitle>Sign in</CardTitle>

--- a/lib/auth/callback-url.ts
+++ b/lib/auth/callback-url.ts
@@ -1,0 +1,35 @@
+const FALLBACK_REDIRECT_PATH = "/";
+
+const DISALLOWED_CALLBACK_PREFIXES = ["/api", "/auth", "/sign-in"];
+
+export function getSafeCallbackPath(
+  callbackUrl: FormDataEntryValue | string | string[] | undefined | null,
+): string {
+  const candidate = Array.isArray(callbackUrl) ? callbackUrl[0] : callbackUrl;
+
+  if (typeof candidate !== "string" || candidate.trim() === "") {
+    return FALLBACK_REDIRECT_PATH;
+  }
+
+  try {
+    const parsed = new URL(candidate, "http://localhost");
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return FALLBACK_REDIRECT_PATH;
+    }
+
+    if (
+      DISALLOWED_CALLBACK_PREFIXES.some((prefix) => isPathOrNestedPath(parsed.pathname, prefix))
+    ) {
+      return FALLBACK_REDIRECT_PATH;
+    }
+
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return FALLBACK_REDIRECT_PATH;
+  }
+}
+
+function isPathOrNestedPath(pathname: string, prefix: string) {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}


### PR DESCRIPTION
## Summary
- preserve sanitized callback URLs through the sign-in form and credentials action
- redirect already signed-in users from /sign-in to the callback target
- include listing authoring routes in the global auth gate so callback URLs are generated consistently

## Verification
- npm run format:check
- npm run lint
- npm run typecheck
- next build (via pre-push hook)