### PR TITLE
[codex] Gate listings behind auth

### DIFF
--- a/lib/auth/route-policy.ts
+++ b/lib/auth/route-policy.ts
@@ -7,20 +7,17 @@ type RoutePattern = `/${string}`;
 
 const PROTECTED_PAGE_PATTERNS = [
   "/admin/:path*",
+  "/listings/:path*",
   "/listing-form/:path*",
   "/my-listings/:path*",
 ] as const;
 
-const PROTECTED_API_PATTERNS = ["/api/admin/:path*"] as const;
-
-const LISTING_WRITE_API_PATTERNS = ["/api/listings/:path*"] as const;
+const PROTECTED_API_PATTERNS = ["/api/admin/:path*", "/api/listings/:path*"] as const;
 
 export function requiresAuthSessionForRequest(request: RouteRequest) {
   return (
     matchesAnyRoutePattern(request.pathname, PROTECTED_PAGE_PATTERNS) ||
-    matchesAnyRoutePattern(request.pathname, PROTECTED_API_PATTERNS) ||
-    (request.method !== "GET" &&
-      matchesAnyRoutePattern(request.pathname, LISTING_WRITE_API_PATTERNS))
+    matchesAnyRoutePattern(request.pathname, PROTECTED_API_PATTERNS)
   );
 }
 

--- a/lib/auth/route-policy.unit.test.ts
+++ b/lib/auth/route-policy.unit.test.ts
@@ -6,6 +6,10 @@ describe("requiresAuthSessionForRequest", () => {
   it("requires auth for protected page route families", () => {
     expect(requiresAuthSessionForRequest({ pathname: "/admin", method: "GET" })).toBe(true);
     expect(requiresAuthSessionForRequest({ pathname: "/admin/users", method: "GET" })).toBe(true);
+    expect(requiresAuthSessionForRequest({ pathname: "/listings", method: "GET" })).toBe(true);
+    expect(requiresAuthSessionForRequest({ pathname: "/listings/abc123", method: "GET" })).toBe(
+      true,
+    );
     expect(requiresAuthSessionForRequest({ pathname: "/listing-form", method: "GET" })).toBe(true);
     expect(requiresAuthSessionForRequest({ pathname: "/listing-form/abc123", method: "GET" })).toBe(
       true,
@@ -20,6 +24,9 @@ describe("requiresAuthSessionForRequest", () => {
     expect(requiresAuthSessionForRequest({ pathname: "/administrator", method: "GET" })).toBe(
       false,
     );
+    expect(requiresAuthSessionForRequest({ pathname: "/listings-extra", method: "GET" })).toBe(
+      false,
+    );
     expect(requiresAuthSessionForRequest({ pathname: "/listing-formal", method: "GET" })).toBe(
       false,
     );
@@ -28,23 +35,16 @@ describe("requiresAuthSessionForRequest", () => {
     );
   });
 
-  it("keeps public listing pages and listing reads outside broad auth gating", () => {
-    expect(requiresAuthSessionForRequest({ pathname: "/listings", method: "GET" })).toBe(false);
-    expect(requiresAuthSessionForRequest({ pathname: "/listings/abc123", method: "GET" })).toBe(
-      false,
-    );
-    expect(requiresAuthSessionForRequest({ pathname: "/api/listings", method: "GET" })).toBe(false);
-    expect(requiresAuthSessionForRequest({ pathname: "/api/listings/abc123", method: "GET" })).toBe(
-      false,
-    );
-  });
-
-  it("requires auth for protected APIs and listing writes", () => {
+  it("requires auth for protected APIs and all listing API access", () => {
     expect(requiresAuthSessionForRequest({ pathname: "/api/admin/accounts", method: "GET" })).toBe(
       true,
     );
     expect(requiresAuthSessionForRequest({ pathname: "/api/administer", method: "GET" })).toBe(
       false,
+    );
+    expect(requiresAuthSessionForRequest({ pathname: "/api/listings", method: "GET" })).toBe(true);
+    expect(requiresAuthSessionForRequest({ pathname: "/api/listings/abc123", method: "GET" })).toBe(
+      true,
     );
     expect(requiresAuthSessionForRequest({ pathname: "/api/listings", method: "POST" })).toBe(true);
     expect(requiresAuthSessionForRequest({ pathname: "/api/listings/abc123", method: "PUT" })).toBe(


### PR DESCRIPTION
## Summary

- Require an authenticated session for `/listings` and all child listing pages.
- Require authentication for `/api/listings` reads as well as writes so listing data is not exposed outside the gated UI.
- Update route-policy unit coverage for listings gating and non-overmatching paths.

## Impact

Unauthenticated users who request a listings page are redirected through the existing NextAuth sign-in flow, which preserves the attempted URL in `callbackUrl` and returns them there after login.

## Validation

- `npm test -- --runTestsByPath lib/auth/route-policy.unit.test.ts`
- `npm run typecheck`
- `npm run lint -- lib/auth/route-policy.ts lib/auth/route-policy.unit.test.ts`
- `npm run build` via push hook