### PR TITLE
Add TanStack Query client state

### DIFF
--- a/app/admin/custom-listing-fields/useAdminCustomListingFieldsApi.ts
+++ b/app/admin/custom-listing-fields/useAdminCustomListingFieldsApi.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { queryKeys } from "@/app/query-keys";
 import type {
   AdminCustomListingField,
   AdminCustomListingFieldListResponse,
@@ -23,30 +24,22 @@ type RequestErrorBody = {
 };
 
 export function useAdminCustomListingFieldsQuery() {
-  const refreshFields = useCallback(async () => {
-    const response = await requestJson<AdminCustomListingFieldListResponse>(
-      "/api/admin/custom-listing-fields",
-      { method: "GET" },
-    );
-    return normalizeFieldCategories(response.data);
-  }, []);
+  const queryClient = useQueryClient();
 
-  return { refreshFields };
+  return {
+    refreshFields: () =>
+      queryClient.fetchQuery({
+        queryKey: queryKeys.adminCustomListingFields(),
+        queryFn: fetchAdminCustomListingFields,
+        staleTime: 0,
+      }),
+  };
 }
 
 export function useCreateAdminCustomListingFieldMutation() {
-  const [isLoading, setIsLoading] = useState(false);
-  const isLoadingRef = useRef(false);
-
-  const createField = useCallback(async (input: CreateCustomListingFieldInput) => {
-    if (isLoadingRef.current) {
-      return null;
-    }
-
-    isLoadingRef.current = true;
-    setIsLoading(true);
-
-    try {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: CreateCustomListingFieldInput) => {
       const response = await requestJson<CreateCustomListingFieldResponse>(
         "/api/admin/custom-listing-fields",
         {
@@ -56,76 +49,113 @@ export function useCreateAdminCustomListingFieldMutation() {
         },
       );
       return normalizeFieldCategory(response.data);
-    } finally {
-      isLoadingRef.current = false;
-      setIsLoading(false);
-    }
-  }, []);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.adminCustomListingFields() });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.accessibilityFeatures() });
+    },
+  });
 
