### PR TITLE
Tighten auth server actions

### DIFF
--- a/app/sign-in/actions.ts
+++ b/app/sign-in/actions.ts
@@ -3,6 +3,7 @@
 import { AuthError } from "next-auth";
 
 import { signIn } from "@/auth";
+import { signInSchema } from "@/lib/auth/validation";
 
 type SignInState = {
   error: string;
@@ -12,10 +13,19 @@ export async function signInWithPassword(
   _state: SignInState,
   formData: FormData,
 ): Promise<SignInState> {
+  const parsed = signInSchema.safeParse({
+    email: formData.get("email"),
+    password: formData.get("password"),
+  });
+
+  if (!parsed.success) {
+    return { error: "Invalid email or password." };
+  }
+
   try {
     await signIn("credentials", {
-      email: formData.get("email"),
-      password: formData.get("password"),
+      email: parsed.data.email,
+      password: parsed.data.password,
       redirectTo: "/",
     });
   } catch (error) {

--- a/components/auth/SessionDock.tsx
+++ b/components/auth/SessionDock.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 
-import { auth, signOut } from "@/auth";
+import { auth } from "@/auth";
 import { Button } from "@/components/ui/button";
+import { signOutFromHeader } from "@/components/site-header/actions";
 import { getOptionalSession } from "@/lib/auth/session";
 
 export async function SessionDock() {
@@ -19,13 +20,7 @@ export async function SessionDock() {
                 {session.user.name ?? session.user.email}
               </span>
             ) : null}
-            <form
-              action={async () => {
-                "use server";
-
-                await signOut({ redirectTo: "/" });
-              }}
-            >
+            <form action={signOutFromHeader}>
               <Button type="submit" variant="ghost" size="sm" className="rounded-full px-3">
                 Sign out
               </Button>


### PR DESCRIPTION
## Summary
- validate sign-in Server Action input with the existing auth Zod schema before calling NextAuth
- reuse the shared sign-out Server Action in SessionDock instead of defining an inline duplicate
- keep structured listing/admin CRUD flows on existing API routes where next-rest-framework provides the more ergonomic validation contract

## Motivation
Server Actions are a good fit for these auth-owned form submissions because they keep credential/session handling server-side without custom fetch glue. They are still public POST mutation boundaries, so sign-in now validates FormData shape server-side before delegating to NextAuth. For JSON CRUD/autosave flows, the existing API routes remain preferable because they expose explicit HTTP contracts and next-rest-framework can handle Zod validation consistently.

## Security
- invalid sign-in input receives the same generic error as invalid credentials, avoiding account or validation detail leakage
- authentication/session mutation continues to be handled by NextAuth server code
- sign-out behavior is centralized through the existing shared action, reducing duplicate auth mutation code

## Verification
- npm run lint
- npm run typecheck
- npm run build
- commit hook: gitleaks staged scan, lint-staged, typecheck
- pre-push hook: npm run build
