### PR TITLE
Migrate custom field dialogs to Radix primitive

### DIFF
--- a/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
+++ b/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
@@ -19,6 +19,7 @@ import {
   DialogHeader,
   DialogOverlay,
   DialogTitle,
+  useDialogOpenerFocus,
 } from "@/components/ui/dialog-shell";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { NativeSelect } from "@/components/ui/native-select";
@@ -46,6 +47,7 @@ export function BulkEditDialog({
   const visibilityEnabled = form.watch("visibilityEnabled");
   const filterableEnabled = form.watch("filterableEnabled");
   const requiredEnabled = form.watch("requiredEnabled");
+  const restoreFocusToOpener = useDialogOpenerFocus();
 
   const handleSubmit = async (values: BulkEditDialogValues) => {
     if (isSaving) {
@@ -79,6 +81,7 @@ export function BulkEditDialog({
         <DialogFormPanel
           className="max-w-xl"
           onSubmit={form.handleSubmit(handleSubmit)}
+          onCloseAutoFocus={restoreFocusToOpener}
           onEscapeKeyDown={preventDismissWhileSaving}
           onInteractOutside={preventDismissWhileSaving}
         >

--- a/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
+++ b/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
@@ -69,7 +69,7 @@ export function BulkEditDialog({
     }
   };
 
-  const preventDismissWhileSaving = (event: Event) => {
+  const handleDismiss = (event: Event) => {
     event.stopPropagation();
 
     if (isSaving) {
@@ -84,8 +84,8 @@ export function BulkEditDialog({
           className="max-w-xl"
           onSubmit={form.handleSubmit(handleSubmit)}
           onCloseAutoFocus={restoreFocusToOpener}
-          onEscapeKeyDown={preventDismissWhileSaving}
-          onInteractOutside={preventDismissWhileSaving}
+          onEscapeKeyDown={handleDismiss}
+          onInteractOutside={handleDismiss}
         >
           <DialogHeader>
             <DialogTitle>Bulk Edit Fields</DialogTitle>

--- a/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
+++ b/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
@@ -61,10 +61,27 @@ export function BulkEditDialog({
     }
   };
 
+  const handleOpenChange = (open: boolean) => {
+    if (!open && !isSaving) {
+      onClose();
+    }
+  };
+
+  const preventDismissWhileSaving = (event: Event) => {
+    if (isSaving) {
+      event.preventDefault();
+    }
+  };
+
   return (
-    <DialogOverlay>
+    <DialogOverlay open onOpenChange={handleOpenChange}>
       <Form {...form}>
-        <DialogFormPanel className="max-w-xl" onSubmit={form.handleSubmit(handleSubmit)}>
+        <DialogFormPanel
+          className="max-w-xl"
+          onSubmit={form.handleSubmit(handleSubmit)}
+          onEscapeKeyDown={preventDismissWhileSaving}
+          onInteractOutside={preventDismissWhileSaving}
+        >
           <DialogHeader>
             <DialogTitle>Bulk Edit Fields</DialogTitle>
             <DialogDescription>

--- a/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
+++ b/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
@@ -63,19 +63,19 @@ export function BulkEditDialog({
     }
   };
 
-  const handleOpenChange = (open: boolean) => {
+  function handleOpenChange(open: boolean) {
     if (!open && !isSaving) {
       onClose();
     }
-  };
+  }
 
-  const handleDismiss = (event: Event) => {
+  function handleDismiss(event: Event) {
     event.stopPropagation();
 
     if (isSaving) {
       event.preventDefault();
     }
-  };
+  }
 
   return (
     <DialogOverlay open onOpenChange={handleOpenChange}>

--- a/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
+++ b/app/admin/custom-listing-fields/components/BulkEditDialog.tsx
@@ -70,6 +70,8 @@ export function BulkEditDialog({
   };
 
   const preventDismissWhileSaving = (event: Event) => {
+    event.stopPropagation();
+
     if (isSaving) {
       event.preventDefault();
     }

--- a/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
+++ b/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
@@ -20,9 +20,24 @@ export function DeleteFieldDialog({
   onClose: () => void;
   onConfirm: () => void;
 }) {
+  const handleOpenChange = (open: boolean) => {
+    if (!open && !isDeleting) {
+      onClose();
+    }
+  };
+
+  const preventDismissWhileDeleting = (event: Event) => {
+    if (isDeleting) {
+      event.preventDefault();
+    }
+  };
+
   return (
-    <DialogOverlay>
-      <DialogPanel>
+    <DialogOverlay open onOpenChange={handleOpenChange}>
+      <DialogPanel
+        onEscapeKeyDown={preventDismissWhileDeleting}
+        onInteractOutside={preventDismissWhileDeleting}
+      >
         <DialogHeader>
           <DialogTitle>Delete Custom Field</DialogTitle>
           <DialogDescription className="mt-2">

--- a/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
+++ b/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
@@ -29,7 +29,7 @@ export function DeleteFieldDialog({
     }
   };
 
-  const preventDismissWhileDeleting = (event: Event) => {
+  const handleDismiss = (event: Event) => {
     event.stopPropagation();
 
     if (isDeleting) {
@@ -41,8 +41,8 @@ export function DeleteFieldDialog({
     <DialogOverlay open onOpenChange={handleOpenChange}>
       <DialogPanel
         onCloseAutoFocus={restoreFocusToOpener}
-        onEscapeKeyDown={preventDismissWhileDeleting}
-        onInteractOutside={preventDismissWhileDeleting}
+        onEscapeKeyDown={handleDismiss}
+        onInteractOutside={handleDismiss}
       >
         <DialogHeader>
           <DialogTitle>Delete Custom Field</DialogTitle>

--- a/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
+++ b/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
@@ -30,6 +30,8 @@ export function DeleteFieldDialog({
   };
 
   const preventDismissWhileDeleting = (event: Event) => {
+    event.stopPropagation();
+
     if (isDeleting) {
       event.preventDefault();
     }

--- a/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
+++ b/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogOverlay,
   DialogPanel,
   DialogTitle,
+  useDialogOpenerFocus,
 } from "@/components/ui/dialog-shell";
 import type { AdminCustomListingField } from "@/shared/schemas/custom-listing-fields";
 
@@ -20,6 +21,8 @@ export function DeleteFieldDialog({
   onClose: () => void;
   onConfirm: () => void;
 }) {
+  const restoreFocusToOpener = useDialogOpenerFocus();
+
   const handleOpenChange = (open: boolean) => {
     if (!open && !isDeleting) {
       onClose();
@@ -35,6 +38,7 @@ export function DeleteFieldDialog({
   return (
     <DialogOverlay open onOpenChange={handleOpenChange}>
       <DialogPanel
+        onCloseAutoFocus={restoreFocusToOpener}
         onEscapeKeyDown={preventDismissWhileDeleting}
         onInteractOutside={preventDismissWhileDeleting}
       >

--- a/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
+++ b/app/admin/custom-listing-fields/components/DeleteFieldDialog.tsx
@@ -23,19 +23,19 @@ export function DeleteFieldDialog({
 }) {
   const restoreFocusToOpener = useDialogOpenerFocus();
 
-  const handleOpenChange = (open: boolean) => {
+  function handleOpenChange(open: boolean) {
     if (!open && !isDeleting) {
       onClose();
     }
-  };
+  }
 
-  const handleDismiss = (event: Event) => {
+  function handleDismiss(event: Event) {
     event.stopPropagation();
 
     if (isDeleting) {
       event.preventDefault();
     }
-  };
+  }
 
   return (
     <DialogOverlay open onOpenChange={handleOpenChange}>

--- a/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
+++ b/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
@@ -18,6 +18,7 @@ import {
   DialogFormPanel,
   DialogHeader,
   DialogOverlay,
+  DialogPanel,
   DialogTitle,
 } from "@/components/ui/dialog-shell";
 import {
@@ -56,11 +57,13 @@ export function FieldEditorDialog({
   onCreate: (payload: CreateFieldDialogPayload) => Promise<void>;
 }) {
   const [keyWasEdited, setKeyWasEdited] = useState(false);
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const normalizedCategories = getUniqueCategoryOptions(categories);
   const form = useForm<CreateFieldDialogValues>({
     resolver: zodResolver(createFieldDialogSchema),
     defaultValues: getDefaultCreateFieldDialogValues(state),
   });
+  const { isDirty } = form.formState;
 
   const handleLabelChange = (label: string) => {
     form.setValue("label", label, { shouldDirty: true, shouldValidate: true });
@@ -84,12 +87,45 @@ export function FieldEditorDialog({
     }
   };
 
+  const requestClose = () => {
+    if (isSaving) {
+      return;
+    }
+
+    if (isDirty) {
+      setDiscardConfirmOpen(true);
+      return;
+    }
+
+    onClose();
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      requestClose();
+    }
+  };
+
+  const handleDismiss = (event: Event) => {
+    if (isSaving) {
+      event.preventDefault();
+      return;
+    }
+
+    if (isDirty) {
+      event.preventDefault();
+      setDiscardConfirmOpen(true);
+    }
+  };
+
   return (
-    <DialogOverlay className="py-6">
+    <DialogOverlay className="py-6" open onOpenChange={handleOpenChange}>
       <Form {...form}>
         <DialogFormPanel
           onSubmit={form.handleSubmit(handleSubmit)}
           className="max-h-[92vh] max-w-4xl overflow-y-auto"
+          onEscapeKeyDown={handleDismiss}
+          onInteractOutside={handleDismiss}
         >
           <DialogHeader className="flex items-start justify-between">
             <div>
@@ -101,7 +137,7 @@ export function FieldEditorDialog({
             <button
               type="button"
               className="text-sm font-medium text-muted-foreground hover:text-foreground"
-              onClick={onClose}
+              onClick={requestClose}
               disabled={isSaving}
             >
               Close
@@ -233,7 +269,13 @@ export function FieldEditorDialog({
           </div>
 
           <DialogFooter className="border-t border-border">
-            <Button type="button" variant="outline" size="lg" onClick={onClose} disabled={isSaving}>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={requestClose}
+              disabled={isSaving}
+            >
               Cancel
             </Button>
             <Button type="submit" size="lg" disabled={isSaving}>
@@ -242,6 +284,30 @@ export function FieldEditorDialog({
           </DialogFooter>
         </DialogFormPanel>
       </Form>
+
+      <DialogOverlay open={discardConfirmOpen} onOpenChange={setDiscardConfirmOpen}>
+        <DialogPanel>
+          <DialogHeader>
+            <DialogTitle>Discard Custom Field?</DialogTitle>
+            <DialogDescription className="mt-2">
+              You have unsaved changes. Discard this custom field and lose the entered values?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={() => setDiscardConfirmOpen(false)}
+            >
+              Keep Editing
+            </Button>
+            <Button type="button" variant="destructive" size="lg" onClick={onClose}>
+              Discard Changes
+            </Button>
+          </DialogFooter>
+        </DialogPanel>
+      </DialogOverlay>
     </DialogOverlay>
   );
 }

--- a/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
+++ b/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type Control, useForm } from "react-hook-form";
 
@@ -59,6 +59,7 @@ export function FieldEditorDialog({
 }) {
   const [keyWasEdited, setKeyWasEdited] = useState(false);
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
+  const discardReturnFocusRef = useRef<HTMLElement | null>(null);
   const normalizedCategories = getUniqueCategoryOptions(categories);
   const form = useForm<CreateFieldDialogValues>({
     resolver: zodResolver(createFieldDialogSchema),
@@ -89,13 +90,37 @@ export function FieldEditorDialog({
     }
   };
 
-  const requestClose = () => {
+  const openDiscardConfirm = (returnFocusTarget?: HTMLElement | null) => {
+    if (returnFocusTarget) {
+      discardReturnFocusRef.current = returnFocusTarget;
+    } else if (
+      discardReturnFocusRef.current === null &&
+      document.activeElement instanceof HTMLElement
+    ) {
+      discardReturnFocusRef.current = document.activeElement;
+    }
+
+    setDiscardConfirmOpen(true);
+  };
+
+  const focusDiscardReturnTarget = () => {
+    window.setTimeout(() => {
+      discardReturnFocusRef.current?.focus({ preventScroll: true });
+    }, 0);
+  };
+
+  const closeDiscardConfirm = () => {
+    setDiscardConfirmOpen(false);
+    focusDiscardReturnTarget();
+  };
+
+  const requestClose = (returnFocusTarget?: HTMLElement | null) => {
     if (isSaving) {
       return;
     }
 
     if (isDirty) {
-      setDiscardConfirmOpen(true);
+      openDiscardConfirm(returnFocusTarget);
       return;
     }
 
@@ -116,8 +141,13 @@ export function FieldEditorDialog({
 
     if (isDirty) {
       event.preventDefault();
-      setDiscardConfirmOpen(true);
+      openDiscardConfirm();
     }
+  };
+
+  const restoreFocusToDiscardRequester = (event: Event) => {
+    event.preventDefault();
+    focusDiscardReturnTarget();
   };
 
   return (
@@ -128,6 +158,9 @@ export function FieldEditorDialog({
           className="max-h-[92vh] max-w-4xl overflow-y-auto"
           onCloseAutoFocus={restoreFocusToOpener}
           onEscapeKeyDown={handleDismiss}
+          onFocusCapture={(event) => {
+            discardReturnFocusRef.current = event.target;
+          }}
           onInteractOutside={handleDismiss}
         >
           <DialogHeader className="flex items-start justify-between">
@@ -140,7 +173,7 @@ export function FieldEditorDialog({
             <button
               type="button"
               className="text-sm font-medium text-muted-foreground hover:text-foreground"
-              onClick={requestClose}
+              onClick={(event) => requestClose(event.currentTarget)}
               disabled={isSaving}
             >
               Close
@@ -276,7 +309,7 @@ export function FieldEditorDialog({
               type="button"
               variant="outline"
               size="lg"
-              onClick={requestClose}
+              onClick={(event) => requestClose(event.currentTarget)}
               disabled={isSaving}
             >
               Cancel
@@ -288,8 +321,18 @@ export function FieldEditorDialog({
         </DialogFormPanel>
       </Form>
 
-      <DialogOverlay open={discardConfirmOpen} onOpenChange={setDiscardConfirmOpen}>
-        <DialogPanel>
+      <DialogOverlay
+        open={discardConfirmOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            setDiscardConfirmOpen(true);
+            return;
+          }
+
+          closeDiscardConfirm();
+        }}
+      >
+        <DialogPanel onCloseAutoFocus={restoreFocusToDiscardRequester}>
           <DialogHeader>
             <DialogTitle>Discard Custom Field?</DialogTitle>
             <DialogDescription className="mt-2">
@@ -297,12 +340,7 @@ export function FieldEditorDialog({
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              size="lg"
-              onClick={() => setDiscardConfirmOpen(false)}
-            >
+            <Button type="button" variant="outline" size="lg" onClick={closeDiscardConfirm}>
               Keep Editing
             </Button>
             <Button type="button" variant="destructive" size="lg" onClick={onClose}>

--- a/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
+++ b/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
@@ -90,7 +90,7 @@ export function FieldEditorDialog({
     }
   };
 
-  const openDiscardConfirm = (returnFocusTarget?: HTMLElement | null) => {
+  function openDiscardConfirm(returnFocusTarget?: HTMLElement | null) {
     if (returnFocusTarget) {
       discardReturnFocusRef.current = returnFocusTarget;
     } else if (
@@ -101,20 +101,20 @@ export function FieldEditorDialog({
     }
 
     setDiscardConfirmOpen(true);
-  };
+  }
 
-  const focusDiscardReturnTarget = () => {
+  function focusDiscardReturnTarget() {
     window.setTimeout(() => {
       discardReturnFocusRef.current?.focus({ preventScroll: true });
     }, 0);
-  };
+  }
 
-  const closeDiscardConfirm = () => {
+  function closeDiscardConfirm() {
     setDiscardConfirmOpen(false);
     focusDiscardReturnTarget();
-  };
+  }
 
-  const requestClose = (returnFocusTarget?: HTMLElement | null) => {
+  function requestClose(returnFocusTarget?: HTMLElement | null) {
     if (isSaving) {
       return;
     }
@@ -125,15 +125,15 @@ export function FieldEditorDialog({
     }
 
     onClose();
-  };
+  }
 
-  const handleOpenChange = (open: boolean) => {
+  function handleOpenChange(open: boolean) {
     if (!open) {
       requestClose();
     }
-  };
+  }
 
-  const handleDismiss = (event: Event) => {
+  function handleDismiss(event: Event) {
     event.stopPropagation();
 
     if (isSaving) {
@@ -145,12 +145,12 @@ export function FieldEditorDialog({
       event.preventDefault();
       openDiscardConfirm();
     }
-  };
+  }
 
-  const restoreFocusToDiscardRequester = (event: Event) => {
+  function restoreFocusToDiscardRequester(event: Event) {
     event.preventDefault();
     focusDiscardReturnTarget();
-  };
+  }
 
   return (
     <DialogOverlay className="py-6" open onOpenChange={handleOpenChange}>

--- a/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
+++ b/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
@@ -20,6 +20,7 @@ import {
   DialogOverlay,
   DialogPanel,
   DialogTitle,
+  useDialogOpenerFocus,
 } from "@/components/ui/dialog-shell";
 import {
   Form,
@@ -64,6 +65,7 @@ export function FieldEditorDialog({
     defaultValues: getDefaultCreateFieldDialogValues(state),
   });
   const { isDirty } = form.formState;
+  const restoreFocusToOpener = useDialogOpenerFocus();
 
   const handleLabelChange = (label: string) => {
     form.setValue("label", label, { shouldDirty: true, shouldValidate: true });
@@ -124,6 +126,7 @@ export function FieldEditorDialog({
         <DialogFormPanel
           onSubmit={form.handleSubmit(handleSubmit)}
           className="max-h-[92vh] max-w-4xl overflow-y-auto"
+          onCloseAutoFocus={restoreFocusToOpener}
           onEscapeKeyDown={handleDismiss}
           onInteractOutside={handleDismiss}
         >

--- a/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
+++ b/app/admin/custom-listing-fields/components/FieldEditorDialog.tsx
@@ -134,6 +134,8 @@ export function FieldEditorDialog({
   };
 
   const handleDismiss = (event: Event) => {
+    event.stopPropagation();
+
     if (isSaving) {
       event.preventDefault();
       return;

--- a/components/ui/dialog-shell.tsx
+++ b/components/ui/dialog-shell.tsx
@@ -10,8 +10,25 @@ type DialogOverlayProps = React.ComponentProps<"div"> &
 
 type DialogContentDismissProps = Pick<
   React.ComponentProps<typeof DialogPrimitive.Content>,
-  "onEscapeKeyDown" | "onInteractOutside"
+  "onCloseAutoFocus" | "onEscapeKeyDown" | "onInteractOutside"
 >;
+
+function useDialogOpenerFocus() {
+  const openerRef = React.useRef<HTMLElement | null>(null);
+
+  if (
+    openerRef.current === null &&
+    typeof document !== "undefined" &&
+    document.activeElement instanceof HTMLElement
+  ) {
+    openerRef.current = document.activeElement;
+  }
+
+  return React.useCallback((event: Event) => {
+    event.preventDefault();
+    openerRef.current?.focus({ preventScroll: true });
+  }, []);
+}
 
 function DialogOverlay({ className, open, onOpenChange, ...props }: DialogOverlayProps) {
   return (
@@ -44,12 +61,13 @@ function DialogPanel({
 
 function DialogFormPanel({
   className,
+  onCloseAutoFocus,
   onEscapeKeyDown,
   onInteractOutside,
   ...props
 }: React.ComponentProps<"form"> & DialogContentDismissProps) {
   return (
-    <DialogPrimitive.Content asChild {...{ onEscapeKeyDown, onInteractOutside }}>
+    <DialogPrimitive.Content asChild {...{ onCloseAutoFocus, onEscapeKeyDown, onInteractOutside }}>
       <form
         className={cn(
           "w-full max-w-md rounded-md border border-border bg-background shadow-2xl",
@@ -93,4 +111,5 @@ export {
   DialogOverlay,
   DialogPanel,
   DialogTitle,
+  useDialogOpenerFocus,
 };

--- a/components/ui/dialog-shell.tsx
+++ b/components/ui/dialog-shell.tsx
@@ -26,7 +26,9 @@ function useDialogOpenerFocus() {
 
   return React.useCallback((event: Event) => {
     event.preventDefault();
-    openerRef.current?.focus({ preventScroll: true });
+    window.setTimeout(() => {
+      openerRef.current?.focus({ preventScroll: true });
+    }, 0);
   }, []);
 }
 

--- a/components/ui/dialog-shell.tsx
+++ b/components/ui/dialog-shell.tsx
@@ -1,22 +1,38 @@
+"use client";
+
 import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
-function DialogOverlay({ className, ...props }: React.ComponentProps<"div">) {
+type DialogOverlayProps = React.ComponentProps<"div"> &
+  Pick<React.ComponentProps<typeof DialogPrimitive.Root>, "open" | "onOpenChange">;
+
+type DialogContentDismissProps = Pick<
+  React.ComponentProps<typeof DialogPrimitive.Content>,
+  "onEscapeKeyDown" | "onInteractOutside"
+>;
+
+function DialogOverlay({ className, open, onOpenChange, ...props }: DialogOverlayProps) {
   return (
-    <div
-      className={cn(
-        "fixed inset-0 z-50 flex items-center justify-center bg-foreground/20 px-4",
-        className,
-      )}
-      {...props}
-    />
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-foreground/20" />
+        <div
+          className={cn("fixed inset-0 z-50 flex items-center justify-center px-4", className)}
+          {...props}
+        />
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }
 
-function DialogPanel({ className, ...props }: React.ComponentProps<"div">) {
+function DialogPanel({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
   return (
-    <div
+    <DialogPrimitive.Content
       className={cn(
         "w-full max-w-md rounded-md border border-border bg-background shadow-2xl",
         className,
@@ -26,15 +42,22 @@ function DialogPanel({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DialogFormPanel({ className, ...props }: React.ComponentProps<"form">) {
+function DialogFormPanel({
+  className,
+  onEscapeKeyDown,
+  onInteractOutside,
+  ...props
+}: React.ComponentProps<"form"> & DialogContentDismissProps) {
   return (
-    <form
-      className={cn(
-        "w-full max-w-md rounded-md border border-border bg-background shadow-2xl",
-        className,
-      )}
-      {...props}
-    />
+    <DialogPrimitive.Content asChild {...{ onEscapeKeyDown, onInteractOutside }}>
+      <form
+        className={cn(
+          "w-full max-w-md rounded-md border border-border bg-background shadow-2xl",
+          className,
+        )}
+        {...props}
+      />
+    </DialogPrimitive.Content>
   );
 }
 
@@ -42,12 +65,20 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return <div className={cn("border-b border-border px-6 py-5", className)} {...props} />;
 }
 
-function DialogTitle({ className, ...props }: React.ComponentProps<"h2">) {
-  return <h2 className={cn("text-xl font-semibold", className)} {...props} />;
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return <DialogPrimitive.Title className={cn("text-xl font-semibold", className)} {...props} />;
 }
 
-function DialogDescription({ className, ...props }: React.ComponentProps<"p">) {
-  return <p className={cn("mt-1 text-sm text-muted-foreground", className)} {...props} />;
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn("mt-1 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
 }
 
 function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {


### PR DESCRIPTION
## Summary
- migrate the custom listing field dialog shell to Radix/shadcn dialog primitives while preserving existing styling
- wire controlled close behavior for field editor, bulk edit, and delete dialogs
- add a dirty-form discard confirmation for the Add Field dialog
- prevent Escape/outside-click dismissal while save/delete operations are in progress

Closes #242

## Verification
- npm run format:check
- npm run typecheck
- npm run lint
- npm run test:unit -- app/admin/custom-listing-fields/custom-listing-fields-dashboard-utils.unit.test.ts
- npm run build (pre-push hook)
- Browser verified on localhost:3100: Add Field dirty form opens discard confirmation on Escape, Keep Editing returns to the form, Cancel reopens confirmation, Discard Changes closes the dialog