### PR TITLE
[codex] Add Resend idempotency keys for invite emails

### DIFF
--- a/lib/auth/invite-email.ts
+++ b/lib/auth/invite-email.ts
@@ -1,25 +1,40 @@
 import "server-only";
 
-import { createResendClient, getEmailFromAddress } from "@/lib/email";
+import {
+  createResendClient,
+  getEmailFromAddress,
+  type TransactionalEmailSendOptions,
+} from "@/lib/email";
 
-export async function sendInviteEmail(params: {
-  email: string;
-  fullName: string;
-  inviteUrl: string;
-}) {
+export async function sendInviteEmail(
+  params: {
+    email: string;
+    fullName: string;
+    inviteUrl: string;
+  } & TransactionalEmailSendOptions,
+) {
   const resend = createResendClient();
   const inviteUrl = getSafeInviteUrl(params.inviteUrl);
-  const result = await resend.emails.send({
-    from: getEmailFromAddress(),
-    to: params.email,
-    subject: "You’ve been invited to the Affordable Housing Portal",
-    text: `Hello ${params.fullName},\n\nYou’ve been invited to the Affordable Housing Portal. Use the link below to create your password and activate your account:\n\n${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`,
-    html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>You’ve been invited to the Affordable Housing Portal.</p><p><a href="${escapeHtml(inviteUrl)}">Create your password and activate your account</a></p><p>If you were not expecting this invite, you can ignore this email.</p>`,
-  });
+  const result = await resend.emails.send(
+    {
+      from: getEmailFromAddress(),
+      to: params.email,
+      subject: "You’ve been invited to the Affordable Housing Portal",
+      text: `Hello ${params.fullName},\n\nYou’ve been invited to the Affordable Housing Portal. Use the link below to create your password and activate your account:\n\n${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`,
+      html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>You’ve been invited to the Affordable Housing Portal.</p><p><a href="${escapeHtml(inviteUrl)}">Create your password and activate your account</a></p><p>If you were not expecting this invite, you can ignore this email.</p>`,
+    },
+    {
+      idempotencyKey: params.idempotencyKey,
+    },
+  );
 
   if (result.error) {
     throw new Error(result.error.message);
   }
+}
+
+export function getAccountInviteEmailIdempotencyKey(inviteId: string) {
+  return `account_invite/${inviteId}`;
 }
 
 function getSafeInviteUrl(value: string) {

--- a/lib/auth/invite-email.unit.test.ts
+++ b/lib/auth/invite-email.unit.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { createResendClient, getEmailFromAddress } from "@/lib/email";
+import { getAccountInviteEmailIdempotencyKey, sendInviteEmail } from "@/lib/auth/invite-email";
+
+jest.mock("@/lib/email", () => ({
+  createResendClient: jest.fn(),
+  getEmailFromAddress: jest.fn(),
+}));
+
+const createResendClientMock = jest.mocked(createResendClient);
+const getEmailFromAddressMock = jest.mocked(getEmailFromAddress);
+const sendMock = jest.fn<(...args: unknown[]) => Promise<{ data: { id: string }; error: null }>>();
+
+describe("getAccountInviteEmailIdempotencyKey", () => {
+  it("uses the persisted invite id as the stable logical email key", () => {
+    expect(getAccountInviteEmailIdempotencyKey("2e42f745-44e8-4ab7-a2a2-c1f42cc8e204")).toBe(
+      "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+    );
+  });
+});
+
+describe("sendInviteEmail", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
+    createResendClientMock.mockReset();
+    createResendClientMock.mockReturnValue({
+      emails: {
+        send: sendMock,
+      },
+    } as unknown as ReturnType<typeof createResendClient>);
+    getEmailFromAddressMock.mockReset();
+    getEmailFromAddressMock.mockReturnValue("Affordable Housing Portal <no-reply@example.org>");
+  });
+
+  it("passes the invite idempotency key to Resend provider options", async () => {
+    await sendInviteEmail({
+      email: "tenant@example.org",
+      fullName: "Tenant User",
+      inviteUrl: "https://housing.example.org/invite?token=abc123",
+      idempotencyKey: getAccountInviteEmailIdempotencyKey("2e42f745-44e8-4ab7-a2a2-c1f42cc8e204"),
+    });
+
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "Affordable Housing Portal <no-reply@example.org>",
+        to: "tenant@example.org",
+        subject: "You’ve been invited to the Affordable Housing Portal",
+      }),
+      {
+        idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+      },
+    );
+  });
+});

--- a/lib/auth/invite-service.ts
+++ b/lib/auth/invite-service.ts
@@ -6,7 +6,7 @@ import { and, eq, gt, isNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { lower, userInvites, users, type UserRole } from "@/db/schema";
-import { sendInviteEmail } from "@/lib/auth/invite-email";
+import { getAccountInviteEmailIdempotencyKey, sendInviteEmail } from "@/lib/auth/invite-email";
 import { createOpaqueToken, hashOpaqueToken } from "@/lib/auth/token";
 
 const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7;
@@ -106,6 +106,7 @@ export async function createInvite(params: {
       email: result.email,
       fullName: params.fullName,
       inviteUrl,
+      idempotencyKey: getAccountInviteEmailIdempotencyKey(result.invite.id),
     });
 
     const sentAt = new Date();

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -2,6 +2,14 @@ import "server-only";
 
 import { Resend } from "resend";
 
+export type TransactionalEmailSendOptions = {
+  /**
+   * Stable key for the logical email, such as account_invite/<inviteId>.
+   * Do not use a random per-attempt value or provider retries can duplicate sends.
+   */
+  idempotencyKey: string;
+};
+
 export function getEmailFromAddress() {
   const from = process.env.EMAIL_FROM;
 


### PR DESCRIPTION
## Summary

- require transactional email helpers to receive a stable idempotency key
- pass Resend idempotency keys through provider options for invite emails
- derive invite send keys from the persisted invite id as `account_invite/<inviteId>`
- add focused unit coverage for the invite idempotency key and Resend send options

## Why

Resend deduplicates requests that reuse the same idempotency key within its idempotency window. Keying invite emails from the logical invite row makes retries safer without blocking intentional new invite sends, because each intentional invite creates a new row and therefore a new key.

Closes #286

## Validation

- `npm test -- --runTestsByPath lib/auth/invite-email.unit.test.ts`
- `npm run test:unit`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`