### PR TITLE
security: add missing workflow permissions blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   supply-chain:
     name: Supply Chain Lockfile


### PR DESCRIPTION
## Summary

Adds top-level `permissions: contents: read` to workflows that were missing an explicit permissions declaration.

**Files changed:**
- `.github/workflows/ci.yml`

Without an explicit `permissions:` block, workflows inherit the org/repo default token permissions, which can be `write-all` depending on settings. Explicit `contents: read` follows the principle of least privilege — these workflows only checkout code and run commands; they don't push, create releases, or write to GitHub Pages.

Resolves `actions/missing-workflow-permissions` code scanning alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
