### PR TITLE
[codex] Remove repeated partner guidance prefix

### DIFF
--- a/components/listing-form-features/ListingFormFeatures.tsx
+++ b/components/listing-form-features/ListingFormFeatures.tsx
@@ -61,8 +61,7 @@ export function ListingFormFeatures({ control }: ListingFormFeaturesProps) {
                       <ToggleField
                         title={option.label}
                         description={[
-                          option.helpText &&
-                            `Partner guidance: This is shown to partners while creating a listing. ${option.helpText}`,
+                          option.helpText,
                           option.description &&
                             `Public listing text: This is shown to renters and applicants on the listing. ${option.description}`,
                         ]


### PR DESCRIPTION
## Summary

Removes the repeated partner guidance intro from accessibility feature descriptions in the listing form. Partner-facing text now shows the field-specific guidance directly, while the public listing text remains unchanged.

## Why

The listing form was prepending `Partner guidance: This is shown to partners while creating a listing.` to every custom accessibility field, which made the same administrative explanation appear repeatedly.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- pre-commit hook: Gitleaks, lint-staged, `npm run typecheck`
- pre-push hook: `npm run build`