### PR TITLE
Add developer documentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,91 @@
 # Affordable Housing Portal
 
-Affordable Housing Portal is [Civic Tech Waterloo Region](https://github.com/CivicTechWR)'s affordable housing platform. It aims to make it easier for housing seekers to find and access listings from affordable housing providers. Many existing platforms fail to centre the needs of marginalized communities — key information is often missing, and listings can be structured in ways that discourage these communities from applying. This project seeks to address those gaps with a more accessible and equitable experience.
+Affordable Housing Portal is [Civic Tech Waterloo Region](https://github.com/CivicTechWR)'s affordable housing platform. It helps housing seekers find affordable housing listings and gives housing providers a place to publish richer, more accessible listing information.
 
-## Overview
+The app is a Next.js 16 App Router application using React 19, TypeScript, Tailwind CSS 4, shadcn/ui primitives, NextAuth credentials auth, Drizzle ORM, Postgres, and Zod-based API contracts.
 
-![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white) ![Next JS](https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white) ![Tailwind CSS](https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white)
+Current product areas include:
 
-The platform is a [Next.js](https://nextjs.org) App Router application using React 19, [Tailwind CSS](https://tailwindcss.com), [shadcn/ui](https://ui.shadcn.com) components, NextAuth credentials auth, Drizzle ORM, and Postgres.
+- signed-in listing search, map/list views, and listing detail pages
+- partner/admin listing authoring with draft autosave and image uploads
+- partner/admin "My Listings" management
+- admin account invites, account management, and custom listing fields
+- listing filters powered by admin-configured listing field definitions
 
-Current user-facing areas include:
+## Documentation
 
-- public listing search and listing detail pages
-- partner/admin listing authoring, draft autosave, image uploads, and "My Listings"
-- admin user invites and account management
-- admin-configurable custom listing fields that can drive public filters
+Start with [docs/README.md](docs/README.md). The developer reference is split by topic so new contributors can find the right level of detail quickly:
 
-## Repository Structure
-
-```
-app/                  → Pages, layouts, server actions, and API route handlers
-├── admin/            → Admin account and custom listing field pages
-├── api/
-│   ├── admin/        → Admin account, invite, and custom field endpoints
-│   ├── auth/         → NextAuth route handler
-│   ├── custom-listing-fields/
-│   ├── image-uploads/
-│   ├── listing-drafts/
-│   └── listings/     → Listing read/write endpoints
-├── listing-form/     → Create/edit listing workflow
-├── listings/         → Public listing browse/search and detail pages
-├── my-listings/      → Partner/admin listing management
-├── sign-in/          → Credentials sign-in
-└── page.tsx          → Redirects housing seekers to /listings
-
-components/           → React components
-├── ui/               → shadcn/ui primitives (button, card, input, etc.)
-├── listing-form-*    → Listing authoring form sections
-├── listing-filter*/  → Search and filter controls
-├── listings-panel/   → Listing results panel
-├── map-view/         → Map display
-├── site-header/      → Header and account menu
-└── ...               → Other shared components
-
-db/                   → Drizzle schema, client, and seed data
-drizzle/              → Generated SQL migrations and snapshots
-lib/                  → Domain services, repositories, auth, policies, utilities
-shared/               → Shared runtime schemas and TypeScript types
-test/                 → Test-only mocks and helpers
-```
-
-## Shared Schemas and Types
-
-Use `shared/schemas/*.ts` for contracts that must stay consistent across frontend and backend code.
-
-- Define request/response contracts once with `zod`.
-- Export inferred TypeScript types with `z.infer<typeof schema>`.
-- API route handlers use these schemas with `next-rest-framework` where applicable.
+- [Getting Started](docs/getting-started.md) for local setup, environment variables, database setup, and scripts
+- [Architecture](docs/architecture.md) for the App Router structure, service/repository boundaries, and feature workflow
+- [Domain Model](docs/domain-model.md) for database tables, enums, relationships, and migration rules
+- [Listings](docs/listings.md) for listing search, listing details, authoring, draft autosave, image uploads, and custom fields
+- [Auth and Admin](docs/auth-and-admin.md) for NextAuth credentials auth, invites, roles, access checks, and admin tools
+- [API Reference](docs/api-reference.md) for route handlers, schemas, endpoint behavior, and error responses
+- [Deployment and Operations](docs/deployment.md) for CI, Docker, Infisical, runtime settings, and migration expectations
+- [Testing and Quality](docs/testing-and-quality.md) for Jest, linting, formatting, hooks, and review expectations
+- [ADR 0001](docs/adr/0001-server-first-listings-data-fetching.md) for the server-first listings data decision
 
 ## Quick Start
 
-### Prerequisites
+Prerequisites:
 
-- [Node.js](https://nodejs.org/) 22.12+
-- npm, using the committed lockfile
+- Node.js 22.12 or newer
+- npm with the committed `package-lock.json`
+- a reachable Postgres database
 
-### Install Dependencies
+Install dependencies:
 
 ```bash
 npm ci
 ```
 
-### Run Locally
-
-Copy the example environment file and set values as needed:
+Create a local environment file:
 
 ```bash
 cp .env.example .env.local
 ```
 
-For a local Postgres instance, `DATABASE_URL` must point at that database. If you use the Docker Compose database from this repo, the host port is `5433` by default:
+Set `DATABASE_URL` to your local database. The committed example uses:
 
-```bash
+```env
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/affordable_housing_portal
+```
+
+If you use the Docker Compose database from this repo, set the host port to `5433`:
+
+```env
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/affordable_housing_portal
 ```
 
-Install dependencies, then run the app:
+Apply migrations and seed local development data:
+
+```bash
+npm run db:migrate
+npm run db:seed
+```
+
+Start the app:
 
 ```bash
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to view the application.
+Open [http://localhost:3000](http://localhost:3000).
 
-### Run Backend Stack with Docker
-
-This repo includes a local backend stack with:
-
-- Next.js app server (API routes + frontend)
-- Postgres database
-- Automatic DB migration + seed on container startup
+The Docker Compose workflow starts Postgres and the development app together, then runs migrations and seed data before `next dev`:
 
 ```bash
 npm run docker:up
 ```
 
-Then open [http://localhost:3000](http://localhost:3000).
-Postgres is exposed on `localhost:5433` by default (override with `POSTGRES_PORT`).
-
-Useful commands:
-
-```bash
-npm run docker:logs
-npm run docker:down
-npm run docker:down:volumes
-```
-
-## Database
-
-The app includes a Drizzle + Postgres schema for users, invites, properties, listings, listing images, saved listings, saved searches, and admin-configurable listing fields.
-
-1. Copy `.env.example` to `.env.local` or provide `DATABASE_URL` through Infisical.
-2. Generate migrations after schema changes with `npm run db:generate`.
-3. Apply migrations with `npm run db:migrate`.
-4. Inspect the schema with `npm run db:studio`.
-5. Seed local data with `npm run db:seed`.
-
-When using Docker Compose, `db:migrate` and `db:seed` are run automatically when the app container starts.
-
-If you set `ADMIN_PASSWORD`, the app enables a one-time bootstrap admin sign-in for `ADMIN_EMAIL` (default `admin@example.com`) until an admin user has a stored local password. This is intended for first-run setup and local/dev recovery from external-auth-only data.
-
 ## Transactional Email Queue
 
-Transactional emails (currently admin invites) are not sent inline. Feature code enqueues a durable [pg-boss](https://github.com/timgit/pg-boss) job in the same Postgres transaction that writes the business records, and an in-process worker is the only caller of the shared `sendEmail()` service (`lib/email.ts`). pg-boss stores jobs in its own `pgboss` schema, which it creates and migrates automatically on first start — no drizzle migration is involved.
+Transactional emails, currently admin invites, are queued durably in Postgres with pg-boss instead of being sent inline. Invite creation and job enqueueing happen in the same transaction, and the worker started from `instrumentation.ts` records whether the provider accepted the request or the job permanently failed. Provider acceptance does not confirm delivery to the recipient's mail server; delivered, bounced, failed, and suppressed webhook outcomes are not currently reconciled.
 
-- **Worker startup**: `instrumentation.ts` `register()` starts the worker, gated on `EMAIL_WORKER_ENABLED=true` in addition to the Node.js runtime check, so builds, CI, tests, and scripts never start pollers. Set `EMAIL_WORKER_ENABLED=true` wherever the long-lived server runs (it is preset in `docker-compose.yml`, and must be set in the Infisical prod environment for deployments); leave it unset everywhere else. Without it the app still enqueues jobs, but nothing sends them.
-- **Delivery semantics**: a successful request means the email is _queued_, not sent. The worker retries transient provider failures with bounded exponential backoff, honors `Retry-After` on rate limits, defers jobs ~24 hours when Resend's daily quota is exhausted, and moves permanently failing jobs to the `email_send_dead_letter` queue (monthly quota exhaustion ends up there too, after logging an error). Quota deferrals do not burn retries but are capped per logical email (`MAX_EMAIL_JOB_DEFERRALS` in `lib/email-queue/worker.ts`); a job that keeps hitting provider limits past the cap also dead-letters. The worker also works the dead letter queue: it records the permanent failure on the source entity (for invites, `emailFailedAt`), so admin invite lists distinguish `queued` (job enqueued), `submitted` (Resend accepted the API request and the worker set the legacy `sentAt` field), `failed` (job dead-lettered before provider acceptance; re-send the invite), and `not_requested` (no email asked for; the invite URL is shared manually). `submitted` does not confirm acceptance by the recipient's mail server: this app does not currently reconcile Resend's delivered, bounced, failed, or suppressed webhook events. Dead-lettered job rows stay queryable for operational follow-up.
-- **Sensitive payloads**: raw one-time tokens and invite URLs are never stored in plaintext job payloads. They are sealed with AES-256-GCM under a key derived from `AUTH_SECRET` (`lib/email-queue/email-job.ts`) and, once the logical email reaches a terminal outcome (submitted, skipped, or dead-lettered with the failure recorded), redacted from every settled job row for that email — quota-deferral ancestors, the failed source row, and dead-letter copies included. Until then, a quota-deferred job passes a copy of its still-sealed payload to the replacement job, and both rows keep it so a crash-recovered attempt can still send. Note that rotating `AUTH_SECRET` makes already-queued sealed payloads undecryptable; those jobs will dead-letter, the affected invites are marked `failed`, and they must be re-sent.
-- **Adding an email type**: extend `EmailJobData` in `lib/email-queue/email-job.ts` (entity reference + sealed secret if needed, plus a priority) and add a matching send handler and dead-letter failure-recording case in `lib/email-queue/worker.ts`. Do not add another delivery path around the queue.
+Set `EMAIL_WORKER_ENABLED=true` on the long-lived app server that should process jobs. Docker Compose enables it by default. See [Auth and Admin](docs/auth-and-admin.md) for submission behavior and [Deployment and Operations](docs/deployment.md) for worker, retry, dead-letter, and secret-rotation guidance.
 
-## Development Commands
+## Common Commands
 
 ```bash
 npm run typecheck
@@ -146,37 +93,28 @@ npm run lint
 npm run format:check
 npm test
 npm run test:unit
-npm run test:integration
+npm run build
 ```
 
-Use `npm run format` and `npm run lint:fix` for automatic formatting and lint fixes.
+Use `npm run format` and `npm run lint:fix` for mechanical fixes.
 
-## Architecture Notes
+## Repository Map
 
-- Public listing search is server-first: `app/listings/page.tsx` calls shared listing services directly for the initial render, while client-side filter refinements fetch `/api/listings`.
-- Route handlers should remain thin and delegate business logic to services under `lib/`.
-- `auth.ts` and `proxy.ts` provide broad session gating and sign-in redirects for protected routes. Page, server action, service, and API code must still enforce role-specific authorization with shared auth/session and policy helpers.
-- Keep cross-boundary contracts in `shared/schemas/` so page code, services, route handlers, and tests use the same validation rules.
+```text
+app/                  Pages, layouts, server actions, route handlers, and route-local UI
+components/           Shared React components and shadcn/ui primitives
+content/              Static content such as product verbiage
+db/                   Drizzle schema, lazy database client, and seed scripts
+drizzle/              Generated SQL migrations and Drizzle snapshots
+docs/                 Developer documentation and ADRs
+lib/                  Server-side domain services, repositories, auth, policies, and utilities
+public/               Static assets served by Next.js
+shared/schemas/       Zod schemas and inferred TypeScript contracts shared across layers
+test/                 Test-only mocks and helpers
+```
 
 ## Contributing
 
-Contributions are welcomed. This repository does not currently include separate `CONTRIBUTING.md` or `CODE_OF_CONDUCT.md` files, so use the workflow below unless project maintainers provide more specific guidance.
+Development tasks are managed through [GitHub Issues](https://github.com/CivicTechWR/accessible-housing-portal/issues).
 
-### Issue Tracking
-
-Development tasks are managed through [GitHub Issues](https://github.com/CivicTechWR/affordable-housing-portal/issues). Please feel free to submit issues even if you don't plan on implementing them yourself. Before creating an issue, check first to see if one already exists. Include as much information as possible, including screenshots where helpful.
-
-### Committing
-
-The Husky pre-commit hook runs secret scanning, `lint-staged`, and `npm run typecheck`. The pre-push hook runs `npm run build`.
-
-### Pull Requests
-
-Pull requests are opened to the `main` branch. The CI workflow currently runs:
-
-- `npm run lint`
-- `npm run format:check`
-- `npm test`
-- `npm run build`
-
-When opening a PR, include the related issue, a description of the change, and testing notes for reviewers.
+Before opening a PR, run the relevant checks and include testing notes. The pre-commit hook runs secret scanning, `lint-staged`, and `npm run typecheck`; the pre-push hook runs `npm run build`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,124 @@
+# Developer Documentation
+
+This directory is the developer reference for Affordable Housing Portal. It is written for new contributors who need to understand how the app fits together before changing code.
+
+## Start Here
+
+| Topic                                                       | Use it when                                                                                                                        |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [Getting Started](getting-started.md)                       | You need to run the app locally, configure environment variables, migrate the database, seed data, or understand scripts.          |
+| [Architecture](architecture.md)                             | You need to know where code belongs, how App Router pages call services, how API handlers are structured, or how to add a feature. |
+| [Domain Model](domain-model.md)                             | You need to understand Drizzle tables, status enums, relationships, custom fields, and migrations.                                 |
+| [Listings](listings.md)                                     | You are changing listing search, details, authoring, draft autosave, images, or dynamic listing fields.                            |
+| [Auth and Admin](auth-and-admin.md)                         | You are changing sign-in, invites, account management, role checks, protected routes, or admin custom fields.                      |
+| [API Reference](api-reference.md)                           | You need endpoint behavior, auth requirements, schema locations, or error handling conventions.                                    |
+| [Deployment and Operations](deployment.md)                  | You need CI, Docker, Infisical, runtime environment, migration, or release expectations.                                           |
+| [Testing and Quality](testing-and-quality.md)               | You need to add tests, run checks, understand hooks, or prepare a PR.                                                              |
+| [ADR 0001](adr/0001-server-first-listings-data-fetching.md) | You need the rationale for server-first listing search.                                                                            |
+
+## System At A Glance
+
+Affordable Housing Portal is a single Next.js App Router application. Pages, API routes, server actions, and route groups live under `app/`. Shared product UI lives under `components/`. Server-side domain logic lives under `lib/`. Database shape lives in `db/schema.ts`, with generated migrations under `drizzle/`.
+
+The main runtime stack is:
+
+- Next.js `16.2.6` with App Router and root-level `proxy.ts`
+- React `19.2.4`
+- TypeScript `6.0.2`
+- Tailwind CSS 4 and shadcn/ui primitives
+- NextAuth `5.0.0-beta.31` credentials provider
+- Drizzle ORM with Postgres
+- pg-boss for durable transactional email jobs
+- Zod schemas in `shared/schemas`
+- `next-rest-framework` for typed route handler contracts
+- Jest and React Testing Library for unit tests
+
+## Core Request Paths
+
+Signed-in listing search:
+
+```text
+app/listings/page.tsx
+  -> getListingsQueryFromSearchParams
+  -> getListingsService
+  -> listing specifications
+  -> listing repository
+  -> Drizzle/Postgres
+  -> ListingsDashboard client refinements
+```
+
+Client-side listing refinements:
+
+```text
+components/listing-filter/*
+  -> app/listings/useListingsQuery.ts
+  -> GET /api/listings
+  -> app/api/listings/handlers.ts
+  -> getListingsService
+```
+
+Listing authoring:
+
+```text
+app/(listing-author)/listing-form/*
+  -> app/listing-form/useListingForm.ts
+  -> POST /api/listing-drafts when a draft is needed
+  -> PUT /api/listings/:id for autosave and publish
+  -> POST /api/image-uploads for image processing
+```
+
+Admin account/custom-field management:
+
+```text
+app/(admin)/admin/*
+  -> admin React hooks or server-rendered pages
+  -> /api/admin/*
+  -> admin services
+  -> admin repositories
+```
+
+Admin invite email submission:
+
+```text
+createInvite transaction
+  -> user_invites row + pg-boss email_send job
+  -> instrumentation.ts worker
+  -> Resend
+  -> submitted or failed status
+```
+
+## Code Ownership Map
+
+| Area                  | Files                                                                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| App routes and pages  | `app/**/page.tsx`, `app/**/layout.tsx`, `app/**/loading.tsx`, `app/**/error.tsx`, `app/**/route.ts`                                                |
+| Listing services      | `lib/listings/*`, `app/listings/*`, `app/listing-form/*`, `components/listing-*`, `components/listings-*`                                          |
+| Auth and sessions     | `auth.ts`, `proxy.ts`, `lib/auth/*`, `components/auth/*`, `app/sign-in/*`, `app/invite/*`                                                          |
+| Admin accounts        | `lib/accounts/*`, `app/(admin)/admin/users/*`, `app/(admin)/admin/invite/*`, `app/api/admin/accounts*`                                             |
+| Transactional email   | `instrumentation.ts`, `lib/email.ts`, `lib/email-queue/*`, `lib/auth/invite-email.ts`                                                              |
+| Custom listing fields | `lib/custom-listing-fields/*`, `app/admin/custom-listing-fields/*`, `app/(admin)/admin/custom-listing-fields/*`, `app/api/*custom-listing-fields*` |
+| Database              | `db/schema.ts`, `db/client.ts`, `drizzle/*`, `drizzle.config.ts`, `db/seed.ts`                                                                     |
+| Shared contracts      | `shared/schemas/*`                                                                                                                                 |
+| Tests                 | `*.unit.test.ts`, `*.unit.test.tsx`, `test/mocks/*`, `jest.config.js`                                                                              |
+
+## Next.js Version Note
+
+This project uses Next.js 16, where some APIs and conventions differ from older Next.js versions. Before changing Next.js-specific code, read the relevant local guide in `node_modules/next/dist/docs/`. The most commonly relevant files are:
+
+- `node_modules/next/dist/docs/01-app/01-getting-started/02-project-structure.md`
+- `node_modules/next/dist/docs/01-app/01-getting-started/05-server-and-client-components.md`
+- `node_modules/next/dist/docs/01-app/01-getting-started/15-route-handlers.md`
+- `node_modules/next/dist/docs/01-app/01-getting-started/16-proxy.md`
+- `node_modules/next/dist/docs/01-app/02-guides/testing/jest.md`
+
+## Documentation Maintenance
+
+Update these docs when you change:
+
+- environment variables or scripts
+- route paths, request schemas, or response schemas
+- database tables, columns, enums, relationships, or migration workflow
+- authorization rules or role behavior
+- listing search, authoring, image handling, or custom-field behavior
+- CI, Docker, deployment, or runtime secret behavior
+- test setup, hooks, build requirements, or deployment expectations

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,156 @@
+# API Reference
+
+API routes live under `app/api`. Most JSON routes use `next-rest-framework` plus Zod schemas from `shared/schemas`.
+
+## API Conventions
+
+- `route.ts` declares HTTP methods, input schemas, output schemas, and possible statuses.
+- `handlers.ts` reads request data and calls a service.
+- Services return `DomainResult<T>` when domain errors are expected.
+- `mapDomainErrorToHttpResponse` maps domain errors to HTTP statuses.
+- Request and response contracts live in `shared/schemas`.
+- Protected behavior must be enforced in services or route handlers, not only in `proxy.ts`.
+
+Domain error mapping:
+
+| Domain code    | HTTP status |
+| -------------- | ----------- |
+| `unauthorized` | `401`       |
+| `forbidden`    | `403`       |
+| `not_found`    | `404`       |
+| `validation`   | `400`       |
+| `conflict`     | `409`       |
+
+Error responses use:
+
+```json
+{
+  "message": "Human-readable error"
+}
+```
+
+## Listings
+
+| Method   | Path                       | Auth                                                     | Purpose                                                 | Contract source                                      |
+| -------- | -------------------------- | -------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
+| `GET`    | `/api/listings`            | Active session; draft/archive visibility is role-limited | List listings with filters and pagination.              | `listingQuerySchema`, `listingListResponseSchema`    |
+| `POST`   | `/api/listings`            | Admin or partner                                         | Create a full listing.                                  | `createListingSchema`, `createListingResponseSchema` |
+| `GET`    | `/api/listings/:id`        | Active session; owner/admin for private                  | Get listing details.                                    | `listingParamsSchema`, `listingByIdResponseSchema`   |
+| `PUT`    | `/api/listings/:id`        | Admin or owning partner                                  | Update listing data, status, images, and custom fields. | `updateListingSchema`, `updateListingResponseSchema` |
+| `DELETE` | `/api/listings/:id`        | Admin or owning partner                                  | Archive a listing.                                      | `deleteListingResponseSchema`                        |
+| `GET`    | `/api/listings/:id/editor` | Admin or owning partner                                  | Load editor-shaped listing data.                        | `listingEditorResponseSchema`                        |
+| `POST`   | `/api/listing-drafts`      | Admin or partner                                         | Create an empty draft listing and property.             | `createDraftListingResponseSchema`                   |
+
+Listing query parameters are documented in [Listings](listings.md).
+
+Listing create/update payloads submit selected accessibility features as `accessibilityFeatures`. Each submitted feature must include the field-definition `id`; storage persists selected public boolean field definitions as boolean keys in `listings.custom_fields`.
+
+Create payloads may include `applicationUrl` as a valid HTTP(S) URL. Update payloads may include `applicationUrl` as a valid HTTP(S) URL or `null` to clear the stored URL.
+
+## Image Uploads
+
+| Method | Path                     | Auth                                                                      | Purpose                                                      |
+| ------ | ------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `POST` | `/api/image-uploads`     | Admin or partner with edit access to `listingId`                          | Upload and process an image file.                            |
+| `GET`  | `/api/image-uploads/:id` | Public if attached to a published listing; owner/admin for private images | Return binary image data or redirect to external `imageUrl`. |
+
+These routes use `runtime = "nodejs"` and direct Web `Request`/`Response` handling because they process files and buffers.
+
+Upload request:
+
+- multipart form data
+- `file`: image file
+- `listingId`: UUID
+
+Upload success response:
+
+```json
+{
+  "message": "Image upload successful",
+  "data": {
+    "id": "uuid",
+    "url": "/api/image-uploads/uuid",
+    "width": 1200,
+    "height": 800,
+    "fileName": "photo.jpg",
+    "fileType": "image/jpeg",
+    "fileSize": 123456
+  }
+}
+```
+
+## Public Custom Listing Fields
+
+| Method | Path                         | Auth   | Purpose                                                | Contract source                                                         |
+| ------ | ---------------------------- | ------ | ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `GET`  | `/api/custom-listing-fields` | Public | List public custom listing fields grouped by category. | `customListingFieldQuerySchema`, `customListingFieldListResponseSchema` |
+
+Supported query parameters:
+
+- `publicOnly`
+- `filterableOnly`
+- `category`
+- `groupId`
+- `type`
+
+The public service always starts from `is_public = true`; `publicOnly` is present for contract symmetry but does not expose private definitions.
+
+## Admin Custom Listing Fields
+
+| Method   | Path                                       | Auth  | Purpose                           | Contract source                                                                   |
+| -------- | ------------------------------------------ | ----- | --------------------------------- | --------------------------------------------------------------------------------- |
+| `GET`    | `/api/admin/custom-listing-fields`         | Admin | List admin field definitions.     | `adminCustomListingFieldQuerySchema`, `adminCustomListingFieldListResponseSchema` |
+| `POST`   | `/api/admin/custom-listing-fields`         | Admin | Create a field definition.        | `createCustomListingFieldSchema`, `createCustomListingFieldResponseSchema`        |
+| `GET`    | `/api/admin/custom-listing-fields/:id`     | Admin | Get one field definition.         | `customListingFieldByIdResponseSchema`                                            |
+| `PUT`    | `/api/admin/custom-listing-fields/:id`     | Admin | Update a field definition.        | `updateCustomListingFieldSchema`, `updateCustomListingFieldResponseSchema`        |
+| `DELETE` | `/api/admin/custom-listing-fields/:id`     | Admin | Delete a field definition.        | `deleteCustomListingFieldResponseSchema`                                          |
+| `PUT`    | `/api/admin/custom-listing-fields/reorder` | Admin | Reorder all fields in a category. | `reorderCustomListingFieldsSchema`, `reorderCustomListingFieldsResponseSchema`    |
+
+Create/update conflict behavior:
+
+- duplicate `key` returns `409`
+- missing target returns `404`
+- invalid mutation returns `400`
+
+Reorder requires the request to include every field in the target category exactly once and to use contiguous sort orders.
+
+## Admin Accounts
+
+| Method   | Path                         | Auth  | Purpose                                                          | Contract source                                               |
+| -------- | ---------------------------- | ----- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
+| `GET`    | `/api/admin/accounts`        | Admin | List accounts with pagination and filters.                       | `accountQuerySchema`, `accountListResponseSchema`             |
+| `POST`   | `/api/admin/accounts`        | Admin | Invite/create an account.                                        | `createAccountInviteSchema`, `createAccountResponseSchema`    |
+| `GET`    | `/api/admin/accounts/:id`    | Admin | Get one account.                                                 | `accountByIdResponseSchema`                                   |
+| `PUT`    | `/api/admin/accounts/:id`    | Admin | Update account fields.                                           | `updateAccountSchema`, `updateAccountResponseSchema`          |
+| `DELETE` | `/api/admin/accounts/:id`    | Admin | Deactivate an account.                                           | `deactivateAccountResponseSchema`                             |
+| `GET`    | `/api/admin/account-invites` | Admin | List recent unaccepted, unexpired invites and submission status. | `accountInviteQuerySchema`, `accountInviteListResponseSchema` |
+
+Account list query parameters:
+
+- `page`
+- `limit`
+- `role`
+- `status`
+- `search`
+
+Account safety conflicts return `409`, such as trying to remove your own admin access or deactivate yourself.
+
+Creating an account with `sendInviteEmail: true` returns success after the email job is queued, not after provider acceptance. Invite-list records expose `status` as `not_requested`, `queued`, `submitted`, or `failed`; queued, failed, and manually shared invites are no longer hidden from the list. `submitted` means Resend accepted the API request, not that the recipient's mail server confirmed delivery.
+
+## Auth
+
+| Method       | Path                      | Auth             | Purpose                              |
+| ------------ | ------------------------- | ---------------- | ------------------------------------ |
+| `GET`/`POST` | `/api/auth/[...nextauth]` | NextAuth-managed | NextAuth credentials/session routes. |
+
+Interactive sign-in uses the server action in `app/sign-in/actions.ts`; invite acceptance uses the server action in `app/invite/actions.ts`.
+
+## Adding Or Changing An Endpoint
+
+1. Add or update schemas in `shared/schemas`.
+2. Update `route.ts` inputs and outputs.
+3. Keep `handlers.ts` focused on request/response mechanics.
+4. Put business rules in a service under `lib`.
+5. Put queries/transactions in a repository under `lib`.
+6. Add tests for schemas, policies, specifications, or service helpers where risk justifies it.
+7. Update this document.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,192 @@
+# Architecture
+
+This app is a Next.js 16 App Router project. Next.js 16 renamed Middleware to Proxy and has App Router conventions that differ from older versions, so use the installed docs in `node_modules/next/dist/docs/` as the source of truth before changing framework-specific code.
+
+## High-Level Shape
+
+```text
+Browser
+  -> App Router page/layout/client component
+  -> optional server action or API route handler
+  -> Zod schema validation
+  -> domain service
+  -> repository/specification helpers
+  -> Drizzle ORM
+  -> Postgres
+```
+
+The project keeps HTTP, UI, business rules, persistence, and shared contracts in distinct layers.
+
+Transactional email follows an asynchronous path:
+
+```text
+invite service transaction
+  -> application records + pg-boss job
+  -> instrumentation.ts worker
+  -> shared email service
+  -> Resend
+  -> submitted or failed application state
+```
+
+Enqueueing the job in the same Postgres transaction as the invite prevents a committed invite from losing its email job. The worker, rather than request-handling code, is the only provider-submission path.
+
+| Layer                    | Owns                                                     | Examples                                                                           |
+| ------------------------ | -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| App Router pages/layouts | URL structure, server rendering, route-level access UI   | `app/listings/page.tsx`, `app/(admin)/admin/layout.tsx`                            |
+| Client components/hooks  | Browser interactivity, forms, query state, optimistic UX | `app/listings/listings.tsx`, `app/listing-form/useListingForm.ts`                  |
+| Route handlers           | HTTP method binding, request parsing, response status    | `app/api/listings/route.ts`, `app/api/listings/handlers.ts`                        |
+| Shared schemas           | Runtime validation and inferred TypeScript contracts     | `shared/schemas/listings.ts`, `shared/schemas/account-management.ts`               |
+| Services                 | Use cases, authorization checks, domain composition      | `lib/listings/listing.service.ts`, `lib/accounts/account.service.ts`               |
+| Repositories             | Drizzle queries and transactions                         | `lib/listings/listing.repository.ts`, `lib/accounts/account.repository.ts`         |
+| Specifications           | Reusable query predicates                                | `lib/listings/listing.specifications.ts`, `lib/accounts/account.specifications.ts` |
+| Policies                 | Role and ownership decisions                             | `lib/policies/listing-policy.ts`, `lib/policies/account-policy.ts`                 |
+| Database schema          | Tables, enums, indexes, inferred row types               | `db/schema.ts`                                                                     |
+| Background email worker  | Durable enqueueing, retry and provider-submission state  | `instrumentation.ts`, `lib/email-queue/*`                                          |
+
+## App Router Conventions
+
+Top-level routing code lives in `app/`.
+
+- `page.tsx` exposes a route.
+- `layout.tsx` wraps a route segment and its children.
+- `loading.tsx`, `error.tsx`, and `not-found.tsx` provide segment-level states.
+- `route.ts` exposes an API Route Handler.
+- Route groups such as `(admin)` and `(listing-author)` organize code without changing the URL.
+
+Examples:
+
+| File                                              | URL                 |
+| ------------------------------------------------- | ------------------- |
+| `app/page.tsx`                                    | `/`                 |
+| `app/listings/page.tsx`                           | `/listings`         |
+| `app/listings/[id]/page.tsx`                      | `/listings/:id`     |
+| `app/(listing-author)/listing-form/page.tsx`      | `/listing-form`     |
+| `app/(listing-author)/listing-form/[id]/page.tsx` | `/listing-form/:id` |
+| `app/(admin)/admin/users/page.tsx`                | `/admin/users`      |
+| `app/api/listings/route.ts`                       | `/api/listings`     |
+
+Components are Server Components by default. Add `"use client"` only for components that need browser APIs, event handlers, local state, React Hook Form, React Query, or `useEffect`.
+
+## Server-First Listings
+
+The listings page follows [ADR 0001](adr/0001-server-first-listings-data-fetching.md). Initial listing data is loaded on the server:
+
+```text
+app/listings/page.tsx
+  -> getListingsService(query)
+  -> findListingSummaries(...)
+```
+
+After hydration, browser-driven filter changes use React Query through `/api/listings`. The API handler calls the same `getListingsService`, so server render and client refetches share filtering and visibility rules. Listing pages and listing APIs require an active session at the proxy layer; service policy still decides whether draft and archived listings are visible to the actor.
+
+## Route Handler Pattern
+
+Most API routes use `next-rest-framework`:
+
+```text
+route.ts
+  -> declares methods, input schemas, output schemas, statuses
+handlers.ts
+  -> reads request data
+  -> calls service
+  -> maps DomainResult errors
+service.ts
+  -> owns business behavior
+```
+
+Keep route handlers thin. Do not put Drizzle queries or business rules directly in handlers.
+
+Binary image upload routes are the exception. They use direct `Request`/`Response` handlers with `runtime = "nodejs"` because they process multipart files and image buffers.
+
+## Service And Repository Boundary
+
+Services answer use-case questions:
+
+- Can this actor do this?
+- Which repository operations need to happen together?
+- How should domain errors be represented?
+- How should persisted data map to response contracts?
+
+Repositories answer persistence questions:
+
+- What tables are queried?
+- Which joins, filters, sort orders, and transactions are needed?
+- What fields are selected or updated?
+
+Specifications keep reusable Drizzle predicates out of services so filters stay testable and composable.
+
+## Shared Contracts
+
+Use `shared/schemas/*.ts` for data crossing a boundary:
+
+- API query parameters
+- API request bodies
+- API response bodies
+- form payloads that map to API payloads
+- route params
+
+Pattern:
+
+```ts
+export const exampleSchema = z.object({ ... })
+export type Example = z.infer<typeof exampleSchema>
+```
+
+When an endpoint changes, update the schema first, then route outputs, handlers, services, UI callers, tests, and documentation.
+
+## Auth And Authorization
+
+Auth is deliberately layered:
+
+- `auth.ts` configures NextAuth credentials, JWT session state, and broad authorization.
+- `proxy.ts` exports the NextAuth proxy so protected requests can be redirected or rejected early.
+- Route-group layouts such as `app/(admin)/admin/layout.tsx` and `app/(listing-author)/layout.tsx` enforce route-level UI access.
+- API handlers and services call `requireAdminSession`, `requireListingWriteSession`, or `getOptionalSession` as needed.
+- Policies in `lib/policies/*` make role and ownership decisions.
+
+The proxy is not the only authorization layer. Any page, server action, service, or API endpoint that exposes protected behavior must enforce its own role-specific rules.
+
+Current proxy-level protected route families are `/admin`, `/listings`, `/listing-form`, `/my-listings`, `/api/admin`, and `/api/listings`.
+
+## Client State
+
+The root layout wraps the app in `QueryProvider`, which creates a TanStack Query client with:
+
+- `refetchOnWindowFocus: false`
+- `retry: 1`
+- `staleTime: 30_000`
+
+Current listing filters use `nuqs` to keep query state URL-driven. React Query handles browser refetches after the initial server render.
+
+## Database Client
+
+`db/client.ts` exports `db` as a lazy proxy around Drizzle and `postgres`. This avoids opening a database connection at module import time and keeps Next build-time module evaluation safer.
+
+If you add another server SDK or database client, use a lazy getter or proxy pattern rather than initializing it at module scope.
+
+The email queue follows the same principle. `lib/email-queue/queue.ts` lazily starts and caches a process-wide pg-boss instance. `instrumentation.ts` starts its workers only in the Node.js runtime when `EMAIL_WORKER_ENABLED=true`, so builds, tests, scripts, and non-worker processes do not start pollers.
+
+## Adding A Feature
+
+Use this workflow for most product changes:
+
+1. Identify the domain area and current owner files.
+2. Add or update Zod schemas in `shared/schemas` for any changed boundary contract.
+3. Update `db/schema.ts` and generate a migration if persistence changes.
+4. Add repository methods for new queries or transactions.
+5. Add service methods for business rules and authorization.
+6. Add or update route handlers if the behavior is exposed over HTTP.
+7. Add or update pages, components, hooks, or server actions.
+8. Add focused tests for pure logic, schemas, policies, specifications, and risky mappings.
+9. Update docs when behavior, setup, routes, schemas, or data model change.
+
+## Common Pitfalls
+
+- Putting queries directly in components or route handlers instead of repositories.
+- Duplicating validation outside `shared/schemas`.
+- Trusting `proxy.ts` as the only authorization check.
+- Importing server-only modules into Client Components.
+- Initializing Postgres, Resend, or other server clients at module scope.
+- Submitting transactional email outside the durable queue worker.
+- Changing `db/schema.ts` without generating a migration.
+- Adding listing fields without deciding whether they belong in normalized columns, `customFields`, or `listing_field_definitions`.

--- a/docs/auth-and-admin.md
+++ b/docs/auth-and-admin.md
@@ -1,0 +1,185 @@
+# Auth And Admin
+
+This guide covers sign-in, sessions, invites, roles, protected routes, account management, and admin custom listing fields.
+
+## Main Files
+
+| Area                  | Files                                                                                                                      |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| NextAuth setup        | `auth.ts`, `app/api/auth/[...nextauth]/route.ts`                                                                           |
+| Proxy                 | `proxy.ts`, `lib/auth/route-policy.ts`                                                                                     |
+| Session helpers       | `lib/auth/session.ts`                                                                                                      |
+| Credentials and users | `lib/auth/user-store.ts`, `lib/auth/password.ts`, `lib/auth/validation.ts`                                                 |
+| Invites               | `lib/auth/invite-service.ts`, `lib/auth/invite-store.ts`, `app/invite/actions.ts`                                          |
+| Account admin         | `lib/accounts/*`, `app/api/admin/accounts/*`, `app/(admin)/admin/users/page.tsx`                                           |
+| Email queue           | `instrumentation.ts`, `lib/email-queue/*`, `lib/email.ts`, `lib/auth/invite-email.ts`                                      |
+| Custom field admin    | `lib/custom-listing-fields/*`, `app/api/admin/custom-listing-fields/*`, `app/(admin)/admin/custom-listing-fields/page.tsx` |
+| Policies              | `lib/policies/account-policy.ts`, `lib/policies/listing-policy.ts`                                                         |
+
+## Roles
+
+| Role      | Current capabilities                                                                                        |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
+| `admin`   | Manage users, manage custom listing fields, create/edit/archive listings, view all draft/archived listings. |
+| `partner` | Create/edit/archive own listings, use "My Listings", view own drafts/archives.                              |
+| `user`    | View signed-in listing search and published listing details. Cannot write listings or access admin areas.   |
+
+## User Statuses
+
+| Status        | Meaning                                                          |
+| ------------- | ---------------------------------------------------------------- |
+| `invited`     | Account exists but invite has not been accepted. Cannot sign in. |
+| `active`      | Account can sign in.                                             |
+| `suspended`   | Account cannot sign in.                                          |
+| `deactivated` | Account cannot sign in.                                          |
+
+`isUserAllowedToSignIn` currently allows only `active`.
+
+## Sign-In Flow
+
+Credentials sign-in is configured in `auth.ts`.
+
+```text
+sign-in form
+  -> signInWithPassword server action
+  -> NextAuth credentials provider
+  -> getUserForAuth(email)
+  -> optional ensureBootstrapAdmin(email, password)
+  -> verifyPassword
+  -> recordSuccessfulLogin
+  -> JWT session with role/status
+```
+
+The session callback adds `id`, `role`, and `status` to `session.user`. Type augmentation is in `types/next-auth.d.ts`.
+
+## Bootstrap Admin
+
+If `ADMIN_PASSWORD` is set, the credentials provider can create or update a bootstrap admin account when signing in with:
+
+- `ADMIN_EMAIL`, defaulting to `admin@example.com`
+- `ADMIN_PASSWORD`
+
+This works only while no admin user already has a stored password hash. It is intended for first-run setup and local/development recovery.
+
+## Invites
+
+Admins create invites through `createAccountService`, which delegates to `createInvite`.
+
+Invite behavior:
+
+- email is normalized to lowercase
+- existing user records are reused by email
+- new user records start with status `invited`
+- invite tokens are opaque and stored only as hashes
+- unaccepted active invites for the same user are expired when a new invite is created
+- invite URLs are generated from `NEXT_PUBLIC_APP_URL`, then `AUTH_URL`, then `http://localhost:3000`
+- when email is requested, the invite and its pg-boss job are written in the same transaction
+- successful invite creation means the email is queued, not submitted
+- the worker requires `EMAIL_WORKER_ENABLED=true`, `RESEND_API_KEY`, and `EMAIL_FROM`
+- admin lists derive `queued`, `submitted`, `failed`, or `not_requested` from persisted queue timestamps; `submitted` means provider acceptance, not confirmed recipient-server delivery
+
+Invite acceptance:
+
+```text
+/invite?token=...
+  -> acceptInviteAction
+  -> validate token and password
+  -> getPendingInviteByToken
+  -> hashPassword
+  -> acceptInvite transaction
+  -> sign in with credentials
+  -> redirect("/")
+```
+
+Password rules:
+
+- 8 to 72 characters
+- at least one letter
+- at least one number
+- confirmation must match
+
+## Protected Routes
+
+`proxy.ts` exports NextAuth's `auth` as the Next.js proxy. `lib/auth/route-policy.ts` decides which requests require an auth session:
+
+- pages under `/admin`
+- pages under `/listings`
+- pages under `/listing-form`
+- pages under `/my-listings`
+- APIs under `/api/admin`
+- all APIs under `/api/listings`
+
+This is a broad gate, not the complete authorization model. Route layouts, server actions, API handlers, and services still enforce role-specific behavior.
+
+Route-group layouts add user-facing protection:
+
+- `app/(admin)/admin/layout.tsx` requires an active admin.
+- `app/(listing-author)/layout.tsx` requires an active admin or partner.
+
+API/session helpers:
+
+- `getOptionalSession` returns a valid active session/user pair when available.
+- `requireSession` returns a `401` response when no active session exists.
+- `requireAdminSession` returns `403` for non-admins.
+- `requireListingWriteSession` returns `403` for non-admin/non-partner users.
+
+## Account Admin
+
+Admins manage accounts through `/admin/users` and `/api/admin/accounts`.
+
+Current behavior:
+
+- list accounts with role, status, and search filters
+- invite an account
+- inspect one account
+- update name, role, status, and organization
+- deactivate an account
+- list recent unaccepted, unexpired invites, including queued, submitted, failed, and manually shared invites
+
+Safety rules in `account-policy.ts`:
+
+- only admins can manage accounts
+- admins cannot remove their own admin access
+- users cannot deactivate their own account through the admin API
+
+## Custom Listing Field Admin
+
+Admins manage dynamic listing fields through `/admin/custom-listing-fields` and `/api/admin/custom-listing-fields`.
+
+Field definition behavior:
+
+- `key` is unique and should be treated as stable once listings use it.
+- `category` is normalized to uppercase in admin services.
+- `publicOnly` maps to `is_public`.
+- `filterableOnly` maps to `is_filterable`.
+- `required` maps to `is_required`.
+- `options` stores select/multi-select choices.
+- reorder requires every field in a category exactly once with contiguous sort order.
+
+Listing filters currently use public, filterable, boolean field definitions.
+
+## Email
+
+Email is intentionally isolated and asynchronous:
+
+- `createInvite` writes the invite and enqueues an `email_send` pg-boss job in one transaction.
+- `instrumentation.ts` starts the worker only in the Node.js runtime when `EMAIL_WORKER_ENABLED=true`.
+- `lib/email-queue/worker.ts` is the only provider-submission path and calls the shared service in `lib/email.ts`.
+- transient provider failures retry with bounded exponential backoff; rate limits and daily quota exhaustion can defer submission.
+- permanently failing jobs move to `email_send_dead_letter`, and the worker records `email_failed_at` for the invite.
+- provider acceptance records the legacy `sent_at` field; no requested email leaves `email_queued_at` unset and produces `not_requested`.
+
+Job payloads identify the invite without storing recipient details in the queue. The one-time invite URL is sealed with AES-256-GCM under a key derived from `AUTH_SECRET` and redacted after a terminal outcome. Rotating `AUTH_SECRET` while jobs are queued makes their sealed URLs unreadable and causes those jobs to fail.
+
+Do not create Resend clients in UI or route handlers or add another provider-submission path around the queue. New email types must extend the job contract and both the send and dead-letter handlers.
+
+## Adding Protected Behavior
+
+When adding a protected feature:
+
+1. Decide which roles can access it.
+2. Add or reuse a policy function in `lib/policies`.
+3. Gate route UI with a layout or page-level server check when needed.
+4. Gate API/services with session helpers and policy checks.
+5. Return `401` for no session, `403` for wrong role, and `404` when hiding private resource existence is intentional.
+6. Add tests for the policy or route-policy behavior when the rule is non-trivial.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,150 @@
+# Deployment And Operations
+
+This project currently has CI, a production-oriented Dockerfile, a local development Docker Compose stack, a development Dockerfile, and Infisical-backed secret commands. There is no documented one-command production deployment in the repository, so treat this file as the operational reference for what the repo itself defines.
+
+## CI
+
+GitHub Actions workflow: `.github/workflows/ci.yml`.
+
+Triggers:
+
+- pull requests targeting `main`
+- pushes to `main`
+- pushes to `rewrite`
+- manual workflow dispatch
+
+Jobs:
+
+| Job                   | Commands                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| Supply Chain Lockfile | `npm ci`, `npm run lockfile:check`, `git diff --exit-code -- package.json package-lock.json` |
+| Lint                  | `npm ci`, `npm run lint`                                                                     |
+| Format Check          | `npm ci`, `npm run format:check`                                                             |
+| Tests                 | `npm ci`, `npm run test`                                                                     |
+| Build                 | `npm ci`, `npm run build`                                                                    |
+
+CI uses Node 22 with npm cache enabled.
+
+## Dockerfile
+
+`Dockerfile` is production-oriented:
+
+1. Starts from `node:22.14.0-slim`.
+2. Installs `openssl`, `curl`, `bash`, `ca-certificates`, and Infisical CLI.
+3. Runs `npm ci`.
+4. Copies the repository.
+5. Runs `npm run build`.
+6. Sets `NODE_ENV=production` and `PORT=3100`.
+7. Starts through `infisical run --env=prod --projectId=2980a086-4367-4a1a-aafd-d1f5d4879253`.
+
+The container command runs:
+
+```bash
+npm run start -- --hostname 0.0.0.0 --port ${PORT}
+```
+
+## Docker Compose
+
+`docker-compose.yml` is a local development stack. It currently defines:
+
+- `db`, a `postgres:16-alpine` container named `ahp-db`
+- `app`, a Next.js development container named `ahp-app`
+
+The database service:
+
+- creates the `affordable_housing_portal` database
+- uses `postgres` / `postgres` local credentials
+- exposes `${POSTGRES_PORT:-5433}:5432`
+- stores data in the `ahp-postgres-data` volume
+- includes a `pg_isready` healthcheck
+
+The app service:
+
+- builds from `Dockerfile.dev`
+- waits for the database healthcheck
+- mounts the repository into `/app`
+- exposes `3000:3000`
+- sets development defaults for auth, app URL, bootstrap admin, and email variables
+- sets `EMAIL_WORKER_ENABLED=true` so the development server processes queued email
+- runs `npm run db:migrate && npm run db:seed && npm run dev -- --hostname 0.0.0.0 --port 3000`
+
+Commands:
+
+```bash
+npm run docker:up
+npm run docker:logs
+npm run docker:down
+npm run docker:down:volumes
+```
+
+## Development Dockerfile
+
+`Dockerfile.dev` is a development image:
+
+- starts from `node:22.14.0-slim`
+- runs `npm ci`
+- copies the repo
+- exposes port 3000
+- runs `npm run dev -- --hostname 0.0.0.0 --port 3000`
+
+The Docker Compose `app` service builds from `Dockerfile.dev` and overrides its default command to run migrations and seeds before `next dev`.
+
+## Runtime Environment
+
+Production runtime needs the same app-level variables described in [Getting Started](getting-started.md), usually supplied by Infisical:
+
+- `DATABASE_URL`
+- `AUTH_SECRET`
+- `NEXT_PUBLIC_APP_URL` and/or `AUTH_URL`
+- `RESEND_API_KEY` and `EMAIL_FROM` on a worker that submits invite emails
+- `EMAIL_WORKER_ENABLED=true` on the long-lived server that should process queued email
+- `AUTH_TRUST_HOST=true` when running behind a trusted proxy/container host
+- optional `ADMIN_EMAIL` and `ADMIN_PASSWORD` only for bootstrap/recovery workflows
+
+The local Docker Compose stack does not require `INFISICAL_TOKEN`; it uses development defaults and the Compose database URL. The production Dockerfile command still requires Infisical access.
+
+## Migrations
+
+The production Docker image does not automatically run migrations. Apply migrations explicitly before or during release with the environment pointed at the target database.
+
+The local Docker Compose app service does run migrations and seeds on startup against the Compose Postgres service.
+
+Available commands:
+
+```bash
+npm run db:migrate
+npm run db:migrate:secrets
+```
+
+Use `db:migrate:secrets` when Infisical `dev` secrets are the intended target. For production, verify the Infisical environment and database target before running migrations.
+
+The `user_invites.email_queued_at` and `email_failed_at` columns are managed through the committed Drizzle migration. pg-boss separately creates and migrates its own `pgboss` schema when the queue starts; do not generate a Drizzle migration for that schema.
+
+## Transactional Email Worker
+
+`instrumentation.ts` starts the in-process pg-boss worker only in the Node.js runtime and only when `EMAIL_WORKER_ENABLED=true`. Enable it on the long-lived application server. If every process leaves the variable unset, requests can still enqueue jobs but no process will submit them to the provider.
+
+The worker retries transient provider failures with bounded exponential backoff, honors `Retry-After`, and defers daily quota failures without consuming retries. Permanent failures and exhausted retry/deferral chains enter `email_send_dead_letter`; the dead-letter worker records the failure on the source invite so the admin UI can surface it.
+
+Monitor server logs for `[email-queue]` errors and inspect the pg-boss queues when invites remain queued. Treat `AUTH_SECRET` rotation as an operational migration: queued invite URLs are encrypted with a derived key, so drain or replace outstanding jobs before rotating it.
+
+## Build-Safe Server Code
+
+`next build` evaluates modules. Server clients that require runtime secrets should be lazily initialized. The database client already follows this pattern in `db/client.ts`.
+
+When adding new server integrations:
+
+- do not create SDK clients at module scope if they require environment variables
+- expose a getter or lazy proxy
+- fail with a clear error only when the integration is actually used
+- keep integration code in server-only modules
+
+## Release Checklist
+
+1. CI is green.
+2. Database migrations are reviewed and applied to the target database.
+3. Required secrets, including `EMAIL_WORKER_ENABLED=true` on the worker process, exist in the target Infisical environment.
+4. `NEXT_PUBLIC_APP_URL`/`AUTH_URL` match the public deployment URL.
+5. Invite email settings are valid and the worker starts successfully if account invites will send email.
+6. The container is started with the intended `PORT`.
+7. Smoke test sign-in, listing search, listing detail, admin access, image retrieval, and invite submission status from queued to submitted or failed.

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -1,0 +1,174 @@
+# Domain Model
+
+The database schema is defined in `db/schema.ts` with Drizzle. SQL migrations and snapshots live under `drizzle/`.
+
+## Enums
+
+| Enum                    | Values                                                        | Used by                                               |
+| ----------------------- | ------------------------------------------------------------- | ----------------------------------------------------- |
+| `user_role`             | `admin`, `partner`, `user`                                    | Access control and UI navigation.                     |
+| `user_status`           | `invited`, `active`, `suspended`, `deactivated`               | Sign-in eligibility and account lifecycle.            |
+| `listing_status`        | `draft`, `published`, `archived`                              | Listing visibility, authoring, and deletion behavior. |
+| `listing_building_type` | `apartment`, `house`, `townhouse`, `condo`                    | Built-in listing building type values.                |
+| `utility_included`      | `heat`, `water`, `electricity`, `gas`, `internet`             | Built-in listing utility inclusion values.            |
+| `listing_field_type`    | `boolean`, `number`, `text`, `select`, `multi_select`, `date` | Admin-configured listing field definitions.           |
+
+Only users with status `active` can sign in.
+
+## Tables
+
+### `users`
+
+Stores local account records.
+
+Important fields:
+
+- `email` has a case-insensitive unique index through `lower(email)`.
+- `external_auth_id` is unique but currently optional.
+- `password_hash` is present for local credentials users.
+- `role` controls admin, partner, and normal user behavior.
+- `status` controls sign-in eligibility.
+- `invite_accepted_at` and `last_login_at` support invite and audit workflows.
+
+### `user_invites`
+
+Stores account invite tokens by hash.
+
+Important behavior:
+
+- Raw invite tokens are not stored. `lib/auth/token.ts` creates opaque tokens and hashes them.
+- New invites expire previous unaccepted invites for the same user.
+- Invites expire after seven days.
+- Accepting an invite marks the invite accepted and activates the user with a password hash.
+- `email_queued_at` records that provider submission was requested and durably enqueued.
+- the worker sets the legacy `sent_at` field after the provider accepts the request or `email_failed_at` after permanent queue failure.
+- those timestamps derive the admin-facing states `not_requested`, `queued`, `submitted`, and `failed`; recipient-server delivery is not currently tracked.
+
+pg-boss stores email jobs in its own `pgboss` schema, outside the Drizzle-managed application schema. Queue payloads reference the invite rather than duplicating recipient details. The one-time invite URL is encrypted under a key derived from `AUTH_SECRET` while queued and redacted after a terminal outcome.
+
+### `properties`
+
+Stores building/property-level data for listings.
+
+Important fields:
+
+- `owner_user_id` links a property to a partner/admin account.
+- address, neighborhood, latitude, and longitude drive listing display and map behavior.
+- contact fields feed listing details and application contact data.
+- `created_by_user_id` and `updated_by_user_id` retain audit context.
+
+### `listings`
+
+Stores the primary listing row.
+
+Important fields:
+
+- `property_id` links to `properties`.
+- `status` controls visibility.
+- common searchable fields such as bedrooms, bathrooms, rent, availability, and square footage are normalized columns.
+- `unit_number`, `building_type`, `lease_term_months`, `utilities_included`, and `application_url` are built-in listing columns.
+- `monthly_rent_cents` and `max_income_cents` store money as integer cents.
+- `custom_fields` stores dynamic feature state in JSONB.
+- `published_at` and `archived_at` capture status transitions.
+
+The `custom_fields` column has a GIN index because listing filters can query dynamic boolean field keys.
+
+### `listing_images`
+
+Stores uploaded listing images and external image references.
+
+Important behavior:
+
+- Uploaded files are processed to JPEG and stored in `image_data`.
+- Seeded or external images can use `image_url`.
+- Images may be attached to a listing or temporarily associated with the uploading user before publish.
+- `sort_order` controls display order.
+
+### `saved_listings`
+
+Stores many-to-many saved listing records between users and listings. Current code defines the table but the main saved-listing product flow is not yet a primary user-facing area.
+
+### `saved_searches`
+
+Stores named search filters as JSONB per user. Current code defines the table for future saved-search behavior.
+
+### `listing_field_definitions`
+
+Stores admin-configured custom listing field definitions.
+
+Important fields:
+
+- `key` is unique and becomes the stable field identifier in listing `custom_fields`.
+- `label`, `description`, `help_text`, and `placeholder` drive UI display.
+- `field_type` describes expected value shape.
+- `category` groups fields for display and reordering.
+- `is_public` controls whether the field is visible outside admin surfaces.
+- `is_filterable` controls whether it can be used as a public filter.
+- `is_required` is available for validation/UI policy.
+- `sort_order` orders fields inside a category.
+- `options` stores selectable values for select-style fields.
+
+Admin services normalize categories to uppercase when creating or updating definitions.
+
+## Relationships
+
+```text
+users
+  -> user_invites.created_by_user_id
+  -> properties.owner_user_id
+  -> properties.created_by_user_id / updated_by_user_id
+  -> listings.created_by_user_id / updated_by_user_id
+  -> listing_images.uploaded_by_user_id
+  -> saved_listings.user_id
+  -> saved_searches.user_id
+  -> listing_field_definitions.created_by_user_id / updated_by_user_id
+
+properties
+  -> listings.property_id
+
+listings
+  -> listing_images.listing_id
+  -> saved_listings.listing_id
+```
+
+Deletion behavior:
+
+- Deleting a user cascades invites, listing image upload ownership, saved listings, and saved searches where configured.
+- Properties and listings use restrictive ownership references because listing records should not silently disappear when an owner changes.
+- Deleting a listing cascades listing images and saved listing rows.
+- "Deleting" a listing through product behavior archives it rather than removing the row.
+
+## `custom_fields` JSON
+
+Listing authoring stores selected admin-configured accessibility features in `listings.custom_fields`. Current authoring writes boolean keys that match `listing_field_definitions.key`; a selected feature is stored as `custom_fields[definition.key] = true`.
+
+Built-in values such as units, rent, bedrooms, bathrooms, building type, lease term, utilities, application URL, and contact data are stored in normalized listing/property columns. Use normalized columns when a field must be frequently filtered, sorted, joined, or constrained. Use `custom_fields` for project-configurable feature metadata that can vary by listing field definitions.
+
+## Money And Dates
+
+- Rent and income values are persisted as cents.
+- Form/API values often use dollar amounts and are converted in `lib/listings/store.ts` or `lib/listings/listing.service.ts`.
+- Listing availability uses a Postgres `date` column and ISO date strings at schema boundaries.
+- User/account timestamps use timezone-aware Postgres timestamps.
+
+## Migrations
+
+When changing persistence:
+
+1. Update `db/schema.ts`.
+2. Generate a migration with `npm run db:generate`.
+3. Review the generated SQL under `drizzle/`.
+4. Apply it locally with `npm run db:migrate`.
+5. Update seed data if the change affects local setup.
+6. Update this document when tables, enums, relationships, or conventions change.
+
+Do not hand-edit Drizzle snapshot files unless you are repairing a migration state issue and understand the impact.
+
+## Seeds
+
+`db/seed.ts` is idempotent for the current seed records. It upserts custom listing field definitions, mock users, properties, listings, and listing image references.
+
+Seed data comes from:
+
+- `db/seeds/custom-listing-fields.ts`
+- `db/seeds/mock-listings.ts`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,165 @@
+# Getting Started
+
+This guide covers local setup, environment variables, database setup, scripts, and common troubleshooting.
+
+## Prerequisites
+
+- Node.js `22.12.0` or newer. The project currently builds its production image from `node:22.14.0-slim`.
+- npm. Use the committed `package-lock.json` with `npm ci`.
+- Postgres. Local development expects a reachable database through `DATABASE_URL`.
+- Optional: Infisical for deployed/prod-like secrets.
+- Optional: Resend credentials if you want the email worker to submit invite emails.
+
+## Install Dependencies
+
+```bash
+npm ci
+```
+
+Do not use `npm install` for routine setup unless you intentionally need to update dependencies and the lockfile.
+
+## Environment Variables
+
+Create a local env file:
+
+```bash
+cp .env.example .env.local
+```
+
+Variables used by the app:
+
+| Variable               | Required                    | Used by                                 | Notes                                                                               |
+| ---------------------- | --------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------- |
+| `DATABASE_URL`         | Yes                         | Drizzle, app services, migrations, seed | Must point at Postgres. `drizzle.config.ts` loads `.env.local` and then `.env`.     |
+| `AUTH_SECRET`          | Yes                         | NextAuth, queued-secret encryption      | Use a random secret and do not rotate it while email jobs are queued.               |
+| `RESEND_API_KEY`       | Email worker processes only | `lib/email.ts`                          | Required when the worker submits a queued invite email to Resend.                   |
+| `EMAIL_FROM`           | Email worker processes only | `lib/email.ts`                          | Sender address used when the worker submits an email to Resend.                     |
+| `EMAIL_WORKER_ENABLED` | Worker processes only       | `instrumentation.ts`, email queue       | Set to `true` only on a long-lived server that should process queued email.         |
+| `NEXT_PUBLIC_APP_URL`  | Recommended                 | Invite URL generation                   | Falls back to `AUTH_URL` and then `http://localhost:3000`.                          |
+| `ADMIN_EMAIL`          | Optional                    | Bootstrap admin                         | Defaults to `admin@example.com`.                                                    |
+| `ADMIN_PASSWORD`       | Optional                    | Bootstrap admin                         | Enables one-time bootstrap admin sign-in until an admin user has a stored password. |
+| `AUTH_TRUST_HOST`      | Deployment                  | NextAuth                                | Use when running behind a trusted proxy/container host.                             |
+| `INFISICAL_TOKEN`      | Production Docker           | Docker image entrypoint                 | Used by the production Dockerfile command.                                          |
+
+Generate a local auth secret with:
+
+```bash
+openssl rand -base64 32
+```
+
+## Database Setup
+
+The app uses Drizzle ORM with Postgres. The schema is in `db/schema.ts`; generated migrations are under `drizzle/`.
+
+The example env points at:
+
+```env
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/affordable_housing_portal
+```
+
+If you use the Docker Compose database from this repo, use the host port exposed by Compose:
+
+```env
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/affordable_housing_portal
+```
+
+Create the database with your preferred local Postgres tooling, then run:
+
+```bash
+npm run db:migrate
+npm run db:seed
+```
+
+The seed script inserts:
+
+- admin-configurable custom listing field definitions
+- mock users for listing data
+- mock properties, listings, and listing images
+
+## Run The App Locally
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+If `ADMIN_PASSWORD` is set, you can sign in with `ADMIN_EMAIL` and `ADMIN_PASSWORD` to bootstrap an admin account, but only until there is already an admin user with a stored local password.
+
+## Docker Notes
+
+The current `docker-compose.yml` starts a local development stack with Postgres and the Next.js dev server.
+
+Current compose behavior:
+
+- starts a `postgres:16-alpine` database on host port `${POSTGRES_PORT:-5433}`
+- builds the app from `Dockerfile.dev`
+- mounts the repository into `/app`
+- sets development defaults for auth, app URL, bootstrap admin, and email variables
+- enables the transactional email worker by default
+- runs `npm run db:migrate`, `npm run db:seed`, then `npm run dev`
+- exposes the app on [http://localhost:3000](http://localhost:3000)
+
+Commands:
+
+```bash
+npm run docker:up
+npm run docker:logs
+npm run docker:down
+npm run docker:down:volumes
+```
+
+Use `npm run dev` when you already have a database and environment configured locally. Use `npm run docker:up` when you want the repo-provided Postgres database and app server together.
+
+## Scripts
+
+| Script                     | Purpose                                           |
+| -------------------------- | ------------------------------------------------- |
+| `npm run dev`              | Start Next.js in development mode.                |
+| `npm run dev:secrets`      | Start dev through Infisical `dev` secrets.        |
+| `npm run build`            | Run `next build`.                                 |
+| `npm run build:secrets`    | Build through Infisical `dev` secrets.            |
+| `npm run start`            | Start a built Next.js app.                        |
+| `npm run start:secrets`    | Start through Infisical `dev` secrets.            |
+| `npm run typecheck`        | Run TypeScript without emitting files.            |
+| `npm run lint`             | Run oxlint.                                       |
+| `npm run lint:fix`         | Apply oxlint fixes.                               |
+| `npm run format`           | Format with oxfmt.                                |
+| `npm run format:check`     | Check oxfmt formatting.                           |
+| `npm test`                 | Run all Jest tests.                               |
+| `npm run test:unit`        | Run tests matching `.unit.test.`.                 |
+| `npm run test:integration` | Run tests matching `.integration.test.`.          |
+| `npm run db:generate`      | Generate a Drizzle migration from `db/schema.ts`. |
+| `npm run db:migrate`       | Apply Drizzle migrations.                         |
+| `npm run db:seed`          | Seed local data using `.env.local` if present.    |
+| `npm run db:studio`        | Open Drizzle Studio.                              |
+| `npm run lockfile:check`   | Check package lockfile integrity.                 |
+
+## Troubleshooting
+
+### `DATABASE_URL is not set`
+
+The database client and Drizzle config fail fast when `DATABASE_URL` is missing. Add it to `.env.local`, or run through Infisical with the relevant `*:secrets` script.
+
+### Migrations do not run
+
+Confirm that:
+
+- `.env.local` has the database you intended
+- the database exists
+- the Postgres user can create/alter tables
+- you are running `npm run db:migrate` from the repository root
+
+### Invite email remains queued or fails
+
+Creating an invite queues its email instead of waiting for provider acceptance. If its status remains `queued`, confirm that a long-lived app server has `EMAIL_WORKER_ENABLED=true`, valid `RESEND_API_KEY` and `EMAIL_FROM` values, and access to the same Postgres database. Check server logs for `[email-queue]` errors.
+
+A `failed` status means the job permanently exhausted provider submission attempts and reached the `email_send_dead_letter` queue. Re-send the invite after correcting the provider or configuration problem. Do not rotate `AUTH_SECRET` while jobs are queued because it is used to encrypt their one-time URLs.
+
+### Image uploads fail
+
+Uploads are validated in `lib/images/image.service.ts`. Supported extensions are `.jpg`, `.jpeg`, `.png`, `.webp`, `.avif`, and `.jxl`; processed output is stored as JPEG. Uploads must be at most 25 MB and 24 megapixels.
+
+### Build-time database errors
+
+The database client in `db/client.ts` uses a lazy proxy so importing server modules during build does not immediately connect to Postgres. Follow the same lazy pattern for new database clients or server SDKs.

--- a/docs/listings.md
+++ b/docs/listings.md
@@ -1,0 +1,204 @@
+# Listings
+
+This guide covers the listing search experience, listing detail pages, authoring workflow, draft autosave, images, and custom listing fields.
+
+## Main Files
+
+| Area                | Files                                                                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Listing search page | `app/listings/page.tsx`, `app/listings/listings.tsx`, `app/listings/query.ts`, `app/listings/data.ts`                                      |
+| Listing detail page | `app/listings/[id]/page.tsx`, `components/listing-details/ListingDetails.tsx`                                                              |
+| Listing authoring   | `app/(listing-author)/listing-form/*`, `app/listing-form/*`, `components/listing-form-*`                                                   |
+| My listings         | `app/(listing-author)/my-listings/page.tsx`, `app/my-listings/MyListingsClient.tsx`                                                        |
+| Listing services    | `lib/listings/listing.service.ts`, `lib/listings/listing.repository.ts`, `lib/listings/listing.specifications.ts`, `lib/listings/store.ts` |
+| Listing API         | `app/api/listings/*`, `app/api/listing-drafts/*`, `app/api/image-uploads/*`                                                                |
+| Listing schemas     | `shared/schemas/listings.ts`                                                                                                               |
+| Listing policies    | `lib/policies/listing-policy.ts`                                                                                                           |
+
+## Listing Search Flow
+
+Listing pages and `/api/listings` routes require an active session through `proxy.ts`. Published listings are visible to signed-in users; draft and archived listing visibility is role-limited in the listing policy.
+
+`app/listings/page.tsx` is a Server Component. It:
+
+1. Resolves `searchParams`.
+2. Parses query values with `getListingsQueryFromSearchParams`.
+3. Calls `connection()` so the route renders with request-time data.
+4. Fetches initial listing results through `getListingsService`.
+5. Fetches dynamic filter groups through `getListingsDashboardData`.
+6. Passes initial data into the `ListingsDashboard` Client Component.
+
+`ListingsDashboard` handles filter controls, map/list display mode, mobile filter state, and client refetches through `useListingsQuery`.
+
+## Query Parameters
+
+Listing search accepts these query parameters through `listingQuerySchema`:
+
+| Query           | Meaning                                                                           |
+| --------------- | --------------------------------------------------------------------------------- |
+| `page`          | Positive integer page number.                                                     |
+| `limit`         | Positive integer page size, capped at 100.                                        |
+| `status`        | `draft`, `published`, or `archived`. Draft/archived access is role-limited.       |
+| `neighborhood`  | Case-insensitive neighborhood match.                                              |
+| `bedrooms`      | Exact count or count plus `+`, such as `2` or `2+`.                               |
+| `bathrooms`     | Exact count or count plus `+`, such as `1` or `1+`.                               |
+| `location`      | Search string, currently treated like the main search term.                       |
+| `search`        | Search string across listing title, description, property name, street, and city. |
+| `minPrice`      | Minimum rent in dollars.                                                          |
+| `maxPrice`      | Maximum rent in dollars.                                                          |
+| `maxRent`       | Legacy maximum rent alias.                                                        |
+| `accessibility` | `true` or `false`, based on enabled boolean custom-field feature data.            |
+| `moveInDate`    | ISO-like date string; filters listings available on or before the date.           |
+| `sort`          | `newest`, `oldest`, `price_asc`, or `price_desc`.                                 |
+| `features`      | One or more dynamic feature keys from public boolean custom fields.               |
+
+The service defaults to published listing visibility unless the actor is allowed to view drafts or archived listings.
+
+## Visibility Rules
+
+Listing visibility is centralized in `lib/policies/listing-policy.ts`.
+
+- Active signed-in users can read published listings through the protected listing routes.
+- Anonymous users cannot read draft or archived listings.
+- Admins can read and edit all listings.
+- Partners can read/edit their own listings.
+- Partners can list their own draft and archived listings.
+- Non-admin/non-partner users cannot write listings.
+
+Services intentionally return `not_found` for some inaccessible listing reads so private listings are not exposed by ID probing.
+
+## Listing Search Implementation
+
+`getListingsService` composes Drizzle specifications from `lib/listings/listing.specifications.ts`:
+
+- status
+- owner
+- neighborhood
+- bedroom and bathroom counts
+- min/max rent
+- accessibility
+- text search
+- available-by date
+- selected dynamic feature definitions
+
+`findListingSummaries` joins listings to properties, applies pagination and ordering, and loads image rows for the result set.
+
+## Dynamic Filters
+
+Filter options come from `listing_field_definitions` records where:
+
+- `is_public = true`
+- `is_filterable = true`
+- `field_type = "boolean"`
+
+`getListingsDashboardData` maps those records into `DynamicFilterGroup` values consumed by the filter accordion.
+
+Filtering by dynamic feature checks:
+
+- canonical boolean custom fields where `custom_fields[definition.key]` is `true`
+
+## Listing Details
+
+`getListingByIdService` loads a listing by ID, checks `canReadListing`, loads images, resolves display features, and returns `ListingDetails`.
+
+Details include:
+
+- title, price, address, beds/baths/square footage
+- display accessibility features
+- image URLs
+- relative time
+- grouped feature categories
+- contact information when all contact fields are present
+- an Apply button when `applicationUrl` is present
+- a direct-contact instruction when complete contact details exist but no online application URL is set
+- a check-back-later message when neither contact nor online application details are available
+- `editUrl` for the owning user
+
+The Apply button opens a confirmation dialog before navigating the browser to the external application URL. When there is no online application URL, the page still shows the appropriate direct-contact or missing-details guidance instead of hiding the application section.
+
+## Authoring Workflow
+
+The authoring routes live under the `(listing-author)` route group and are available at:
+
+- `/listing-form`
+- `/listing-form/:id`
+- `/my-listings`
+
+`app/(listing-author)/layout.tsx` requires an active `admin` or `partner` account.
+
+The form uses:
+
+- React Hook Form
+- `listingFormSchema` in `app/listing-form/types.ts`
+- API mapping helpers in `app/listing-form/api.ts`
+- React Query hooks for draft creation, editor loading, and updates
+
+## Draft Autosave
+
+`useListingForm` owns the draft lifecycle:
+
+1. A new form starts with local defaults and no listing ID.
+2. When autosave needs a persisted row, it calls `POST /api/listing-drafts`.
+3. The URL is replaced with `/listing-form/:id` after a draft is created.
+4. Form changes are mapped to update payloads and saved after an 800 ms debounce.
+5. Publish waits for in-flight autosave, then sends a final `PUT /api/listings/:id` with status `published`.
+
+Published listing edits do not draft-autosave. The UI warns before navigating away with unsaved published changes.
+
+## Create, Update, Archive
+
+Creation and update behavior is split across service and repository code:
+
+- `createDraftListingService` creates an empty property and draft listing.
+- `createListingService` creates a property and listing in one transaction.
+- `updateListingByIdService` checks edit access, merges dynamic feature state in `customFields`, updates property/listing columns, and syncs images.
+- `deleteListingByIdService` archives the listing rather than deleting it.
+
+Status timestamps are managed by `resolveListingStatusTimestamps`.
+
+## Image Uploads
+
+Image endpoints use direct Node.js route handlers:
+
+- `POST /api/image-uploads`
+- `GET /api/image-uploads/:id`
+
+Upload behavior in `lib/images/image.service.ts`:
+
+- requires an active admin or partner session
+- requires edit access to the target listing
+- accepts `.jpg`, `.jpeg`, `.png`, `.webp`, `.avif`, and `.jxl`
+- rejects files over 25 MB
+- rejects images over 24 megapixels
+- normalizes output to JPEG
+- resizes within 1600 x 1600 without enlargement
+- stores processed bytes in `listing_images.image_data`
+
+Public published images use long immutable cache headers. Draft/private images use short private caching.
+
+## Built-In And Custom Field Storage
+
+The listing form includes built-in fields and admin-configured feature fields.
+
+Built-in listing fields are persisted in normalized columns on `listings` or `properties`, including:
+
+- title, description, status, and unit number
+- building type, bedrooms, bathrooms, square feet, rent, availability, lease term, and included utilities
+- application URL and contact fields
+- property name and address fields
+
+`lib/listings/store.ts` maps selected admin-configured accessibility features into `listings.custom_fields`. Current authoring writes selected public boolean feature definitions as boolean keys where `custom_fields[definition.key]` is `true`.
+
+Create/update payloads send selected features through `accessibilityFeatures`, and each submitted feature must include the field-definition `id`. Update/autosave payloads use `applicationUrl: null` when an author clears the application URL field.
+
+If a new listing field must be searchable, sortable, joined, or constrained at scale, prefer a normalized column. If it is project-configurable feature metadata, prefer `listing_field_definitions` plus `customFields`.
+
+## Adding A Listing Feature
+
+1. Decide whether the field belongs in `listings`, `properties`, `listing_field_definitions`, or `customFields`.
+2. Update `shared/schemas/listings.ts` for API/form contracts.
+3. Update `app/listing-form/types.ts` and mapping helpers.
+4. Update `lib/listings/store.ts` for persistence mapping.
+5. Update service/repository code if normalized columns or queries change.
+6. Add or update tests for schema, mapping, specifications, or UI hooks.
+7. Update this document and [API Reference](api-reference.md) if public behavior changes.

--- a/docs/testing-and-quality.md
+++ b/docs/testing-and-quality.md
@@ -1,0 +1,119 @@
+# Testing And Quality
+
+This project uses Jest for tests, oxlint for linting, oxfmt for formatting, TypeScript strictness, and Husky hooks for local quality gates.
+
+## Commands
+
+| Command                    | Purpose                                  |
+| -------------------------- | ---------------------------------------- |
+| `npm test`                 | Run all Jest tests.                      |
+| `npm run test:unit`        | Run tests matching `.unit.test.`.        |
+| `npm run test:integration` | Run tests matching `.integration.test.`. |
+| `npm run typecheck`        | Run `tsc --noEmit`.                      |
+| `npm run lint`             | Run oxlint.                              |
+| `npm run lint:fix`         | Apply oxlint fixes.                      |
+| `npm run format`           | Format with oxfmt.                       |
+| `npm run format:check`     | Check formatting.                        |
+| `npm run build`            | Run a production Next.js build.          |
+| `npm run lockfile:check`   | Check package lockfile integrity.        |
+
+## Jest Setup
+
+Jest is configured in `jest.config.js` with:
+
+- `testEnvironment: "jsdom"`
+- `ts-jest` transforms
+- `@/*` mapped to the repository root
+- `server-only` mapped to `test/mocks/server-only.ts`
+
+The installed Next.js Jest guide notes that async Server Components are not a strong fit for Jest. Prefer focused tests around schemas, services, policies, specifications, hooks, and pure mapping functions. Use broader browser or end-to-end coverage when async Server Component behavior needs confidence.
+
+## Existing Test Patterns
+
+Current tests cover:
+
+- custom listing field ordering
+- listing custom field mapping and submitted feature id handling
+- listing specifications
+- route policy matching
+- address utilities
+- listing form schemas and API mapping
+- listing apply-button confirmation and no-URL fallback behavior
+- listing detail utilities display behavior
+- custom listing field dashboard utilities
+- listing filter hooks/components
+- price range input behavior
+- transactional email provider error classification and idempotency
+- queue enqueueing, deduplication, retry configuration, and worker startup gating
+- quota/rate-limit deferral, dead-letter handling, and invite submission status mapping
+- queued-secret encryption, redaction, and plaintext-sensitive-data prevention
+
+Test naming convention:
+
+```text
+*.unit.test.ts
+*.unit.test.tsx
+```
+
+## What To Test
+
+Add focused tests when changing:
+
+- Zod schemas in `shared/schemas`
+- policy functions in `lib/policies`
+- route matching in `lib/auth/route-policy.ts`
+- Drizzle specification builders in `lib/*/*.specifications.ts`
+- mappers between form data, API payloads, and persistence
+- money/date conversion logic
+- custom-field ordering or display behavior
+- hooks with non-trivial state transitions
+
+Repository methods that require a real database should usually be covered by integration tests once an integration test database pattern exists. Until then, keep business logic in services/helpers where it can be unit tested without a database.
+
+## Hooks
+
+The local hooks are:
+
+- `.husky/pre-commit`
+- `.husky/pre-push`
+
+Pre-commit runs:
+
+```bash
+node_modules/.bin/gitleaks-secret-scanner
+npx lint-staged
+npm run typecheck
+```
+
+Pre-push runs:
+
+```bash
+npm run build
+```
+
+These hooks are not a substitute for running targeted tests while developing.
+
+## CI
+
+GitHub Actions runs lockfile, lint, format, test, and build jobs for pull requests to `main` and pushes to `main` or `rewrite`. See [Deployment and Operations](deployment.md) for the exact workflow shape.
+
+## Review Checklist
+
+Before opening a PR:
+
+1. Run the checks relevant to the change.
+2. Include testing notes in the PR description.
+3. Confirm schemas and docs are updated for changed contracts.
+4. Confirm migrations are included for schema changes.
+5. Confirm protected behavior has service-level authorization.
+6. Confirm new Client Components do not import server-only modules.
+7. Confirm new server SDK/database clients use lazy initialization.
+
+## Documentation Checks
+
+There is no dedicated markdown linter. Treat docs like code:
+
+- keep commands copy-pastable
+- link to owning files when possible
+- update docs in the same PR as behavior changes
+- remove stale setup instructions when scripts or Docker behavior changes


### PR DESCRIPTION
## Summary

- Adds a developer documentation index and topic-specific docs for setup, architecture, domain model, listings, auth/admin, API routes, deployment/operations, and testing/quality.
- Updates the root README to point contributors toward the developer reference and current quick-start flow.
- Documents the durable pg-boss transactional email queue, provider-submission statuses, worker configuration, retry/dead-letter operations, encrypted job payloads, and migration boundaries now on `main`.
- Refreshes the docs for current auth-gated listing access, Docker Compose app+Postgres behavior, normalized listing/custom-field storage, and the listing-details application fallback.
- Corrects the repository Issues link and distinguishes queued/provider-submitted email from confirmed recipient-server delivery.

## Base

Rebased onto `main` at `496174d8` after #303 was squash-merged.

## Validation

- `npx oxfmt --check README.md docs -c .oxfmtrc.json`
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand --no-watchman` (18 suites, 116 tests)
- `npm run lockfile:check`
- `npm run build`
- local Markdown link and repository-path validation