-  return { createField, isLoading };
+  return { createField: mutation.mutateAsync, isLoading: mutation.isPending };
 }
 
 export function useUpdateAdminCustomListingFieldMutation() {
-  const updateField = useCallback(async (fieldId: string, input: UpdateCustomListingFieldInput) => {
-    const response = await requestJson<UpdateCustomListingFieldResponse>(
-      `/api/admin/custom-listing-fields/${fieldId}`,
-      {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(input),
-      },
-    );
-    return normalizeFieldCategory(response.data);
-  }, []);
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async ({
+      fieldId,
+      input,
+    }: {
+      fieldId: string;
+      input: UpdateCustomListingFieldInput;
+    }) => {
+      const response = await requestJson<UpdateCustomListingFieldResponse>(
+        `/api/admin/custom-listing-fields/${fieldId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(input),
+        },
+      );
+      return normalizeFieldCategory(response.data);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.adminCustomListingFields() });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.accessibilityFeatures() });
+    },
+  });
 
-  return { updateField };
+  return {
+    updateField: (fieldId: string, input: UpdateCustomListingFieldInput) =>
+      mutation.mutateAsync({ fieldId, input }),
+  };
 }
 
 export function useBulkUpdateAdminCustomListingFieldsMutation() {
-  const [isLoading, setIsLoading] = useState(false);
   const { updateField } = useUpdateAdminCustomListingFieldMutation();
+  const mutation = useMutation({
+    mutationFn: async ({
+      fields,
+      input,
+    }: {
+      fields: AdminCustomListingField[];
+      input: UpdateCustomListingFieldInput;
+    }) => Promise.all(fields.map((field) => updateField(field.id, input))),
+  });
 
-  const updateFields = useCallback(
-    async (fields: AdminCustomListingField[], input: UpdateCustomListingFieldInput) => {
-      setIsLoading(true);
-
-      try {
-        return await Promise.all(fields.map((field) => updateField(field.id, input)));
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [updateField],
-  );
-
-  return { updateFields, isLoading };
+  return {
+    updateFields: (fields: AdminCustomListingField[], input: UpdateCustomListingFieldInput) =>
+      mutation.mutateAsync({ fields, input }),
+    isLoading: mutation.isPending,
+  };
 }
 
 export function useReorderAdminCustomListingFieldsMutation() {
-  const reorderFields = useCallback(async (input: ReorderCustomListingFieldsInput) => {
-    const response = await requestJson<ReorderCustomListingFieldsResponse>(
-      "/api/admin/custom-listing-fields/reorder",
-      {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(input),
-      },
-    );
-    return normalizeFieldCategories(response.data);
-  }, []);
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (input: ReorderCustomListingFieldsInput) => {
+      const response = await requestJson<ReorderCustomListingFieldsResponse>(
+        "/api/admin/custom-listing-fields/reorder",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(input),
+        },
+      );
+      return normalizeFieldCategories(response.data);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.adminCustomListingFields() });
+    },
+  });
 
-  return { reorderFields };
+  return { reorderFields: mutation.mutateAsync };
 }
 
 export function useDeleteAdminCustomListingFieldMutation() {
-  const deleteField = useCallback(async (fieldId: string) => {
-    await requestJson<DeleteCustomListingFieldResponse>(
-      `/api/admin/custom-listing-fields/${fieldId}`,
-      { method: "DELETE" },
-    );
-  }, []);
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async (fieldId: string) => {
+      await requestJson<DeleteCustomListingFieldResponse>(
+        `/api/admin/custom-listing-fields/${fieldId}`,
+        { method: "DELETE" },
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.adminCustomListingFields() });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.accessibilityFeatures() });
+    },
+  });
 
-  return { deleteField };
+  return { deleteField: mutation.mutateAsync };
+}
+
+async function fetchAdminCustomListingFields() {
+  const response = await requestJson<AdminCustomListingFieldListResponse>(
+    "/api/admin/custom-listing-fields",
+    { method: "GET" },
+  );
+  return normalizeFieldCategories(response.data);
 }
 
 async function requestJson<T = unknown>(url: string, init: RequestInit): Promise<T> {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SiteHeader } from "@/components/site-header/SiteHeader";
 import { SiteFooter } from "@/components/site-footer/SiteFooter";
+import { QueryProvider } from "./query-provider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,9 +28,11 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="flex min-h-full flex-col">
-        <SiteHeader />
-        <div className="flex-1">{children}</div>
-        <SiteFooter />
+        <QueryProvider>
+          <SiteHeader />
+          <div className="flex-1">{children}</div>
+          <SiteFooter />
+        </QueryProvider>
       </body>
     </html>
   );

--- a/app/listing-form/useAccessibilityFeaturesQuery.ts
+++ b/app/listing-form/useAccessibilityFeaturesQuery.ts
@@ -1,45 +1,25 @@
-import { useState, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 
-import {
-  customListingFieldListResponseSchema,
-  type CustomListingFieldGroup,
-} from "@/shared/schemas/custom-listing-fields";
+import { queryKeys } from "@/app/query-keys";
+import { customListingFieldListResponseSchema } from "@/shared/schemas/custom-listing-fields";
 
 export function useAccessibilityFeaturesQuery() {
-  const [data, setData] = useState<CustomListingFieldGroup[] | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
+  const result = useQuery({
+    queryKey: queryKeys.accessibilityFeatures(),
+    queryFn: async ({ signal }) => {
+      const response = await fetch(
+        "/api/custom-listing-fields?publicOnly=true&filterableOnly=true&type=boolean",
+        { signal },
+      );
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function fetchFeatures() {
-      try {
-        const response = await fetch(
-          "/api/custom-listing-fields?publicOnly=true&filterableOnly=true&type=boolean",
-        );
-        if (!response.ok) {
-          throw new Error("Failed to fetch accessibility features");
-        }
-        const payload = customListingFieldListResponseSchema.parse(await response.json());
-        if (!cancelled) {
-          setData(payload.data);
-          setIsLoading(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setIsError(true);
-          setIsLoading(false);
-        }
+      if (!response.ok) {
+        throw new Error("Failed to fetch accessibility features");
       }
-    }
+      const payload = customListingFieldListResponseSchema.parse(await response.json());
+      return payload.data;
+    },
+    staleTime: 5 * 60_000,
+  });
 
-    void fetchFeatures();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return { data, isLoading, isError };
+  return { data: result.data ?? null, isLoading: result.isLoading, isError: result.isError };
 }

--- a/app/listing-form/useCreateDraftListingQuery.ts
+++ b/app/listing-form/useCreateDraftListingQuery.ts
@@ -1,28 +1,26 @@
-import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { queryKeys } from "@/app/query-keys";
 import { parseCreateDraftListingResponse } from "./api";
 
 export function useCreateDraftListingQuery() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
-
-  const createDraftListing = async () => {
-    setIsLoading(true);
-    setIsError(false);
-
-    try {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async () => {
       const response = await fetch("/api/listing-drafts", {
         method: "POST",
       });
 
       return await parseCreateDraftListingResponse(response);
-    } catch (error) {
-      setIsError(true);
-      throw error instanceof Error ? error : new Error("Unable to create draft listing");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.myListings() });
+    },
+  });
 
-  return { createDraftListing, isLoading, isError };
+  return {
+    createDraftListing: mutation.mutateAsync,
+    isLoading: mutation.isPending,
+    isError: mutation.isError,
+  };
 }

--- a/app/listing-form/useEditListingQuery.ts
+++ b/app/listing-form/useEditListingQuery.ts
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/app/query-keys";
 import type { UpdateListingInput } from "@/shared/schemas/listings";
 import { parseCreateListingResponse } from "./api";
 
@@ -8,14 +9,9 @@ interface EditListingInput {
 }
 
 export function useEditListingQuery() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
-
-  const editListing = async ({ listingId, payload }: EditListingInput) => {
-    setIsLoading(true);
-    setIsError(false);
-
-    try {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async ({ listingId, payload }: EditListingInput) => {
       const response = await fetch(`/api/listings/${listingId}`, {
         method: "PUT",
         headers: {
@@ -25,13 +21,19 @@ export function useEditListingQuery() {
       });
 
       return await parseCreateListingResponse(response);
-    } catch (error) {
-      setIsError(true);
-      throw error instanceof Error ? error : new Error("Unable to edit listing");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.listingEditor(variables.listingId),
+      });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.myListings() });
+      void queryClient.invalidateQueries({ queryKey: ["listings"] });
+    },
+  });
 
-  return { editListing, isLoading, isError };
+  return {
+    editListing: mutation.mutateAsync,
+    isLoading: mutation.isPending,
+    isError: mutation.isError,
+  };
 }

--- a/app/listing-form/useGetListingQuery.ts
+++ b/app/listing-form/useGetListingQuery.ts
@@ -1,50 +1,25 @@
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
+import { queryKeys } from "@/app/query-keys";
 import { parseListingEditorResponse } from "./api";
-import type { ListingFormInput } from "./types";
 
 export function useGetListingQuery(listingId?: string) {
-  const [data, setData] = useState<ListingFormInput | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isError, setIsError] = useState(false);
-
-  useEffect(() => {
-    if (!listingId) {
-      setData(null);
-      setIsError(false);
-      setIsLoading(false);
-      return;
-    }
-
-    setIsError(false);
-    setIsLoading(true);
-    let cancelled = false;
-
-    async function fetchListing() {
-      try {
-        const response = await fetch(`/api/listings/${listingId}/editor`, {
-          method: "GET",
-        });
-        const payload = await parseListingEditorResponse(response);
-
-        if (!cancelled) {
-          setData(payload.data);
-          setIsLoading(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setIsError(true);
-          setIsLoading(false);
-        }
+  const result = useQuery({
+    queryKey: queryKeys.listingEditor(listingId),
+    queryFn: async ({ signal }) => {
+      if (!listingId) {
+        return null;
       }
-    }
 
-    void fetchListing();
+      const response = await fetch(`/api/listings/${listingId}/editor`, {
+        method: "GET",
+        signal,
+      });
+      const payload = await parseListingEditorResponse(response);
+      return payload.data;
+    },
+    enabled: Boolean(listingId),
+  });
 
-    return () => {
-      cancelled = true;
-    };
-  }, [listingId]);
-
-  return { data, isLoading, isError };
+  return { data: result.data ?? null, isLoading: result.isLoading, isError: result.isError };
 }

--- a/app/listings/useListingsQuery.ts
+++ b/app/listings/useListingsQuery.ts
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 
+import { queryKeys } from "@/app/query-keys";
 import { createListingsQueryString } from "./query";
 import type { ListingListResponse, ListingQuery } from "@/shared/schemas/listings";
 
@@ -10,53 +12,27 @@ export function useListingsQuery(
   initialData: ListingListResponse,
   initialQueryString: string,
 ) {
-  const [data, setData] = useState(initialData);
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
   const queryString = useMemo(() => createListingsQueryString(query), [query]);
+  const result = useQuery({
+    queryKey: queryKeys.listings(queryString),
+    queryFn: async ({ signal }) => {
+      const response = await fetch(`/api/listings?${queryString}`, {
+        signal,
+      });
 
-  useEffect(() => {
-    if (queryString === initialQueryString) {
-      setData(initialData);
-      setError(null);
-      setIsLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-
-    async function fetchListings() {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const response = await fetch(`/api/listings?${queryString}`, {
-          signal: controller.signal,
-        });
-
-        if (!response.ok) {
-          throw new Error("Failed to fetch listings.");
-        }
-
-        const payload = (await response.json()) as ListingListResponse;
-        setData(payload);
-      } catch (fetchError) {
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        setError(fetchError instanceof Error ? fetchError.message : "Failed to fetch listings.");
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
+      if (!response.ok) {
+        throw new Error("Failed to fetch listings.");
       }
-    }
 
-    void fetchListings();
+      return (await response.json()) as ListingListResponse;
+    },
+    initialData: queryString === initialQueryString ? initialData : undefined,
+    placeholderData: keepPreviousData,
+  });
 
-    return () => controller.abort();
-  }, [initialData, initialQueryString, queryString]);
-
-  return { data, error, isLoading };
+  return {
+    data: result.data ?? initialData,
+    error: result.error instanceof Error ? result.error.message : null,
+    isLoading: result.isFetching && queryString !== initialQueryString,
+  };
 }

--- a/app/my-listings/MyListingsClient.tsx
+++ b/app/my-listings/MyListingsClient.tsx
@@ -4,7 +4,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { formatDistance } from "date-fns";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { queryKeys } from "@/app/query-keys";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -47,10 +49,71 @@ const statusLabelByValue = {
 
 export function MyListingsClient({ initialListings, renderedAt }: MyListingsClientProps) {
   const router = useRouter();
-  const [listings, setListings] = useState(sortListings(initialListings));
-  const [mutatingListingId, setMutatingListingId] = useState<string | null>(null);
-  const [mutationError, setMutationError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const [now, setNow] = useState(() => new Date(renderedAt));
+  const listingsQuery = useQuery({
+    queryKey: queryKeys.myListings(),
+    queryFn: () => sortListings(initialListings),
+    initialData: sortListings(initialListings),
+    enabled: false,
+  });
+  const listings = listingsQuery.data;
+
+  const statusMutation = useMutation({
+    mutationFn: async ({
+      listingId,
+      nextStatus,
+    }: {
+      listingId: string;
+      nextStatus: MyListingItem["status"];
+    }) => {
+      const isDelete = nextStatus === "archived";
+      const response = await fetch(`/api/listings/${listingId}`, {
+        method: isDelete ? "DELETE" : "PUT",
+        headers: isDelete ? undefined : { "content-type": "application/json" },
+        body: isDelete ? undefined : JSON.stringify({ status: nextStatus }),
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { message?: string } | null;
+        throw new Error(
+          payload?.message ??
+            (isDelete ? "Unable to delete listing." : "Unable to restore listing."),
+        );
+      }
+
+      return { listingId, nextStatus };
+    },
+    onMutate: async ({ listingId, nextStatus }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.myListings() });
+      const previousListings = queryClient.getQueryData<MyListingItem[]>(queryKeys.myListings());
+
+      queryClient.setQueryData<MyListingItem[]>(queryKeys.myListings(), (current = []) =>
+        sortListings(
+          current.map((listing) =>
+            listing.id === listingId
+              ? {
+                  ...listing,
+                  status: nextStatus,
+                  updatedAt: new Date().toISOString(),
+                }
+              : listing,
+          ),
+        ),
+      );
+
+      return { previousListings };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousListings) {
+        queryClient.setQueryData(queryKeys.myListings(), context.previousListings);
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["listings"] });
+      router.refresh();
+    },
+  });
 
   useEffect(() => {
     setNow(new Date());
@@ -65,86 +128,8 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
   }, []);
 
   useEffect(() => {
-    setListings(sortListings(initialListings));
-  }, [initialListings]);
-
-  async function handleDelete(listingId: string) {
-    setMutationError(null);
-    setMutatingListingId(listingId);
-
-    try {
-      const response = await fetch(`/api/listings/${listingId}`, {
-        method: "DELETE",
-      });
-
-      if (!response.ok) {
-        const payload = (await response.json().catch(() => null)) as { message?: string } | null;
-        throw new Error(payload?.message ?? "Unable to delete listing.");
-      }
-
-      setListings((current) =>
-        sortListings(
-          current.map((listing) =>
-            listing.id === listingId
-              ? {
-                  ...listing,
-                  status: "archived",
-                  updatedAt: new Date().toISOString(),
-                }
-              : listing,
-          ),
-        ),
-      );
-      router.refresh();
-    } catch (error) {
-      setMutationError(
-        error instanceof Error ? error.message : "Unable to delete listing. Please try again.",
-      );
-    } finally {
-      setMutatingListingId(null);
-    }
-  }
-
-  async function handleUndelete(listingId: string) {
-    setMutationError(null);
-    setMutatingListingId(listingId);
-
-    try {
-      const response = await fetch(`/api/listings/${listingId}`, {
-        method: "PUT",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ status: "draft" }),
-      });
-
-      if (!response.ok) {
-        const payload = (await response.json().catch(() => null)) as { message?: string } | null;
-        throw new Error(payload?.message ?? "Unable to restore listing.");
-      }
-
-      setListings((current) =>
-        sortListings(
-          current.map((listing) =>
-            listing.id === listingId
-              ? {
-                  ...listing,
-                  status: "draft",
-                  updatedAt: new Date().toISOString(),
-                }
-              : listing,
-          ),
-        ),
-      );
-      router.refresh();
-    } catch (error) {
-      setMutationError(
-        error instanceof Error ? error.message : "Unable to restore listing. Please try again.",
-      );
-    } finally {
-      setMutatingListingId(null);
-    }
-  }
+    queryClient.setQueryData(queryKeys.myListings(), sortListings(initialListings));
+  }, [initialListings, queryClient]);
 
   if (listings.length === 0) {
     return (
@@ -160,16 +145,19 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
 
   return (
     <div className="space-y-4">
-      {mutationError ? (
+      {statusMutation.error ? (
         <AlertBanner variant="error" size="default" className="rounded-lg">
-          {mutationError}
+          {statusMutation.error instanceof Error
+            ? statusMutation.error.message
+            : "Unable to update listing. Please try again."}
         </AlertBanner>
       ) : null}
 
       <div className="grid gap-4">
         {listings.map((listing) => {
           const isDeleted = listing.status === "archived";
-          const isMutating = mutatingListingId === listing.id;
+          const isMutating =
+            statusMutation.isPending && statusMutation.variables?.listingId === listing.id;
 
           return (
             <Card key={listing.id}>
@@ -243,7 +231,10 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
                                 "Delete this listing? It will be kept in a deleted state and can be recovered later from the database if needed.",
                               )
                             ) {
-                              void handleDelete(listing.id);
+                              statusMutation.mutate({
+                                listingId: listing.id,
+                                nextStatus: "archived",
+                              });
                             }
                           }}
                         >
@@ -259,7 +250,12 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
                           type="button"
                           variant="outline"
                           disabled={isMutating}
-                          onClick={() => void handleUndelete(listing.id)}
+                          onClick={() =>
+                            statusMutation.mutate({
+                              listingId: listing.id,
+                              nextStatus: "draft",
+                            })
+                          }
                         >
                           {isMutating ? "Restoring..." : "Undelete"}
                         </Button>

--- a/app/my-listings/MyListingsClient.tsx
+++ b/app/my-listings/MyListingsClient.tsx
@@ -158,6 +158,8 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
           const isDeleted = listing.status === "archived";
           const isMutating =
             statusMutation.isPending && statusMutation.variables?.listingId === listing.id;
+          const pendingLabel =
+            statusMutation.variables?.nextStatus === "archived" ? "Deleting..." : "Restoring...";
 
           return (
             <Card key={listing.id}>
@@ -238,7 +240,7 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
                             }
                           }}
                         >
-                          {isMutating ? "Deleting..." : "Delete"}
+                          {isMutating ? pendingLabel : "Delete"}
                         </Button>
                       </>
                     ) : (
@@ -257,7 +259,7 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
                             })
                           }
                         >
-                          {isMutating ? "Restoring..." : "Undelete"}
+                          {isMutating ? pendingLabel : "Undelete"}
                         </Button>
                       </>
                     )}

--- a/app/query-keys.ts
+++ b/app/query-keys.ts
@@ -1,0 +1,11 @@
+export const queryKeys = {
+  adminCustomListingFields: () => ["admin", "custom-listing-fields"] as const,
+  accessibilityFeatures: () => ["custom-listing-fields", "accessibility-features"] as const,
+  listingEditor: (listingId?: string) => ["listing-editor", listingId] as const,
+  listings: (queryString: string) => ["listings", queryString] as const,
+  myListings: () => ["my-listings"] as const,
+  recentInvites: () => ["admin", "account-invites", "recent"] as const,
+};
+
+export type ListingsQueryKey = ReturnType<typeof queryKeys.listings>;
+export type ListingEditorQueryKey = ReturnType<typeof queryKeys.listingEditor>;

--- a/app/query-provider.tsx
+++ b/app/query-provider.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            retry: 1,
+            staleTime: 30_000,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/components/admin-invite/useAdminInvite.ts
+++ b/components/admin-invite/useAdminInvite.ts
@@ -1,7 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { queryKeys } from "@/app/query-keys";
 import { buildInviteRecordFromAccountInvite } from "@/components/admin-invite/invite-records";
 import type { InviteActionResult, InviteRecord } from "@/components/admin-invite/types";
 import { accountInviteListResponseSchema } from "@/shared/schemas/account-management";
@@ -13,7 +15,7 @@ export function useAdminInvite(input?: {
   initialInvites?: InviteRecord[];
   shouldHydrateInvites?: boolean;
 }) {
-  const [invites, setInvites] = useState<InviteRecord[]>(input?.initialInvites ?? []);
+  const queryClient = useQueryClient();
   const [lastResult, setLastResult] = useState<InviteActionResult | null>(null);
   const shouldHydrateInvites = input?.shouldHydrateInvites ?? true;
 
@@ -30,33 +32,12 @@ export function useAdminInvite(input?: {
     return payload.data.map(buildInviteRecordFromAccountInvite);
   }, []);
 
-  useEffect(() => {
-    if (!shouldHydrateInvites) {
-      return;
-    }
-
-    let cancelled = false;
-
-    async function hydrateRecentInvites() {
-      try {
-        const nextInvites = await fetchRecentInvites();
-
-        if (!cancelled) {
-          setInvites(nextInvites);
-        }
-      } catch {
-        if (!cancelled) {
-          setInvites([]);
-        }
-      }
-    }
-
-    void hydrateRecentInvites();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [fetchRecentInvites, shouldHydrateInvites]);
+  const recentInvitesQuery = useQuery({
+    queryKey: queryKeys.recentInvites(),
+    queryFn: fetchRecentInvites,
+    enabled: shouldHydrateInvites,
+    initialData: input?.initialInvites,
+  });
 
   const handleInviteResult = useCallback(
     (result: InviteActionResult) => {
@@ -68,7 +49,7 @@ export function useAdminInvite(input?: {
 
       void fetchRecentInvites()
         .then((nextInvites) => {
-          setInvites(nextInvites);
+          queryClient.setQueryData(queryKeys.recentInvites(), nextInvites);
         })
         .catch(() => {
           if (!result.invite) {
@@ -77,16 +58,16 @@ export function useAdminInvite(input?: {
 
           const invite = result.invite;
 
-          setInvites((previousInvites) => {
-            return [invite, ...previousInvites].slice(0, MAX_RECENT_INVITES);
-          });
+          queryClient.setQueryData<InviteRecord[]>(queryKeys.recentInvites(), (previous = []) =>
+            [invite, ...previous].slice(0, MAX_RECENT_INVITES),
+          );
         });
     },
-    [fetchRecentInvites],
+    [fetchRecentInvites, queryClient],
   );
 
   return {
-    invites,
+    invites: recentInvitesQuery.data ?? [],
     lastResult,
     handleInviteResult,
   };

--- a/components/listing-form-images/ListingFormImages.tsx
+++ b/components/listing-form-images/ListingFormImages.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
 import { z } from "zod";
 
 import { ListingFormControl, ListingFormImage } from "@/app/listing-form/types";
@@ -61,8 +62,10 @@ export function ListingFormImages({
   activateDraftListing,
   prepareDraftListing,
 }: ListingFormImagesProps) {
-  const [isUploading, setIsUploading] = useState(false);
-  const [uploadError, setUploadError] = useState<string | null>(null);
+  const uploadMutation = useMutation({
+    mutationFn: async ({ file, listingId }: { file: File; listingId: string }) =>
+      uploadFile(file, listingId),
+  });
 
   const handleImageUpload = async (
     event: ChangeEvent<HTMLInputElement>,
@@ -75,15 +78,15 @@ export function ListingFormImages({
       return;
     }
 
-    setUploadError(null);
-    setIsUploading(true);
-
     try {
       const uploadedImages: ListingFormImage[] = [];
       const resolvedListingId = listingId ?? (await prepareDraftListing());
 
       for (const file of Array.from(files)) {
-        const uploadedImage = await uploadFile(file, resolvedListingId);
+        const uploadedImage = await uploadMutation.mutateAsync({
+          file,
+          listingId: resolvedListingId,
+        });
         uploadedImages.push({
           id: uploadedImage.id,
           url: uploadedImage.url,
@@ -96,12 +99,9 @@ export function ListingFormImages({
       if (!listingId) {
         activateDraftListing(resolvedListingId);
       }
-    } catch (error) {
-      setUploadError(
-        error instanceof Error ? error.message : "Unable to upload image(s). Please try again.",
-      );
+    } catch {
+      // TanStack Query stores the error for rendering beside the input.
     } finally {
-      setIsUploading(false);
       event.target.value = "";
     }
   };
@@ -127,17 +127,23 @@ export function ListingFormImages({
                   multiple
                   accept={acceptedImageTypes}
                   onChange={(event) => handleImageUpload(event, images, field.onChange)}
-                  disabled={isUploading}
+                  disabled={uploadMutation.isPending}
                 />
               </FormControl>
               <FormDescription>
-                {isUploading
+                {uploadMutation.isPending
                   ? "Uploading images..."
                   : !listingId
                     ? "Uploading an image will create a draft automatically."
                     : "You can select multiple files at once. Captions are optional."}
               </FormDescription>
-              {uploadError && <p className="text-sm text-destructive">{uploadError}</p>}
+              {uploadMutation.error && (
+                <p className="text-sm text-destructive">
+                  {uploadMutation.error instanceof Error
+                    ? uploadMutation.error.message
+                    : "Unable to upload image(s). Please try again."}
+                </p>
+              )}
 
               {images.length > 0 && (
                 <div className="space-y-4 pt-2">

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hugeicons/core-free-icons": "^4.1.1",
         "@hugeicons/react": "^1.1.6",
         "@jsquash/jxl": "^1.3.0",
+        "@tanstack/react-query": "^5.100.6",
         "@vis.gl/react-maplibre": "^8.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6507,6 +6508,32 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.6.tgz",
+      "integrity": "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.6.tgz",
+      "integrity": "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@hugeicons/core-free-icons": "^4.1.1",
     "@hugeicons/react": "^1.1.6",
     "@jsquash/jxl": "^1.3.0",
+    "@tanstack/react-query": "^5.100.6",
     "@vis.gl/react-maplibre": "^8.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add a root TanStack Query provider and shared query keys
- migrate client-side listing, listing form, admin field, invite, image upload, and my-listings API state to TanStack Query
- add cache invalidation and optimistic updates for relevant mutations

## Validation
- npm run typecheck
- npm run lint
- npm test -- --runTestsByPath app/listing-form/api.unit.test.ts app/listing-form/types.unit.test.ts app/admin/custom-listing-fields/custom-listing-fields-dashboard-utils.unit.test.ts components/listing-filter/useListingFilter.unit.test.tsx
- npm run build
- Browser Use smoke test on localhost:3100: listings filter/map/detail, listing form accessibility load and draft autosave, my-listings restore/delete, admin custom field create/update/delete, admin invite recent invites render