### PR TITLE
Refactor repeated UI styling into shared components

### DIFF
--- a/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
+++ b/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
@@ -12,7 +12,16 @@ import {
 } from "../custom-listing-fields-dashboard-forms";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogFormPanel,
+  DialogHeader,
+  DialogOverlay,
+  DialogTitle,
+} from "@/components/ui/dialog-shell";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { NativeSelect } from "@/components/ui/native-select";
 import { type BulkEditPayload } from "../custom-listing-fields-dashboard-utils";
 import { CategoryCombobox } from "./CategoryCombobox";
 
@@ -53,18 +62,15 @@ export function BulkEditDialog({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/20 px-4">
+    <DialogOverlay>
       <Form {...form}>
-        <form
-          className="w-full max-w-xl rounded-md border border-border bg-background shadow-2xl"
-          onSubmit={form.handleSubmit(handleSubmit)}
-        >
-          <div className="border-b border-border px-6 py-5">
-            <h2 className="text-xl font-semibold">Bulk Edit Fields</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
+        <DialogFormPanel className="max-w-xl" onSubmit={form.handleSubmit(handleSubmit)}>
+          <DialogHeader>
+            <DialogTitle>Bulk Edit Fields</DialogTitle>
+            <DialogDescription>
               Apply changes to {selectedCount} selected {selectedCount === 1 ? "field" : "fields"}.
-            </p>
-          </div>
+            </DialogDescription>
+          </DialogHeader>
 
           <div className="space-y-5 px-6 py-5">
             <BulkEditOption
@@ -103,15 +109,14 @@ export function BulkEditDialog({
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <select
+                      <NativeSelect
                         value={field.value}
                         onChange={field.onChange}
                         disabled={!visibilityEnabled || isSaving}
-                        className="h-7 w-full rounded-md border border-input bg-input/20 px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50 md:text-xs"
                       >
                         <option value="public">Public</option>
                         <option value="internal">Internal</option>
-                      </select>
+                      </NativeSelect>
                     </FormControl>
                     <FormMessage className="text-xs" />
                   </FormItem>
@@ -131,15 +136,14 @@ export function BulkEditDialog({
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <select
+                      <NativeSelect
                         value={field.value ? "yes" : "no"}
                         onChange={(event) => field.onChange(event.target.value === "yes")}
                         disabled={!filterableEnabled || isSaving}
-                        className="h-7 w-full rounded-md border border-input bg-input/20 px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50 md:text-xs"
                       >
                         <option value="yes">Filterable</option>
                         <option value="no">Not filterable</option>
-                      </select>
+                      </NativeSelect>
                     </FormControl>
                     <FormMessage className="text-xs" />
                   </FormItem>
@@ -159,15 +163,14 @@ export function BulkEditDialog({
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <select
+                      <NativeSelect
                         value={field.value ? "yes" : "no"}
                         onChange={(event) => field.onChange(event.target.value === "yes")}
                         disabled={!requiredEnabled || isSaving}
-                        className="h-7 w-full rounded-md border border-input bg-input/20 px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50 md:text-xs"
                       >
                         <option value="yes">Required</option>
                         <option value="no">Not required</option>
-                      </select>
+                      </NativeSelect>
                     </FormControl>
                     <FormMessage className="text-xs" />
                   </FormItem>
@@ -180,17 +183,17 @@ export function BulkEditDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-3 border-t border-border px-6 py-4">
+          <DialogFooter className="border-t border-border">
             <Button type="button" variant="outline" size="lg" onClick={onClose} disabled={isSaving}>
               Cancel
             </Button>
             <Button type="submit" size="lg" disabled={isSaving}>
               {isSaving ? "Applying..." : "Apply Bulk Edit"}
             </Button>
-          </div>
-        </form>
+          </DialogFooter>
+        </DialogFormPanel>
       </Form>
-    </div>
+    </DialogOverlay>
   );
 }
 

--- a/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
+++ b/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
@@ -1,4 +1,12 @@
 import { Button } from "@/components/ui/button";
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPanel,
+  DialogTitle,
+} from "@/components/ui/dialog-shell";
 import type { AdminCustomListingField } from "@/shared/schemas/custom-listing-fields";
 
 export function DeleteFieldDialog({
@@ -13,16 +21,16 @@ export function DeleteFieldDialog({
   onConfirm: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/20 px-4">
-      <div className="w-full max-w-md rounded-md border border-border bg-background shadow-2xl">
-        <div className="border-b border-border px-6 py-5">
-          <h2 className="text-xl font-semibold">Delete Custom Field</h2>
-          <p className="mt-2 text-sm text-muted-foreground">
+    <DialogOverlay>
+      <DialogPanel>
+        <DialogHeader>
+          <DialogTitle>Delete Custom Field</DialogTitle>
+          <DialogDescription className="mt-2">
             Delete {field.label}? Existing listing values with this key will no longer be managed by
             the custom field dashboard.
-          </p>
-        </div>
-        <div className="flex justify-end gap-3 px-6 py-4">
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
           <Button type="button" variant="outline" size="lg" onClick={onClose} disabled={isDeleting}>
             Cancel
           </Button>
@@ -35,8 +43,8 @@ export function DeleteFieldDialog({
           >
             {isDeleting ? "Deleting..." : "Delete Field"}
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogPanel>
+    </DialogOverlay>
   );
 }

--- a/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
+++ b/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
@@ -13,6 +13,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
+  DialogDescription,
+  DialogFooter,
+  DialogFormPanel,
+  DialogHeader,
+  DialogOverlay,
+  DialogTitle,
+} from "@/components/ui/dialog-shell";
+import {
   Form,
   FormControl,
   FormDescription,
@@ -22,6 +30,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { NativeSelect } from "@/components/ui/native-select";
 import { Textarea } from "@/components/ui/textarea";
 import {
   FIELD_HELP_TEXT,
@@ -76,18 +85,18 @@ export function FieldEditorDialog({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/20 px-4 py-6">
+    <DialogOverlay className="py-6">
       <Form {...form}>
-        <form
+        <DialogFormPanel
           onSubmit={form.handleSubmit(handleSubmit)}
-          className="max-h-[92vh] w-full max-w-4xl overflow-y-auto rounded-md border border-border bg-background shadow-2xl"
+          className="max-h-[92vh] max-w-4xl overflow-y-auto"
         >
-          <div className="flex items-start justify-between border-b border-border px-6 py-5">
+          <DialogHeader className="flex items-start justify-between">
             <div>
-              <h2 className="text-xl font-semibold">Add Custom Field</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <DialogTitle>Add Custom Field</DialogTitle>
+              <DialogDescription>
                 Configure how this field appears on listing forms, listing pages, and filters.
-              </p>
+              </DialogDescription>
             </div>
             <button
               type="button"
@@ -97,7 +106,7 @@ export function FieldEditorDialog({
             >
               Close
             </button>
-          </div>
+          </DialogHeader>
 
           <div className="grid gap-5 px-6 py-5 md:grid-cols-2">
             <FormField
@@ -171,15 +180,14 @@ export function FieldEditorDialog({
                     {FIELD_HELP_TEXT.visibility}
                   </FormDescription>
                   <FormControl>
-                    <select
+                    <NativeSelect
                       value={field.value ? "public" : "internal"}
                       onChange={(event) => field.onChange(event.target.value === "public")}
                       disabled={isSaving}
-                      className="h-7 w-full rounded-md border border-input bg-input/20 px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50 md:text-xs"
                     >
                       <option value="public">Public</option>
                       <option value="internal">Internal</option>
-                    </select>
+                    </NativeSelect>
                   </FormControl>
                   <FormMessage className="text-xs" />
                 </FormItem>
@@ -224,17 +232,17 @@ export function FieldEditorDialog({
             ) : null}
           </div>
 
-          <div className="flex justify-end gap-3 border-t border-border px-6 py-4">
+          <DialogFooter className="border-t border-border">
             <Button type="button" variant="outline" size="lg" onClick={onClose} disabled={isSaving}>
               Cancel
             </Button>
             <Button type="submit" size="lg" disabled={isSaving}>
               {isSaving ? "Saving..." : "Add Field"}
             </Button>
-          </div>
-        </form>
+          </DialogFooter>
+        </DialogFormPanel>
       </Form>
-    </div>
+    </DialogOverlay>
   );
 }
 

--- a/app/admin/custom-listing-fields/page.tsx
+++ b/app/admin/custom-listing-fields/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { getOptionalSession } from "@/lib/auth/session";
 import { getAdminCustomListingFieldsService } from "@/lib/custom-listing-fields/custom-listing-field-admin.service";
 import { CustomListingFieldsDashboard } from "./CustomListingFieldsDashboard";
+import { PageMessage } from "@/components/page-shell/AppPageShell";
 
 export const metadata: Metadata = {
   title: "Custom Listing Fields | WR Housing Bridge",
@@ -20,28 +21,16 @@ export default async function CustomListingFieldsPage() {
 
   if (authzUser?.role !== "admin") {
     return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/60 px-6 py-10">
-        <div className="mx-auto max-w-3xl rounded-md border border-border bg-background p-6">
-          <h1 className="text-xl font-semibold">Admin access required</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Only admin accounts can manage custom listing fields.
-          </p>
-        </div>
-      </main>
+      <PageMessage title="Admin access required">
+        Only admin accounts can manage custom listing fields.
+      </PageMessage>
     );
   }
 
   const result = await getAdminCustomListingFieldsService({});
 
   if (!result.ok) {
-    return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/60 px-6 py-10">
-        <div className="mx-auto max-w-3xl rounded-md border border-border bg-background p-6">
-          <h1 className="text-xl font-semibold">Unable to load custom fields</h1>
-          <p className="mt-2 text-sm text-muted-foreground">{result.error.message}</p>
-        </div>
-      </main>
-    );
+    return <PageMessage title="Unable to load custom fields">{result.error.message}</PageMessage>;
   }
 
   return <CustomListingFieldsDashboard initialFields={result.value.data} />;

--- a/app/admin/invite/page.tsx
+++ b/app/admin/invite/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import verbiage from "@/content/verbiage.json";
 import { buildInviteRecordFromAccountInvite } from "@/components/admin-invite/invite-records";
 import { AdminInvitePanel } from "@/components/admin-invite/AdminInvitePanel";
+import { PageMessage } from "@/components/page-shell/AppPageShell";
 import { getOptionalSession } from "@/lib/auth/session";
 import { getRecentAccountInvitesService } from "@/lib/accounts/account.service";
 
@@ -33,14 +34,13 @@ export default async function AdminInvitePage() {
 
   if (authzUser?.role !== "admin") {
     return (
-      <main className="min-h-screen bg-background px-6 py-10">
-        <div className="mx-auto max-w-3xl rounded-md border border-border bg-card p-6">
-          <h1 className="text-xl font-semibold text-foreground">Admin access required</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Only admin accounts can send and review account invites.
-          </p>
-        </div>
-      </main>
+      <PageMessage
+        title="Admin access required"
+        className="min-h-screen bg-background"
+        contentClassName="bg-card"
+      >
+        Only admin accounts can send and review account invites.
+      </PageMessage>
     );
   }
 

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,15 +1,18 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
 
+import { AppPageShell, PageMessage } from "@/components/page-shell/AppPageShell";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
 import { getOptionalSession } from "@/lib/auth/session";
 import { findPendingAccountInvites } from "@/lib/auth/invite-store";
 import { getAccountsService } from "@/lib/accounts/account.service";
+import { cn } from "@/lib/utils";
 import type { AccountListResponse } from "@/shared/schemas/account-management";
-import { AppPageShell, PageMessage } from "@/components/page-shell/AppPageShell";
 
 export const metadata: Metadata = {
   title: "Manage Users | WR Housing Bridge",
@@ -139,6 +142,85 @@ function formatStatus(status: AccountListResponse["data"][number]["status"]) {
   }
 }
 
+function AdminDataSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <Card className="gap-0 overflow-hidden py-0">
+      <CardHeader className="border-b bg-background py-4">
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      {children}
+    </Card>
+  );
+}
+
+function DesktopDataTable({ columns, children }: { columns: string[]; children: ReactNode }) {
+  return (
+    <div className="hidden overflow-x-auto lg:block">
+      <table className="min-w-full border-collapse text-left text-sm">
+        <thead className="bg-muted/60 text-muted-foreground">
+          <tr>
+            {columns.map((column) => (
+              <th key={column} className="px-4 py-3 font-medium">
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+function DesktopDataRow({ children }: { children: ReactNode }) {
+  return <tr className="border-t border-border/80 align-top">{children}</tr>;
+}
+
+function DesktopDataCell({ children, muted = false }: { children: ReactNode; muted?: boolean }) {
+  return <td className={cn("px-4 py-4", muted && "text-muted-foreground")}>{children}</td>;
+}
+
+function MobileDataList({ children }: { children: ReactNode }) {
+  return <CardContent className="grid gap-4 p-4 lg:hidden">{children}</CardContent>;
+}
+
+function MobileDataCard({ children }: { children: ReactNode }) {
+  return <div className="rounded-xl border border-border bg-background p-4">{children}</div>;
+}
+
+function MobileDataHeader({
+  title,
+  subtitle,
+  badges,
+}: {
+  title: string;
+  subtitle: string;
+  badges: ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="space-y-1">
+        <p className="font-medium text-foreground">{title}</p>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      </div>
+      <div className="flex flex-wrap gap-2">{badges}</div>
+    </div>
+  );
+}
+
+function MobileDetails({ children }: { children: ReactNode }) {
+  return <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">{children}</dl>;
+}
+
+function MobileDetail({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 text-foreground">{children}</dd>
+    </div>
+  );
+}
+
 export default async function AdminUsersPage() {
   const { session, authzUser } = await getOptionalSession();
 
@@ -176,212 +258,145 @@ export default async function AdminUsersPage() {
           </Button>
         </div>
 
-        <Card className="gap-0 overflow-hidden py-0">
-          <CardHeader className="border-b bg-background py-4">
-            <CardTitle>Pending invites</CardTitle>
-          </CardHeader>
+        <AdminDataSection title="Pending invites">
+          <DesktopDataTable
+            columns={["Invitee", "Organization", "Role", "Status", "Invited", "Expires"]}
+          >
+            {pendingInvites.length > 0 ? (
+              pendingInvites.map((invite) => (
+                <DesktopDataRow key={invite.id}>
+                  <DesktopDataCell>
+                    <div className="space-y-1">
+                      <p className="font-medium text-foreground">{invite.name}</p>
+                      <p className="text-xs text-muted-foreground">{invite.email}</p>
+                    </div>
+                  </DesktopDataCell>
+                  <DesktopDataCell muted>{invite.organization ?? "Not provided"}</DesktopDataCell>
+                  <DesktopDataCell>
+                    <Badge variant={roleBadgeVariant(invite.role)}>{formatRole(invite.role)}</Badge>
+                  </DesktopDataCell>
+                  <DesktopDataCell>
+                    <Badge variant="outline">Pending</Badge>
+                  </DesktopDataCell>
+                  <DesktopDataCell muted>
+                    {formatDateTime(invite.invitedAt.toISOString())}
+                  </DesktopDataCell>
+                  <DesktopDataCell muted>
+                    {formatDateTime(invite.expiresAt.toISOString())}
+                  </DesktopDataCell>
+                </DesktopDataRow>
+              ))
+            ) : (
+              <tr className="border-t border-border/80">
+                <td colSpan={6} className="px-4 py-8">
+                  <EmptyState className="border-0 bg-transparent py-0">
+                    No active invites found.
+                  </EmptyState>
+                </td>
+              </tr>
+            )}
+          </DesktopDataTable>
 
-          <div className="hidden overflow-x-auto lg:block">
-            <table className="min-w-full border-collapse text-left text-sm">
-              <thead className="bg-muted/60 text-muted-foreground">
-                <tr>
-                  <th className="px-4 py-3 font-medium">Invitee</th>
-                  <th className="px-4 py-3 font-medium">Organization</th>
-                  <th className="px-4 py-3 font-medium">Role</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium">Invited</th>
-                  <th className="px-4 py-3 font-medium">Expires</th>
-                </tr>
-              </thead>
-              <tbody>
-                {pendingInvites.length > 0 ? (
-                  pendingInvites.map((invite) => (
-                    <tr key={invite.id} className="border-t border-border/80 align-top">
-                      <td className="px-4 py-4">
-                        <div className="space-y-1">
-                          <p className="font-medium text-foreground">{invite.name}</p>
-                          <p className="text-xs text-muted-foreground">{invite.email}</p>
-                        </div>
-                      </td>
-                      <td className="px-4 py-4 text-muted-foreground">
-                        {invite.organization ?? "Not provided"}
-                      </td>
-                      <td className="px-4 py-4">
+          <MobileDataList>
+            {pendingInvites.length > 0 ? (
+              pendingInvites.map((invite) => (
+                <MobileDataCard key={invite.id}>
+                  <MobileDataHeader
+                    title={invite.name}
+                    subtitle={invite.email}
+                    badges={
+                      <>
                         <Badge variant={roleBadgeVariant(invite.role)}>
                           {formatRole(invite.role)}
                         </Badge>
-                      </td>
-                      <td className="px-4 py-4">
                         <Badge variant="outline">Pending</Badge>
-                      </td>
-                      <td className="px-4 py-4 text-muted-foreground">
-                        {formatDateTime(invite.invitedAt.toISOString())}
-                      </td>
-                      <td className="px-4 py-4 text-muted-foreground">
-                        {formatDateTime(invite.expiresAt.toISOString())}
-                      </td>
-                    </tr>
-                  ))
-                ) : (
-                  <tr className="border-t border-border/80">
-                    <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
-                      No active invites found.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-
-          <CardContent className="grid gap-4 p-4 lg:hidden">
-            {pendingInvites.length > 0 ? (
-              pendingInvites.map((invite) => (
-                <div key={invite.id} className="rounded-xl border border-border bg-background p-4">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <p className="font-medium text-foreground">{invite.name}</p>
-                      <p className="text-sm text-muted-foreground">{invite.email}</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <Badge variant={roleBadgeVariant(invite.role)}>
-                        {formatRole(invite.role)}
-                      </Badge>
-                      <Badge variant="outline">Pending</Badge>
-                    </div>
-                  </div>
-
-                  <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
-                    <div>
-                      <dt className="text-muted-foreground">Organization</dt>
-                      <dd className="mt-1 text-foreground">
-                        {invite.organization ?? "Not provided"}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-muted-foreground">Invited</dt>
-                      <dd className="mt-1 text-foreground">
-                        {formatDateTime(invite.invitedAt.toISOString())}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-muted-foreground">Expires</dt>
-                      <dd className="mt-1 text-foreground">
-                        {formatDateTime(invite.expiresAt.toISOString())}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
+                      </>
+                    }
+                  />
+                  <MobileDetails>
+                    <MobileDetail label="Organization">
+                      {invite.organization ?? "Not provided"}
+                    </MobileDetail>
+                    <MobileDetail label="Invited">
+                      {formatDateTime(invite.invitedAt.toISOString())}
+                    </MobileDetail>
+                    <MobileDetail label="Expires">
+                      {formatDateTime(invite.expiresAt.toISOString())}
+                    </MobileDetail>
+                  </MobileDetails>
+                </MobileDataCard>
               ))
             ) : (
-              <div className="rounded-xl border border-dashed border-border bg-background px-4 py-8 text-center text-sm text-muted-foreground">
-                No active invites found.
-              </div>
+              <EmptyState>No active invites found.</EmptyState>
             )}
-          </CardContent>
-        </Card>
+          </MobileDataList>
+        </AdminDataSection>
 
-        <Card className="gap-0 overflow-hidden py-0">
-          <CardHeader className="border-b bg-background py-4">
-            <CardTitle>User directory</CardTitle>
-          </CardHeader>
-
-          <div className="hidden overflow-x-auto lg:block">
-            <table className="min-w-full border-collapse text-left text-sm">
-              <thead className="bg-muted/60 text-muted-foreground">
-                <tr>
-                  <th className="px-4 py-3 font-medium">User</th>
-                  <th className="px-4 py-3 font-medium">Organization</th>
-                  <th className="px-4 py-3 font-medium">Role</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium">Created</th>
-                  <th className="px-4 py-3 font-medium">Last login</th>
-                </tr>
-              </thead>
-              <tbody>
-                {accounts.map((account) => (
-                  <tr key={account.id} className="border-t border-border/80 align-top">
-                    <td className="px-4 py-4">
-                      <div className="space-y-1">
-                        <p className="font-medium text-foreground">
-                          {account.name ?? account.email ?? "Unnamed user"}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {account.email ?? "No email"}
-                        </p>
-                      </div>
-                    </td>
-                    <td className="px-4 py-4 text-muted-foreground">
-                      {account.organization ?? "Not provided"}
-                    </td>
-                    <td className="px-4 py-4">
-                      <Badge variant={roleBadgeVariant(account.role)}>
-                        {formatRole(account.role)}
-                      </Badge>
-                    </td>
-                    <td className="px-4 py-4">
-                      <Badge variant={statusBadgeVariant(account.status)}>
-                        {formatStatus(account.status)}
-                      </Badge>
-                    </td>
-                    <td className="px-4 py-4 text-muted-foreground">
-                      <div className="space-y-1">
-                        <p>{formatDateTime(account.createdAt)}</p>
-                        <p className="text-xs">Updated {formatDateTime(account.updatedAt)}</p>
-                      </div>
-                    </td>
-                    <td className="px-4 py-4 text-muted-foreground">
-                      {formatDateTime(account.lastLoginAt)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <CardContent className="grid gap-4 p-4 lg:hidden">
+        <AdminDataSection title="User directory">
+          <DesktopDataTable
+            columns={["User", "Organization", "Role", "Status", "Created", "Last login"]}
+          >
             {accounts.map((account) => (
-              <div key={account.id} className="rounded-xl border border-border bg-background p-4">
-                <div className="flex flex-wrap items-start justify-between gap-3">
+              <DesktopDataRow key={account.id}>
+                <DesktopDataCell>
                   <div className="space-y-1">
                     <p className="font-medium text-foreground">
                       {account.name ?? account.email ?? "Unnamed user"}
                     </p>
-                    <p className="text-sm text-muted-foreground">{account.email ?? "No email"}</p>
+                    <p className="text-xs text-muted-foreground">{account.email ?? "No email"}</p>
                   </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Badge variant={roleBadgeVariant(account.role)}>
-                      {formatRole(account.role)}
-                    </Badge>
-                    <Badge variant={statusBadgeVariant(account.status)}>
-                      {formatStatus(account.status)}
-                    </Badge>
+                </DesktopDataCell>
+                <DesktopDataCell muted>{account.organization ?? "Not provided"}</DesktopDataCell>
+                <DesktopDataCell>
+                  <Badge variant={roleBadgeVariant(account.role)}>{formatRole(account.role)}</Badge>
+                </DesktopDataCell>
+                <DesktopDataCell>
+                  <Badge variant={statusBadgeVariant(account.status)}>
+                    {formatStatus(account.status)}
+                  </Badge>
+                </DesktopDataCell>
+                <DesktopDataCell muted>
+                  <div className="space-y-1">
+                    <p>{formatDateTime(account.createdAt)}</p>
+                    <p className="text-xs">Updated {formatDateTime(account.updatedAt)}</p>
                   </div>
-                </div>
-
-                <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
-                  <div>
-                    <dt className="text-muted-foreground">Organization</dt>
-                    <dd className="mt-1 text-foreground">
-                      {account.organization ?? "Not provided"}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-muted-foreground">Created</dt>
-                    <dd className="mt-1 text-foreground">{formatDateTime(account.createdAt)}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-muted-foreground">Updated</dt>
-                    <dd className="mt-1 text-foreground">{formatDateTime(account.updatedAt)}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-muted-foreground">Last login</dt>
-                    <dd className="mt-1 text-foreground">{formatDateTime(account.lastLoginAt)}</dd>
-                  </div>
-                </dl>
-              </div>
+                </DesktopDataCell>
+                <DesktopDataCell muted>{formatDateTime(account.lastLoginAt)}</DesktopDataCell>
+              </DesktopDataRow>
             ))}
-          </CardContent>
-        </Card>
+          </DesktopDataTable>
+
+          <MobileDataList>
+            {accounts.map((account) => (
+              <MobileDataCard key={account.id}>
+                <MobileDataHeader
+                  title={account.name ?? account.email ?? "Unnamed user"}
+                  subtitle={account.email ?? "No email"}
+                  badges={
+                    <>
+                      <Badge variant={roleBadgeVariant(account.role)}>
+                        {formatRole(account.role)}
+                      </Badge>
+                      <Badge variant={statusBadgeVariant(account.status)}>
+                        {formatStatus(account.status)}
+                      </Badge>
+                    </>
+                  }
+                />
+                <MobileDetails>
+                  <MobileDetail label="Organization">
+                    {account.organization ?? "Not provided"}
+                  </MobileDetail>
+                  <MobileDetail label="Created">{formatDateTime(account.createdAt)}</MobileDetail>
+                  <MobileDetail label="Updated">{formatDateTime(account.updatedAt)}</MobileDetail>
+                  <MobileDetail label="Last login">
+                    {formatDateTime(account.lastLoginAt)}
+                  </MobileDetail>
+                </MobileDetails>
+              </MobileDataCard>
+            ))}
+          </MobileDataList>
+        </AdminDataSection>
       </div>
     </AppPageShell>
   );

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -9,6 +9,7 @@ import { getOptionalSession } from "@/lib/auth/session";
 import { findPendingAccountInvites } from "@/lib/auth/invite-store";
 import { getAccountsService } from "@/lib/accounts/account.service";
 import type { AccountListResponse } from "@/shared/schemas/account-management";
+import { AppPageShell, PageMessage } from "@/components/page-shell/AppPageShell";
 
 export const metadata: Metadata = {
   title: "Manage Users | WR Housing Bridge",
@@ -147,14 +148,7 @@ export default async function AdminUsersPage() {
 
   if (authzUser?.role !== "admin") {
     return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/60 px-6 py-10">
-        <div className="mx-auto max-w-3xl rounded-md border border-border bg-background p-6">
-          <h1 className="text-xl font-semibold">Admin access required</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Only admin accounts can manage users.
-          </p>
-        </div>
-      </main>
+      <PageMessage title="Admin access required">Only admin accounts can manage users.</PageMessage>
     );
   }
 
@@ -162,20 +156,13 @@ export default async function AdminUsersPage() {
   const pendingInvites = await findPendingAccountInvites();
 
   if (!result.ok) {
-    return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/60 px-6 py-10">
-        <div className="mx-auto max-w-3xl rounded-md border border-border bg-background p-6">
-          <h1 className="text-xl font-semibold">Unable to load users</h1>
-          <p className="mt-2 text-sm text-muted-foreground">{result.error.message}</p>
-        </div>
-      </main>
-    );
+    return <PageMessage title="Unable to load users">{result.error.message}</PageMessage>;
   }
 
   const accounts = result.value.data;
 
   return (
-    <main className="min-h-[calc(100vh-7rem)] bg-muted/40 px-4 py-8 sm:px-6">
+    <AppPageShell>
       <div className="mx-auto max-w-7xl space-y-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-2">
@@ -396,6 +383,6 @@ export default async function AdminUsersPage() {
           </CardContent>
         </Card>
       </div>
-    </main>
+    </AppPageShell>
   );
 }

--- a/app/invite/page.tsx
+++ b/app/invite/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 
+import { AuthCard } from "@/components/auth/AuthCard";
+import { AuthPageShell } from "@/components/auth/AuthPageShell";
 import { AcceptInviteForm } from "@/components/auth/AcceptInviteForm";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getPendingInviteByToken } from "@/lib/auth/invite-store";
 
 type InvitePageProps = {
@@ -25,28 +26,25 @@ export default async function InvitePage({ searchParams }: InvitePageProps) {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top,_var(--color-muted)_0%,_transparent_45%),linear-gradient(180deg,_var(--color-background)_0%,_color-mix(in_oklab,var(--color-background),black_4%)_100%)] px-6 py-20">
+    <AuthPageShell>
       <AcceptInviteForm token={token} email={invite.user.email} />
-    </main>
+    </AuthPageShell>
   );
 }
 
 function InvalidInviteState() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background px-6 py-20">
-      <Card className="w-full max-w-md border border-border/80 shadow-xl shadow-black/5">
-        <CardHeader className="border-b border-border/60">
-          <CardTitle>Invite unavailable</CardTitle>
-          <CardDescription>
-            This invite link is missing, expired, or has already been used.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="pt-4">
+    <AuthPageShell variant="default">
+      <AuthCard
+        title="Invite unavailable"
+        description="This invite link is missing, expired, or has already been used."
+      >
+        <div className="pt-0">
           <Button asChild size="sm" className="rounded-full px-4">
             <Link href="/sign-in">Go to sign in</Link>
           </Button>
-        </CardContent>
-      </Card>
-    </main>
+        </div>
+      </AuthCard>
+    </AuthPageShell>
   );
 }

--- a/app/listing-form/ListingForm.tsx
+++ b/app/listing-form/ListingForm.tsx
@@ -11,6 +11,7 @@ import {
   type ListingFormPreviewMode,
 } from "@/components/listing-form-preview/ListingFormPreview";
 import { ListingFormSkeleton } from "@/components/listing-form-skeleton/ListingFormSkeleton";
+import { AlertBanner } from "@/components/ui/alert-banner";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 
@@ -74,14 +75,14 @@ export default function ListingForm({ listingId }: ListingFormProps) {
     return (
       <ListingFormLayout
         formContent={
-          <div className="bg-destructive/15 text-destructive p-8 rounded-lg border border-destructive/20">
+          <AlertBanner variant="error" size="lg">
             <h3 className="mb-2">Error Loading Listing</h3>
             <p>
               {isEditMode
                 ? "We encountered an error while retrieving this listing. It may have been deleted or there is a network issue."
                 : "We encountered an error while preparing this form. Please refresh and try again."}
             </p>
-          </div>
+          </AlertBanner>
         }
       />
     );

--- a/app/listing-form/[id]/page.tsx
+++ b/app/listing-form/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 
 import ListingForm from "../ListingForm";
 import { ListingFormSkeleton } from "@/components/listing-form-skeleton/ListingFormSkeleton";
+import { PageMessage } from "@/components/page-shell/AppPageShell";
 import { getOptionalSession } from "@/lib/auth/session";
 
 export const metadata: Metadata = {
@@ -21,14 +22,9 @@ export default async function EditListingFormPage({ params }: { params: Promise<
 
   if (authzUser?.role !== "admin" && authzUser?.role !== "partner") {
     return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/60 px-6 py-10">
-        <div className="mx-auto max-w-3xl rounded-md border border-border bg-background p-6">
-          <h1 className="text-xl font-semibold">Listing author access required</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Only partner and admin accounts can manage listing drafts.
-          </p>
-        </div>
-      </main>
+      <PageMessage title="Listing author access required">
+        Only partner and admin accounts can manage listing drafts.
+      </PageMessage>
     );
   }
 

--- a/app/listing-form/page.tsx
+++ b/app/listing-form/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 
 import ListingForm from "./ListingForm";
 import { ListingFormSkeleton } from "@/components/listing-form-skeleton/ListingFormSkeleton";
+import { PageMessage } from "@/components/page-shell/AppPageShell";
 import { getOptionalSession } from "@/lib/auth/session";
 
 export const metadata: Metadata = {
@@ -21,14 +22,9 @@ export default async function ListingFormPage() {
 
   if (authzUser?.role !== "admin" && authzUser?.role !== "partner") {
     return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/60 px-6 py-10">
-        <div className="mx-auto max-w-3xl rounded-md border border-border bg-background p-6">
-          <h1 className="text-xl font-semibold">Listing author access required</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Only partner and admin accounts can create new listings.
-          </p>
-        </div>
-      </main>
+      <PageMessage title="Listing author access required">
+        Only partner and admin accounts can create new listings.
+      </PageMessage>
     );
   }
 

--- a/app/listings/listings.tsx
+++ b/app/listings/listings.tsx
@@ -13,6 +13,7 @@ import { ListingsPanel } from "@/components/listings-panel/ListingsPanel";
 import type { ListingListResponse, ListingQuery, ListingSummary } from "@/shared/schemas/listings";
 import dynamic from "next/dynamic";
 import { useListingsQuery } from "./useListingsQuery";
+import { AlertBanner } from "@/components/ui/alert-banner";
 
 const LazyMapView = dynamic<{ listings: ListingSummary[] }>(
   () => import("../../components/map-view/MapView.tsx").then((mod) => mod.MapView),
@@ -126,9 +127,9 @@ export default function ListingsDashboard({
         <FilterButton {...filterButtonProps} viewport="desktop" />
       </header>
       {error ? (
-        <div className="border-b border-destructive/20 bg-destructive/5 px-4 py-2 text-sm text-destructive">
+        <AlertBanner variant="error" size="flush" className="border-b">
           {error}
-        </div>
+        </AlertBanner>
       ) : null}
       <main className="flex min-h-0 flex-1 flex-col overflow-x-hidden lg:flex-row">
         {displayMode !== DisplayMode.MAP ? (

--- a/app/my-listings/MyListingsClient.tsx
+++ b/app/my-listings/MyListingsClient.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertBanner } from "@/components/ui/alert-banner";
+import { EmptyState } from "@/components/ui/empty-state";
 
 type MyListingItem = {
   id: string;
@@ -148,8 +149,10 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
   if (listings.length === 0) {
     return (
       <Card>
-        <CardContent className="py-10 text-sm text-muted-foreground">
-          No listings yet. Start a draft to begin publishing inventory.
+        <CardContent>
+          <EmptyState size="spacious" className="border-0">
+            No listings yet. Start a draft to begin publishing inventory.
+          </EmptyState>
         </CardContent>
       </Card>
     );

--- a/app/my-listings/MyListingsClient.tsx
+++ b/app/my-listings/MyListingsClient.tsx
@@ -8,6 +8,7 @@ import { formatDistance } from "date-fns";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AlertBanner } from "@/components/ui/alert-banner";
 
 type MyListingItem = {
   id: string;
@@ -157,9 +158,9 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
   return (
     <div className="space-y-4">
       {mutationError ? (
-        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+        <AlertBanner variant="error" size="default" className="rounded-lg">
           {mutationError}
-        </div>
+        </AlertBanner>
       ) : null}
 
       <div className="grid gap-4">

--- a/app/my-listings/page.tsx
+++ b/app/my-listings/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { AppPageShell, PageMessage } from "@/components/page-shell/AppPageShell";
 import { getOptionalSession } from "@/lib/auth/session";
 import { getMyListingsService } from "@/lib/listings/listing.service";
 import { MyListingsClient } from "./MyListingsClient";
@@ -16,25 +17,29 @@ export default async function MyListingsPage() {
 
   if (!session?.user) {
     return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/40 px-4 py-8 sm:px-6">
-        <div className="mx-auto max-w-5xl rounded-xl border bg-background p-6">
-          <h1 className="text-2xl font-semibold">My Listings</h1>
-          <p className="mt-2 text-sm text-muted-foreground">Sign in to manage your listings.</p>
-        </div>
-      </main>
+      <PageMessage
+        title="My Listings"
+        width="5xl"
+        className="bg-muted/40 px-4 py-8 sm:px-6"
+        contentClassName="rounded-xl"
+        titleClassName="text-2xl"
+      >
+        Sign in to manage your listings.
+      </PageMessage>
     );
   }
 
   if (authzUser?.role !== "admin" && authzUser?.role !== "partner") {
     return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/40 px-4 py-8 sm:px-6">
-        <div className="mx-auto max-w-5xl rounded-xl border bg-background p-6">
-          <h1 className="text-2xl font-semibold">My Listings</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Only partner and admin accounts can manage listings.
-          </p>
-        </div>
-      </main>
+      <PageMessage
+        title="My Listings"
+        width="5xl"
+        className="bg-muted/40 px-4 py-8 sm:px-6"
+        contentClassName="rounded-xl"
+        titleClassName="text-2xl"
+      >
+        Only partner and admin accounts can manage listings.
+      </PageMessage>
     );
   }
 
@@ -42,17 +47,21 @@ export default async function MyListingsPage() {
 
   if (!result.ok) {
     return (
-      <main className="min-h-[calc(100vh-7rem)] bg-muted/40 px-4 py-8 sm:px-6">
-        <div className="mx-auto max-w-5xl rounded-xl border bg-background p-6">
-          <h1 className="text-2xl font-semibold">My Listings</h1>
-          <p className="mt-2 text-sm text-destructive">{result.error.message}</p>
-        </div>
-      </main>
+      <PageMessage
+        title="My Listings"
+        width="5xl"
+        tone="error"
+        className="bg-muted/40 px-4 py-8 sm:px-6"
+        contentClassName="rounded-xl"
+        titleClassName="text-2xl"
+      >
+        {result.error.message}
+      </PageMessage>
     );
   }
 
   return (
-    <main className="min-h-[calc(100vh-7rem)] bg-muted/40 px-4 py-8 sm:px-6">
+    <AppPageShell>
       <div className="mx-auto max-w-5xl space-y-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -68,6 +77,6 @@ export default async function MyListingsPage() {
 
         <MyListingsClient initialListings={result.value.data} renderedAt={renderedAt} />
       </div>
-    </main>
+    </AppPageShell>
   );
 }

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 
+import { AuthPageShell } from "@/components/auth/AuthPageShell";
 import { SignInForm } from "@/components/auth/SignInForm";
 import { getSafeCallbackPath } from "@/lib/auth/callback-url";
 import { getOptionalSession } from "@/lib/auth/session";
@@ -22,8 +23,8 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top,_var(--color-muted)_0%,_transparent_45%),linear-gradient(180deg,_var(--color-background)_0%,_color-mix(in_oklab,var(--color-background),black_4%)_100%)] px-6 py-20">
+    <AuthPageShell>
       <SignInForm callbackUrl={callbackPath} />
-    </main>
+    </AuthPageShell>
   );
 }

--- a/components/admin-invite/InviteResultBanner.tsx
+++ b/components/admin-invite/InviteResultBanner.tsx
@@ -1,4 +1,5 @@
 import type { InviteActionResult } from "@/components/admin-invite/types";
+import { AlertBanner } from "@/components/ui/alert-banner";
 
 type InviteResultBannerProps = {
   result: InviteActionResult | null;
@@ -12,16 +13,8 @@ export function InviteResultBanner({ result }: InviteResultBannerProps) {
   const isSuccess = result.status === "sent";
 
   return (
-    <div
-      role={isSuccess ? "status" : "alert"}
-      className={[
-        "rounded-md border px-3 py-2 text-sm",
-        isSuccess
-          ? "border-primary/20 bg-primary/5 text-foreground"
-          : "border-destructive/40 bg-destructive/10 text-destructive",
-      ].join(" ")}
-    >
+    <AlertBanner variant={isSuccess ? "success" : "error"} size="sm">
       {result.message}
-    </div>
+    </AlertBanner>
   );
 }

--- a/components/admin-invite/RecentInvitesList.tsx
+++ b/components/admin-invite/RecentInvitesList.tsx
@@ -1,5 +1,6 @@
 import verbiage from "@/content/verbiage.json";
 import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
 import type { InviteRecord } from "@/components/admin-invite/types";
 import { inviteRoleLabels } from "@/components/admin-invite/types";
 
@@ -23,9 +24,7 @@ export function RecentInvitesList({ invites }: RecentInvitesListProps) {
       </header>
 
       {invites.length === 0 ? (
-        <p className="rounded-md border border-dashed px-3 py-4 text-xs text-muted-foreground">
-          {copy.emptyState}
-        </p>
+        <EmptyState size="sm">{copy.emptyState}</EmptyState>
       ) : (
         <ul className="space-y-2">
           {invites.map((invite) => (

--- a/components/auth/AcceptInviteForm.tsx
+++ b/components/auth/AcceptInviteForm.tsx
@@ -3,15 +3,8 @@
 import { useActionState } from "react";
 
 import { acceptInviteAction } from "@/app/invite/actions";
+import { AuthCard } from "@/components/auth/AuthCard";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
 type InviteState = {
@@ -28,46 +21,43 @@ export function AcceptInviteForm({ token, email }: Readonly<{ token: string; ema
   return (
     <form action={action}>
       <input type="hidden" name="token" value={token} />
-      <Card className="w-full max-w-md border border-border/80 shadow-xl shadow-black/5">
-        <CardHeader className="border-b border-border/60">
-          <CardTitle>Create your password</CardTitle>
-          <CardDescription>{email}</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 pt-4">
-          <div className="space-y-1.5">
-            <label htmlFor="password" className="text-xs font-medium text-foreground">
-              Password
-            </label>
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              autoComplete="new-password"
-              required
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <label htmlFor="confirmPassword" className="text-xs font-medium text-foreground">
-              Confirm password
-            </label>
-            <Input
-              id="confirmPassword"
-              name="confirmPassword"
-              type="password"
-              autoComplete="new-password"
-              required
-            />
-          </div>
-
-          {state.error ? <p className="text-xs text-destructive">{state.error}</p> : null}
-        </CardContent>
-        <CardFooter className="border-t border-border/60 pt-4">
+      <AuthCard
+        title="Create your password"
+        description={email}
+        footer={
           <Button type="submit" size="sm" className="rounded-full px-4" disabled={pending}>
             {pending ? "Saving..." : "Set password"}
           </Button>
-        </CardFooter>
-      </Card>
+        }
+      >
+        <div className="space-y-1.5">
+          <label htmlFor="password" className="text-xs font-medium text-foreground">
+            Password
+          </label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="confirmPassword" className="text-xs font-medium text-foreground">
+            Confirm password
+          </label>
+          <Input
+            id="confirmPassword"
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        {state.error ? <p className="text-xs text-destructive">{state.error}</p> : null}
+      </AuthCard>
     </form>
   );
 }

--- a/components/auth/AuthCard.tsx
+++ b/components/auth/AuthCard.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type AuthCardProps = {
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+};
+
+export function AuthCard({ title, description, children, footer, className }: AuthCardProps) {
+  return (
+    <Card
+      className={cn("w-full max-w-md border border-border/80 shadow-xl shadow-black/5", className)}
+    >
+      <CardHeader className="border-b border-border/60">
+        <CardTitle>{title}</CardTitle>
+        {description ? <CardDescription>{description}</CardDescription> : null}
+      </CardHeader>
+      <CardContent className="space-y-4 pt-4">{children}</CardContent>
+      {footer ? <CardFooter className="border-t border-border/60 pt-4">{footer}</CardFooter> : null}
+    </Card>
+  );
+}

--- a/components/auth/AuthPageShell.tsx
+++ b/components/auth/AuthPageShell.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type AuthPageShellProps = {
+  children: ReactNode;
+  className?: string;
+  variant?: "default" | "gradient";
+};
+
+export function AuthPageShell({ children, className, variant = "gradient" }: AuthPageShellProps) {
+  return (
+    <main
+      className={cn(
+        "flex min-h-screen items-center justify-center px-6 py-20",
+        variant === "gradient"
+          ? "bg-[radial-gradient(circle_at_top,_var(--color-muted)_0%,_transparent_45%),linear-gradient(180deg,_var(--color-background)_0%,_color-mix(in_oklab,var(--color-background),black_4%)_100%)]"
+          : "bg-background",
+        className,
+      )}
+    >
+      {children}
+    </main>
+  );
+}

--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -3,15 +3,8 @@
 import { useActionState } from "react";
 
 import { signInWithPassword } from "@/app/sign-in/actions";
+import { AuthCard } from "@/components/auth/AuthCard";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
 const initialState = {
@@ -28,40 +21,37 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
   return (
     <form action={action}>
       <input type="hidden" name="callbackUrl" value={callbackUrl} />
-      <Card className="w-full max-w-md border border-border/80 shadow-xl shadow-black/5">
-        <CardHeader className="border-b border-border/60">
-          <CardTitle>Sign in</CardTitle>
-          <CardDescription>Use the email address that was invited to the portal.</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 pt-4">
-          <div className="space-y-1.5">
-            <label htmlFor="email" className="text-xs font-medium text-foreground">
-              Email
-            </label>
-            <Input id="email" name="email" type="email" autoComplete="email" required />
-          </div>
-
-          <div className="space-y-1.5">
-            <label htmlFor="password" className="text-xs font-medium text-foreground">
-              Password
-            </label>
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              autoComplete="current-password"
-              required
-            />
-          </div>
-
-          {state.error ? <p className="text-xs text-destructive">{state.error}</p> : null}
-        </CardContent>
-        <CardFooter className="border-t border-border/60 pt-4">
+      <AuthCard
+        title="Sign in"
+        description="Use the email address that was invited to the portal."
+        footer={
           <Button type="submit" size="sm" className="rounded-full px-4" disabled={pending}>
             {pending ? "Signing in..." : "Sign in"}
           </Button>
-        </CardFooter>
-      </Card>
+        }
+      >
+        <div className="space-y-1.5">
+          <label htmlFor="email" className="text-xs font-medium text-foreground">
+            Email
+          </label>
+          <Input id="email" name="email" type="email" autoComplete="email" required />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="password" className="text-xs font-medium text-foreground">
+            Password
+          </label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+          />
+        </div>
+
+        {state.error ? <p className="text-xs text-destructive">{state.error}</p> : null}
+      </AuthCard>
     </form>
   );
 }

--- a/components/listing-form-layout/ListingFormLayout.tsx
+++ b/components/listing-form-layout/ListingFormLayout.tsx
@@ -29,6 +29,53 @@ export interface ListingFormLayoutProps {
   isPreviewExpanded?: boolean;
 }
 
+function PaneHeader({ children }: { children: ReactNode }) {
+  return <div className="border-b border-foreground/10 px-4 py-3 md:px-6">{children}</div>;
+}
+
+function PaneFooter({ children }: { children: ReactNode }) {
+  return (
+    <div className="mt-10 flex justify-end gap-4 border-t border-foreground/10 pt-8">
+      {children}
+    </div>
+  );
+}
+
+function PaneBody({
+  children,
+  footer,
+  isSticky = false,
+}: {
+  children: ReactNode;
+  footer?: ReactNode;
+  isSticky?: boolean;
+}) {
+  return (
+    <div className={cn("px-4 py-5 md:px-6 md:py-6", isSticky && "lg:sticky lg:top-0")}>
+      {children}
+      {footer ? <PaneFooter>{footer}</PaneFooter> : null}
+    </div>
+  );
+}
+
+function StickyPaneScroll({ children, footer }: { children: ReactNode; footer?: ReactNode }) {
+  return (
+    <ScrollArea type="always" className="lg:sticky lg:top-0 lg:h-[calc(100vh-10rem)]">
+      <PaneBody footer={footer}>{children}</PaneBody>
+    </ScrollArea>
+  );
+}
+
+function PreviewDivider({ dividerControl }: { dividerControl?: ReactNode }) {
+  return (
+    <div className="order-1 hidden bg-background lg:order-2 lg:flex lg:border-x lg:border-foreground/10">
+      <div className="sticky top-0 flex h-full min-h-[calc(100vh-10rem)] w-full items-stretch justify-center">
+        {dividerControl ?? <div className="h-full w-full" />}
+      </div>
+    </div>
+  );
+}
+
 export function ListingFormLayout({
   formPaneHeader,
   previewPaneHeader,
@@ -51,51 +98,23 @@ export function ListingFormLayout({
         )}
       >
         <section className={cn("order-2 min-w-0 bg-muted/60 lg:order-1")}>
-          {formPaneHeader && (
-            <div className="border-b border-foreground/10 px-4 py-3 md:px-6">{formPaneHeader}</div>
-          )}
+          {formPaneHeader && <PaneHeader>{formPaneHeader}</PaneHeader>}
           {isExpandedWithPreview ? (
-            <ScrollArea type="always" className="lg:sticky lg:top-0 lg:h-[calc(100vh-10rem)]">
-              <div className="px-4 py-5 md:px-6 md:py-6">
-                {formContent}
-                {footer && (
-                  <div className="mt-10 flex justify-end gap-4 border-t border-foreground/10 pt-8">
-                    {footer}
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
+            <StickyPaneScroll footer={footer}>{formContent}</StickyPaneScroll>
           ) : (
-            <div className="px-4 py-5 md:px-6 md:py-6">
-              {formContent}
-              {footer && (
-                <div className="mt-10 flex justify-end gap-4 border-t border-foreground/10 pt-8">
-                  {footer}
-                </div>
-              )}
-            </div>
+            <PaneBody footer={footer}>{formContent}</PaneBody>
           )}
         </section>
 
         {previewContent && (
           <>
-            <div className="order-1 hidden bg-background lg:order-2 lg:flex lg:border-x lg:border-foreground/10">
-              <div className="sticky top-0 flex h-full min-h-[calc(100vh-10rem)] w-full items-stretch justify-center">
-                {dividerControl ?? <div className="h-full w-full" />}
-              </div>
-            </div>
+            <PreviewDivider dividerControl={dividerControl} />
             <section className="order-1 min-w-0 lg:order-3">
-              {previewPaneHeader && (
-                <div className="border-b border-foreground/10 px-4 py-3 md:px-6">
-                  {previewPaneHeader}
-                </div>
-              )}
+              {previewPaneHeader && <PaneHeader>{previewPaneHeader}</PaneHeader>}
               {isExpandedWithPreview ? (
-                <ScrollArea type="always" className="lg:sticky lg:top-0 lg:h-[calc(100vh-10rem)]">
-                  <div className="px-4 py-5 md:px-6 md:py-6">{previewContent}</div>
-                </ScrollArea>
+                <StickyPaneScroll>{previewContent}</StickyPaneScroll>
               ) : (
-                <div className="px-4 py-5 md:px-6 md:py-6 lg:sticky lg:top-0">{previewContent}</div>
+                <PaneBody isSticky>{previewContent}</PaneBody>
               )}
             </section>
           </>

--- a/components/listings-card/ListingsCard.tsx
+++ b/components/listings-card/ListingsCard.tsx
@@ -53,6 +53,17 @@ function isProtectedUploadedImageUrl(imageUrl: string) {
   return imageUrl.startsWith("/api/image-uploads/");
 }
 
+function FeatureBadge({ children }: { children: string }) {
+  return (
+    <Badge
+      variant="secondary"
+      className="border-transparent bg-secondary/60 px-1.5 py-0 text-[10px] font-normal"
+    >
+      {children}
+    </Badge>
+  );
+}
+
 export function ListingsCard({
   id,
   title,
@@ -143,13 +154,7 @@ export function ListingsCard({
           >
             <div className="flex flex-wrap gap-1.5 items-center">
               {baseFeatures.map((f, idx) => (
-                <Badge
-                  variant="secondary"
-                  key={`${f}-${idx}`}
-                  className="font-normal text-[10px] px-1.5 py-0 border-transparent bg-secondary/60"
-                >
-                  {f}
-                </Badge>
+                <FeatureBadge key={`${f}-${idx}`}>{f}</FeatureBadge>
               ))}
 
               {hasMoreFeatures && (
@@ -160,13 +165,7 @@ export function ListingsCard({
                   </summary>
                   <div className="mt-1.5 flex flex-wrap gap-1.5">
                     {extraFeatures.map((f, idx) => (
-                      <Badge
-                        variant="secondary"
-                        key={`${f}-${MAX_FEATURES + idx}`}
-                        className="font-normal text-[10px] px-1.5 py-0 border-transparent bg-secondary/60"
-                      >
-                        {f}
-                      </Badge>
+                      <FeatureBadge key={`${f}-${MAX_FEATURES + idx}`}>{f}</FeatureBadge>
                     ))}
                   </div>
                 </details>

--- a/components/page-shell/AppPageShell.tsx
+++ b/components/page-shell/AppPageShell.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type AppPageShellProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function AppPageShell({ children, className }: AppPageShellProps) {
+  return (
+    <main className={cn("min-h-[calc(100vh-7rem)] bg-muted/40 px-4 py-8 sm:px-6", className)}>
+      {children}
+    </main>
+  );
+}
+
+type PageMessageProps = {
+  title: string;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  titleClassName?: string;
+  tone?: "default" | "error";
+  width?: "3xl" | "5xl";
+};
+
+export function PageMessage({
+  title,
+  children,
+  className,
+  contentClassName,
+  titleClassName,
+  tone = "default",
+  width = "3xl",
+}: PageMessageProps) {
+  return (
+    <AppPageShell className={cn("bg-muted/60 px-6 py-10", className)}>
+      <div
+        className={cn(
+          "mx-auto rounded-md border border-border bg-background p-6",
+          width === "3xl" ? "max-w-3xl" : "max-w-5xl",
+          contentClassName,
+        )}
+      >
+        <h1 className={cn("text-xl font-semibold", titleClassName)}>{title}</h1>
+        <p
+          className={cn(
+            "mt-2 text-sm",
+            tone === "error" ? "text-destructive" : "text-muted-foreground",
+          )}
+        >
+          {children}
+        </p>
+      </div>
+    </AppPageShell>
+  );
+}

--- a/components/ui/alert-banner.tsx
+++ b/components/ui/alert-banner.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertBannerVariants = cva("rounded-md border text-sm", {
+  variants: {
+    variant: {
+      error: "border-destructive/20 bg-destructive/5 text-destructive",
+      success: "border-primary/20 bg-primary/5 text-foreground",
+      info: "border-border bg-muted/60 text-muted-foreground",
+    },
+    size: {
+      default: "px-4 py-3",
+      sm: "px-3 py-2",
+      flush: "rounded-none border-x-0 px-4 py-2",
+      lg: "rounded-lg p-8",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+    size: "default",
+  },
+});
+
+function AlertBanner({
+  className,
+  variant,
+  size,
+  role,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertBannerVariants>) {
+  return (
+    <div
+      role={role ?? (variant === "error" ? "alert" : "status")}
+      className={cn(alertBannerVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { AlertBanner, alertBannerVariants };

--- a/components/ui/dialog-shell.tsx
+++ b/components/ui/dialog-shell.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 z-50 flex items-center justify-center bg-foreground/20 px-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogPanel({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "w-full max-w-md rounded-md border border-border bg-background shadow-2xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogFormPanel({ className, ...props }: React.ComponentProps<"form">) {
+  return (
+    <form
+      className={cn(
+        "w-full max-w-md rounded-md border border-border bg-background shadow-2xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("border-b border-border px-6 py-5", className)} {...props} />;
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return <h2 className={cn("text-xl font-semibold", className)} {...props} />;
+}
+
+function DialogDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return <p className={cn("mt-1 text-sm text-muted-foreground", className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex justify-end gap-3 px-6 py-4", className)} {...props} />;
+}
+
+export {
+  DialogDescription,
+  DialogFooter,
+  DialogFormPanel,
+  DialogHeader,
+  DialogOverlay,
+  DialogPanel,
+  DialogTitle,
+};

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const emptyStateVariants = cva("border border-dashed text-center text-muted-foreground", {
+  variants: {
+    size: {
+      default: "rounded-xl border-border bg-background px-4 py-8 text-sm",
+      sm: "rounded-md px-3 py-4 text-xs",
+      spacious: "rounded-lg px-4 py-10 text-sm",
+    },
+  },
+  defaultVariants: {
+    size: "default",
+  },
+});
+
+function EmptyState({
+  className,
+  size,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyStateVariants>) {
+  return <div className={cn(emptyStateVariants({ size, className }))} {...props} />;
+}
+
+export { EmptyState, emptyStateVariants };

--- a/components/ui/native-select.tsx
+++ b/components/ui/native-select.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function NativeSelect({ className, ...props }: React.ComponentProps<"select">) {
+  return (
+    <select
+      className={cn(
+        "h-7 w-full rounded-md border border-input bg-input/20 px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:opacity-50 md:text-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { NativeSelect };


### PR DESCRIPTION
## Summary
- Add shared page shell/message, auth shell/card, alert banner, native select, and dialog shell components
- Replace repeated access/error page wrappers, auth wrappers, alert banners, compact selects, and custom-field dialog structure
- Keep existing Tailwind utility usage for one-off layout while centralizing repeated UI patterns

## Verification
- npm run format
- npm run typecheck
- npm run lint
- npm run build