### PR TITLE
Add reliable email queue for transactional delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/affordable_housing_po
 AUTH_SECRET=replace-with-a-random-secret
 RESEND_API_KEY=re_replace_me
 EMAIL_FROM=Affordable Housing Portal <no-reply@example.com>
+# Auth for the email queue drain endpoint (/api/cron/email-jobs) and worker.
+CRON_SECRET=replace-with-a-random-secret
+# Optional dedicated key for encrypted email job payloads (openssl rand -base64 32).
+# Falls back to a key derived from AUTH_SECRET when unset.
+# EMAIL_JOB_SECRET_KEY=
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=ChangeMe123

--- a/.github/workflows/email-queue-drain.yml
+++ b/.github/workflows/email-queue-drain.yml
@@ -1,0 +1,51 @@
+name: Email Queue Drain
+
+# Production consumer for the email job queue (docs/email-queue.md). Retries
+# must drain every few minutes so they stay inside Resend's 24-hour
+# idempotency window; Vercel Hobby crons run at most daily, so this external
+# scheduler does the frequent polling on any plan.
+#
+# Setup: define the repository variable EMAIL_QUEUE_DRAIN_URL
+# (e.g. https://<production-host>/api/cron/email-jobs) and the repository
+# secret CRON_SECRET (same value as the deployment's CRON_SECRET env var).
+# The job is skipped while the variable is unset.
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  drain:
+    name: Drain due email jobs
+    runs-on: ubuntu-latest
+    if: vars.EMAIL_QUEUE_DRAIN_URL != ''
+    steps:
+      - name: Call the drain endpoint
+        env:
+          DRAIN_URL: ${{ vars.EMAIL_QUEUE_DRAIN_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET secret is not configured." >&2
+            exit 1
+          fi
+
+          status=$(curl --silent --show-error --output /tmp/drain-response \
+            --write-out "%{http_code}" --max-time 120 --request POST \
+            --header "Authorization: Bearer $CRON_SECRET" \
+            "$DRAIN_URL")
+
+          cat /tmp/drain-response
+          echo
+
+          if [ "$status" != "200" ]; then
+            echo "::error::Drain endpoint responded with HTTP $status." >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ npm run test:integration
 
 Use `npm run format` and `npm run lint:fix` for automatic formatting and lint fixes.
 
+## Transactional Email
+
+Transactional email (account invites today) is delivered through a Postgres-backed job queue with retries, idempotent sends, and encrypted handling of one-time URLs — feature code never calls Resend directly. See [docs/email-queue.md](docs/email-queue.md) for the design and for worker setup in local dev (`npm run email:worker`), Docker (`docker compose --profile worker up`), and deployment (cron hitting `/api/cron/email-jobs` with `CRON_SECRET`).
+
 ## Architecture Notes
 
 - Public listing search is server-first: `app/listings/page.tsx` calls shared listing services directly for the initial render, while client-side filter refinements fetch `/api/listings`.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Use `npm run format` and `npm run lint:fix` for automatic formatting and lint fi
 
 ## Transactional Email
 
-Transactional email (account invites today) is delivered through a Postgres-backed job queue with retries, idempotent sends, and encrypted handling of one-time URLs — feature code never calls Resend directly. See [docs/email-queue.md](docs/email-queue.md) for the design and for worker setup in local dev (`npm run email:worker`), Docker (`docker compose --profile worker up`), and deployment (`vercel.json` schedules a cron against `/api/cron/email-jobs` authorized by `CRON_SECRET`; self-hosted deployments run the polling worker or system cron instead).
+Transactional email (account invites today) is delivered through a Postgres-backed job queue with retries, idempotent sends, and encrypted handling of one-time URLs — feature code never calls Resend directly. Production needs a drain scheduler hitting `/api/cron/email-jobs` (authorized by `CRON_SECRET`) every few minutes so retries stay inside Resend's 24h idempotency window: the shipped GitHub Actions workflow (`.github/workflows/email-queue-drain.yml`) does this on any Vercel plan, `vercel.json` adds a daily Vercel-cron backstop, and self-hosted deployments can run the polling worker (`npm run email:worker`, or `docker compose --profile worker up`) instead. See [docs/email-queue.md](docs/email-queue.md) for the design and setup.
 
 ## Architecture Notes
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Use `npm run format` and `npm run lint:fix` for automatic formatting and lint fi
 
 ## Transactional Email
 
-Transactional email (account invites today) is delivered through a Postgres-backed job queue with retries, idempotent sends, and encrypted handling of one-time URLs — feature code never calls Resend directly. See [docs/email-queue.md](docs/email-queue.md) for the design and for worker setup in local dev (`npm run email:worker`), Docker (`docker compose --profile worker up`), and deployment (cron hitting `/api/cron/email-jobs` with `CRON_SECRET`).
+Transactional email (account invites today) is delivered through a Postgres-backed job queue with retries, idempotent sends, and encrypted handling of one-time URLs — feature code never calls Resend directly. See [docs/email-queue.md](docs/email-queue.md) for the design and for worker setup in local dev (`npm run email:worker`), Docker (`docker compose --profile worker up`), and deployment (`vercel.json` schedules a cron against `/api/cron/email-jobs` authorized by `CRON_SECRET`; self-hosted deployments run the polling worker or system cron instead).
 
 ## Architecture Notes
 

--- a/app/admin/invite/actions.ts
+++ b/app/admin/invite/actions.ts
@@ -52,15 +52,27 @@ export async function sendAdminInviteAction(
       };
     }
 
+    // Delivery happens through the durable email job queue, so the invite can
+    // exist while its email is still queued (or, rarely, dead-lettered).
+    // Report what actually happened instead of assuming the email went out.
+    if (result.value.data.emailDelivery === "failed") {
+      return {
+        status: "error",
+        message: result.value.message,
+      };
+    }
+
+    const status = result.value.data.emailDelivery === "queued" ? "queued" : "sent";
+
     return {
-      status: "sent",
+      status,
       message: result.value.message,
       invite: {
         id: result.value.data.id,
         email: result.value.data.email.trim().toLowerCase(),
         role: result.value.data.role,
         invitedAt: new Date().toISOString(),
-        status: "sent",
+        status,
       },
     };
   } catch (error) {

--- a/app/admin/invite/actions.ts
+++ b/app/admin/invite/actions.ts
@@ -56,9 +56,12 @@ export async function sendAdminInviteAction(
     // exist while its email is still queued (or, rarely, dead-lettered).
     // Report what actually happened instead of assuming the email went out.
     if (result.value.data.emailDelivery === "failed") {
+      // The message tells the admin to share the link manually, so the link
+      // must actually be there to share.
       return {
         status: "error",
         message: result.value.message,
+        inviteUrl: result.value.data.inviteUrl,
       };
     }
 

--- a/app/admin/invite/actions.ts
+++ b/app/admin/invite/actions.ts
@@ -72,7 +72,7 @@ export async function sendAdminInviteAction(
         email: result.value.data.email.trim().toLowerCase(),
         role: result.value.data.role,
         invitedAt: new Date().toISOString(),
-        status,
+        emailDelivery: status,
       },
     };
   } catch (error) {

--- a/app/api/cron/email-jobs/route.ts
+++ b/app/api/cron/email-jobs/route.ts
@@ -1,0 +1,49 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { drainEmailJobs } from "@/lib/email-jobs/email-job-service";
+
+/**
+ * Protected drain endpoint for the email job queue. Hit it from a scheduler
+ * (Vercel cron, system cron) or the polling worker in scripts/email-worker.mjs.
+ * Concurrent calls are safe; workers claim disjoint job sets.
+ */
+function isAuthorized(request: Request) {
+  const secret = process.env.CRON_SECRET;
+
+  if (!secret) {
+    return false;
+  }
+
+  const received = Buffer.from(request.headers.get("authorization") ?? "");
+  const expected = Buffer.from(`Bearer ${secret}`);
+
+  return received.length === expected.length && timingSafeEqual(received, expected);
+}
+
+async function drain(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const summary = await drainEmailJobs();
+
+    if (summary.claimed > 0 || summary.backlog.failed > 0) {
+      console.info("Email job drain summary", summary);
+    }
+
+    return Response.json(summary);
+  } catch (error) {
+    console.error("Email job drain failed", error);
+
+    return Response.json({ message: "Email job drain failed." }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  return drain(request);
+}
+
+export async function POST(request: Request) {
+  return drain(request);
+}

--- a/components/admin-invite/AdminInviteForm.tsx
+++ b/components/admin-invite/AdminInviteForm.tsx
@@ -43,7 +43,8 @@ export function AdminInviteForm({ onResult }: AdminInviteFormProps) {
 
     onResult(state);
 
-    if (state.status === "sent") {
+    // "queued" also created the invite; only true errors keep the form filled.
+    if (state.status === "sent" || state.status === "queued") {
       setName("");
       setEmail("");
       setOrganization("");

--- a/components/admin-invite/InviteResultBanner.tsx
+++ b/components/admin-invite/InviteResultBanner.tsx
@@ -10,10 +10,11 @@ export function InviteResultBanner({ result }: InviteResultBannerProps) {
     return null;
   }
 
-  const isSuccess = result.status === "sent";
+  const variant =
+    result.status === "sent" ? "success" : result.status === "queued" ? "info" : "error";
 
   return (
-    <AlertBanner variant={isSuccess ? "success" : "error"} size="sm">
+    <AlertBanner variant={variant} size="sm">
       {result.message}
     </AlertBanner>
   );

--- a/components/admin-invite/InviteResultBanner.tsx
+++ b/components/admin-invite/InviteResultBanner.tsx
@@ -16,6 +16,11 @@ export function InviteResultBanner({ result }: InviteResultBannerProps) {
   return (
     <AlertBanner variant={variant} size="sm">
       {result.message}
+      {result.inviteUrl ? (
+        <code className="mt-1.5 block select-all break-all rounded bg-muted px-2 py-1 font-mono text-xs text-foreground">
+          {result.inviteUrl}
+        </code>
+      ) : null}
     </AlertBanner>
   );
 }

--- a/components/admin-invite/RecentInvitesList.tsx
+++ b/components/admin-invite/RecentInvitesList.tsx
@@ -40,7 +40,9 @@ export function RecentInvitesList({ invites }: RecentInvitesListProps) {
               </div>
               <div className="flex items-center gap-2">
                 <Badge variant="outline">{inviteRoleLabels[invite.role]}</Badge>
-                <Badge variant="secondary">{invite.status}</Badge>
+                <Badge variant={invite.emailDelivery === "failed" ? "destructive" : "secondary"}>
+                  {invite.emailDelivery}
+                </Badge>
               </div>
             </li>
           ))}

--- a/components/admin-invite/invite-records.ts
+++ b/components/admin-invite/invite-records.ts
@@ -9,6 +9,6 @@ export function buildInviteRecordFromAccountInvite(
     email: invite.email.trim().toLowerCase(),
     role: invite.role,
     invitedAt: invite.invitedAt,
-    status: "sent",
+    emailDelivery: invite.emailDelivery,
   };
 }

--- a/components/admin-invite/types.ts
+++ b/components/admin-invite/types.ts
@@ -42,4 +42,6 @@ export type InviteActionResult = {
   status: InviteStatus;
   message: string;
   invite?: InviteRecord;
+  /** Set when the message asks the admin to share the invite link manually. */
+  inviteUrl?: string;
 };

--- a/components/admin-invite/types.ts
+++ b/components/admin-invite/types.ts
@@ -24,12 +24,18 @@ export type InviteFormValues = {
 
 export type InviteStatus = "sent" | "queued" | "error";
 
+/**
+ * Named emailDelivery (not status) because the admin users page already uses
+ * "Pending" as the acceptance status of an invite.
+ */
+export type InviteEmailDelivery = "sent" | "queued" | "failed";
+
 export type InviteRecord = {
   id: string;
   email: string;
   role: InviteRole;
   invitedAt: string;
-  status: Exclude<InviteStatus, "error">;
+  emailDelivery: InviteEmailDelivery;
 };
 
 export type InviteActionResult = {

--- a/components/admin-invite/types.ts
+++ b/components/admin-invite/types.ts
@@ -22,14 +22,14 @@ export type InviteFormValues = {
   organization: string;
 };
 
-export type InviteStatus = "sent" | "error";
+export type InviteStatus = "sent" | "queued" | "error";
 
 export type InviteRecord = {
   id: string;
   email: string;
   role: InviteRole;
   invitedAt: string;
-  status: InviteStatus;
+  status: Exclude<InviteStatus, "error">;
 };
 
 export type InviteActionResult = {

--- a/components/admin-invite/useAdminInvite.ts
+++ b/components/admin-invite/useAdminInvite.ts
@@ -49,20 +49,9 @@ export function useAdminInvite(input?: {
 
       void fetchRecentInvites()
         .then((nextInvites) => {
-          // The API only returns invites whose email already went out, so a
-          // queued invite must be kept visible from the action result.
-          const queuedInvite =
-            result.invite?.status === "queued" &&
-            !nextInvites.some((invite) => invite.id === result.invite?.id)
-              ? result.invite
-              : null;
-
-          queryClient.setQueryData(
-            queryKeys.recentInvites(),
-            queuedInvite
-              ? [queuedInvite, ...nextInvites].slice(0, MAX_RECENT_INVITES)
-              : nextInvites,
-          );
+          // The API derives emailDelivery from the email job, so queued and
+          // failed invites are included; no client-side merging is needed.
+          queryClient.setQueryData(queryKeys.recentInvites(), nextInvites);
         })
         .catch(() => {
           if (!result.invite) {

--- a/components/admin-invite/useAdminInvite.ts
+++ b/components/admin-invite/useAdminInvite.ts
@@ -43,7 +43,10 @@ export function useAdminInvite(input?: {
     (result: InviteActionResult) => {
       setLastResult(result);
 
-      if (result.status !== "sent" && result.status !== "queued") {
+      const inviteWasCreated =
+        result.status === "sent" || result.status === "queued" || Boolean(result.inviteUrl);
+
+      if (!inviteWasCreated) {
         return;
       }
 

--- a/components/admin-invite/useAdminInvite.ts
+++ b/components/admin-invite/useAdminInvite.ts
@@ -43,13 +43,26 @@ export function useAdminInvite(input?: {
     (result: InviteActionResult) => {
       setLastResult(result);
 
-      if (result.status !== "sent") {
+      if (result.status !== "sent" && result.status !== "queued") {
         return;
       }
 
       void fetchRecentInvites()
         .then((nextInvites) => {
-          queryClient.setQueryData(queryKeys.recentInvites(), nextInvites);
+          // The API only returns invites whose email already went out, so a
+          // queued invite must be kept visible from the action result.
+          const queuedInvite =
+            result.invite?.status === "queued" &&
+            !nextInvites.some((invite) => invite.id === result.invite?.id)
+              ? result.invite
+              : null;
+
+          queryClient.setQueryData(
+            queryKeys.recentInvites(),
+            queuedInvite
+              ? [queuedInvite, ...nextInvites].slice(0, MAX_RECENT_INVITES)
+              : nextInvites,
+          );
         })
         .catch(() => {
           if (!result.invite) {

--- a/components/admin-invite/useAdminInvite.unit.test.tsx
+++ b/components/admin-invite/useAdminInvite.unit.test.tsx
@@ -1,0 +1,68 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/app/query-keys";
+import { useAdminInvite } from "@/components/admin-invite/useAdminInvite";
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+  useQueryClient: jest.fn(),
+}));
+
+const setQueryDataMock = jest.fn();
+const fetchMock = jest.fn<typeof fetch>();
+const originalFetch = global.fetch;
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe("useAdminInvite", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useQuery).mockReturnValue({ data: [] } as ReturnType<typeof useQuery>);
+    jest.mocked(useQueryClient).mockReturnValue({
+      setQueryData: setQueryDataMock,
+    } as unknown as ReturnType<typeof useQueryClient>);
+    global.fetch = fetchMock;
+  });
+
+  it("refreshes recent invites when delivery failed after creating the invite", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: "2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+            email: "tenant@example.org",
+            name: "Tenant Example",
+            role: "user",
+            organization: null,
+            invitedAt: "2026-06-11T12:00:00.000Z",
+            emailDelivery: "failed",
+          },
+        ],
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useAdminInvite({ shouldHydrateInvites: false }));
+
+    act(() => {
+      result.current.handleInviteResult({
+        status: "error",
+        message: "Account invited, but the email could not be delivered.",
+        inviteUrl: "https://housing.example.org/invite?token=manual-link",
+      });
+    });
+
+    await waitFor(() => {
+      expect(setQueryDataMock).toHaveBeenCalledWith(queryKeys.recentInvites(), [
+        expect.objectContaining({
+          email: "tenant@example.org",
+          emailDelivery: "failed",
+        }),
+      ]);
+    });
+  });
+});

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -364,8 +364,8 @@ export const emailJobs = pgTable(
     status: emailJobStatusEnum("status").notNull().default("pending"),
     /**
      * Stable key for the logical email (e.g. account_invite/<inviteId>).
-     * Dedupes enqueues and is forwarded to the provider so retries cannot
-     * double-send.
+     * Dedupes enqueues and is forwarded to the provider so retries within
+     * Resend's 24h idempotency window cannot double-send.
      */
     idempotencyKey: text("idempotency_key").notNull(),
     payload: jsonb("payload")

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -46,6 +46,14 @@ export const customListingFieldTypeEnum = pgEnum("listing_field_type", [
   "multi_select",
   "date",
 ]);
+export const emailJobTypeEnum = pgEnum("email_job_type", ["account_invite"]);
+export const emailJobStatusEnum = pgEnum("email_job_status", [
+  "pending",
+  "processing",
+  "sent",
+  "failed",
+  "canceled",
+]);
 
 export type SavedSearchFilters = {
   bathrooms?: number | null;
@@ -338,6 +346,58 @@ export const customListingFields = pgTable(
   ],
 );
 
+export type EmailJobType = (typeof emailJobTypeEnum.enumValues)[number];
+export type EmailJobStatus = (typeof emailJobStatusEnum.enumValues)[number];
+
+/**
+ * Stable entity references only (inviteId, passwordResetId, ...). Raw tokens,
+ * one-time links, and other secrets must never appear here; they belong in the
+ * encrypted secret_context column.
+ */
+export type EmailJobPayload = Record<string, string>;
+
+export const emailJobs = pgTable(
+  "email_jobs",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    type: emailJobTypeEnum("type").notNull(),
+    status: emailJobStatusEnum("status").notNull().default("pending"),
+    /**
+     * Stable key for the logical email (e.g. account_invite/<inviteId>).
+     * Dedupes enqueues and is forwarded to the provider so retries cannot
+     * double-send.
+     */
+    idempotencyKey: text("idempotency_key").notNull(),
+    payload: jsonb("payload")
+      .$type<EmailJobPayload>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    /**
+     * AES-256-GCM encrypted JSON for send-time data that cannot be re-derived
+     * from entity references (e.g. the invite URL containing the raw token).
+     * Cleared as soon as the job reaches a terminal state.
+     */
+    secretContext: byteaBuffer("secret_context"),
+    recipientEmail: text("recipient_email").notNull(),
+    attempts: integer("attempts").notNull().default(0),
+    maxAttempts: integer("max_attempts").notNull(),
+    runAfter: timestamp("run_after", { withTimezone: true }).notNull().defaultNow(),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    sentAt: timestamp("sent_at", { withTimezone: true }),
+    providerMessageId: text("provider_message_id"),
+    lastError: text("last_error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("email_jobs_idempotency_key_unique").on(table.idempotencyKey),
+    index("email_jobs_status_run_after_idx").on(table.status, table.runAfter),
+  ],
+);
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type UserInvite = typeof userInvites.$inferSelect;
@@ -354,3 +414,5 @@ export type SavedSearch = typeof savedSearches.$inferSelect;
 export type NewSavedSearch = typeof savedSearches.$inferInsert;
 export type CustomListingField = typeof customListingFields.$inferSelect;
 export type NewCustomListingField = typeof customListingFields.$inferInsert;
+export type EmailJob = typeof emailJobs.$inferSelect;
+export type NewEmailJob = typeof emailJobs.$inferInsert;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-ChangeMe123}
       RESEND_API_KEY: ${RESEND_API_KEY:-re_replace_me}
       EMAIL_FROM: ${EMAIL_FROM:-Affordable Housing Portal <no-reply@example.com>}
+      CRON_SECRET: ${CRON_SECRET:-replace-with-a-random-secret}
     ports:
       - "3000:3000"
     volumes:
@@ -43,6 +44,25 @@ services:
       - /app/node_modules
     command: >
       sh -c "npm run db:migrate && npm run db:seed && npm run dev -- --hostname 0.0.0.0 --port 3000"
+
+  # Opt-in email queue worker: docker compose --profile worker up
+  email-worker:
+    container_name: ahp-email-worker
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    restart: unless-stopped
+    profiles:
+      - worker
+    depends_on:
+      - app
+    environment:
+      EMAIL_WORKER_APP_URL: http://app:3000
+      CRON_SECRET: ${CRON_SECRET:-replace-with-a-random-secret}
+    volumes:
+      - .:/app
+      - /app/node_modules
+    command: node scripts/email-worker.mjs
 
 volumes:
   ahp-postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY:-re_replace_me}
       EMAIL_FROM: ${EMAIL_FROM:-Affordable Housing Portal <no-reply@example.com>}
       CRON_SECRET: ${CRON_SECRET:-replace-with-a-random-secret}
+      # Optional dedicated key for encrypted email job payloads; empty falls
+      # back to a key derived from AUTH_SECRET.
+      EMAIL_JOB_SECRET_KEY: ${EMAIL_JOB_SECRET_KEY:-}
     ports:
       - "3000:3000"
     volumes:

--- a/docs/email-queue.md
+++ b/docs/email-queue.md
@@ -13,7 +13,10 @@ of calling Resend directly from feature code.
    provider outage.
 2. **Immediate attempt** — Right after commit, the service makes one
    best-effort `tryProcessEmailJobNow(...)` call so the common case delivers
-   within the request. Failures are swallowed; the job stays queued.
+   within the request. Failures are swallowed (the job stays queued), but the
+   outcome is returned so callers report delivery truthfully: the admin invite
+   flow surfaces "sent" only when the provider accepted the email and "queued"
+   otherwise, never a false success.
 3. **Worker drain** — A worker repeatedly claims due jobs and processes them.
    Claiming uses `SELECT ... FOR UPDATE SKIP LOCKED` plus a 10-minute
    processing lease, so any number of workers can run concurrently without

--- a/docs/email-queue.md
+++ b/docs/email-queue.md
@@ -1,0 +1,114 @@
+# Transactional Email Queue
+
+All transactional email (currently account invites; password resets and saved
+search alerts later) is delivered through a Postgres-backed job queue instead
+of calling Resend directly from feature code.
+
+## How it works
+
+1. **Enqueue (outbox)** — Feature services call
+   `enqueueEmailJob(...)` from `lib/email-jobs/email-job-service.ts`, passing
+   their open Drizzle transaction. The job row commits atomically with the
+   entity that triggered it, so a created invite can never lose its email to a
+   provider outage.
+2. **Immediate attempt** — Right after commit, the service makes one
+   best-effort `tryProcessEmailJobNow(...)` call so the common case delivers
+   within the request. Failures are swallowed; the job stays queued.
+3. **Worker drain** — A worker repeatedly claims due jobs and processes them.
+   Claiming uses `SELECT ... FOR UPDATE SKIP LOCKED` plus a 10-minute
+   processing lease, so any number of workers can run concurrently without
+   double-claiming, and jobs from crashed workers are reclaimed.
+4. **Retries** — Transient failures are retried with exponential backoff
+   (30s doubling to a 30min cap, ±20% jitter) up to `max_attempts` (default 7).
+   Exhausted jobs are dead-lettered as `failed` with sanitized error context.
+
+## Job lifecycle
+
+```
+pending ──claim──▶ processing ──▶ sent       (provider accepted; terminal)
+   ▲                   │
+   └───retry+backoff───┼────────▶ failed     (attempts exhausted; terminal)
+                       └────────▶ canceled   (obsolete, e.g. invite accepted/
+                                              expired/superseded; terminal)
+```
+
+Every send passes the job's idempotency key (e.g. `account_invite/<inviteId>`)
+to Resend, so a retry after a crash cannot double-send a logical email. The
+same key has a unique index on `email_jobs`, so re-enqueueing is a no-op.
+
+## Sensitive payloads
+
+Job payloads (`payload` jsonb) hold **stable entity references only**
+(`inviteId`, later `passwordResetId`, ...). Recipient name/email are loaded
+fresh at send time.
+
+Data that cannot be re-derived at processing time — the invite URL containing
+the raw one-time token (only its hash is stored on `user_invites`) — is kept in
+`secret_context`, encrypted with AES-256-GCM. The key comes from
+`EMAIL_JOB_SECRET_KEY` (32 bytes, base64; `openssl rand -base64 32`) or, when
+unset, is derived from `AUTH_SECRET` via HKDF. `secret_context` is deleted as
+soon as a job reaches a terminal state; completed jobs retain only type,
+recipient, provider message id, timestamps, attempts, and sanitized errors.
+
+Rotating the encryption key makes still-pending secret contexts undecryptable;
+those jobs fail with a clear error and can be re-issued (e.g. re-invite).
+
+## Running the worker
+
+The drain endpoint `POST|GET /api/cron/email-jobs` requires
+`Authorization: Bearer $CRON_SECRET` and processes due jobs for up to ~50s per
+call. It is safe to call from several schedulers at once.
+
+- **Local dev** — usually unnecessary: the immediate attempt sends invites
+  inline. To process retries, run `npm run email:worker` next to `npm run dev`
+  (uses `CRON_SECRET` and optional `EMAIL_WORKER_APP_URL` /
+  `EMAIL_WORKER_POLL_INTERVAL_MS`, default `http://localhost:3000` / 15s).
+- **Docker** — `docker compose --profile worker up` starts the `email-worker`
+  service alongside the app.
+- **Vercel / serverless** — schedule the endpoint with a cron, e.g. in
+  `vercel.json`:
+
+  ```json
+  { "crons": [{ "path": "/api/cron/email-jobs", "schedule": "* * * * *" }] }
+  ```
+
+  Vercel sends `Authorization: Bearer $CRON_SECRET` automatically when the
+  `CRON_SECRET` env var is set.
+
+- **Self-hosted deployment** — run `node scripts/email-worker.mjs` as a
+  long-lived process (systemd, container), or hit the endpoint from system
+  cron.
+
+## Operations
+
+Failed jobs stay visible: the drain response reports
+`backlog: { pending, failed }`, and dead-lettered rows keep their sanitized
+`last_error`:
+
+```sql
+select id, type, recipient_email, attempts, last_error, updated_at
+from email_jobs where status = 'failed' order by updated_at desc;
+```
+
+To retry a failed job after fixing the cause:
+
+```sql
+update email_jobs
+set status = 'pending', attempts = 0, run_after = now()
+where id = '<job id>';
+```
+
+(For `account_invite` jobs whose secret context was already cleared, issue a
+fresh invite instead — the old one-time URL is not recoverable by design.)
+
+## Adding a new email type
+
+1. Add the type to `email_job_type` (enum migration) and to
+   `EmailJobDescriptor` in `lib/email-jobs/types.ts`, declaring which fields
+   are plain payload references vs encrypted secret context.
+2. Implement a handler in `lib/email-jobs/handlers.ts` that loads entities by
+   reference, decides whether the send is still relevant (throw
+   `EmailJobCanceledError` if not), renders content, and calls
+   `sendTransactionalEmail` with the job's idempotency key.
+3. Enqueue with `enqueueEmailJob(...)` inside the feature's transaction. Do not
+   call Resend directly.

--- a/docs/email-queue.md
+++ b/docs/email-queue.md
@@ -18,18 +18,29 @@ of calling Resend directly from feature code.
    flow surfaces "sent" only when the provider accepted the email and "queued"
    otherwise, never a false success. The attempt is bounded by a ~5s deadline
    so a hanging provider cannot stall the admin request; the deadline does
-   not cancel the in-flight send. If the runtime keeps the process alive a
-   late success still records `sent`; on serverless runtimes that freeze
-   background work the claimed job waits out the 10-minute lease and is
-   reclaimed by a worker, with the provider idempotency key preventing a
-   double-send.
+   not cancel the in-flight send (the provider call itself is bounded by the
+   15s send timeout). If the runtime keeps the process alive a late outcome
+   is still recorded as long as the attempt's claim is held; on serverless
+   runtimes that freeze background work the claimed job waits out the
+   10-minute lease and is reclaimed by a worker, with the provider
+   idempotency key preventing a double-send.
 3. **Worker drain** — A worker repeatedly claims due jobs and processes them.
    Claiming uses `SELECT ... FOR UPDATE SKIP LOCKED` plus a 10-minute
    processing lease, so any number of workers can run concurrently without
-   double-claiming, and jobs from crashed workers are reclaimed.
-4. **Retries** — Transient failures are retried with exponential backoff
-   (30s doubling to a 30min cap, ±20% jitter) up to `max_attempts` (default 7).
-   Exhausted jobs are dead-lettered as `failed` with sanitized error context.
+   double-claiming, and jobs from crashed workers are reclaimed. Jobs are
+   claimed **one at a time**: a claim burns an attempt, so claiming a batch
+   would let one hung send (or a killed worker) exhaust the attempts of jobs
+   that were never processed.
+4. **Retries** — Each provider call is bounded by a hard 15s timeout, and
+   transient failures are retried with exponential backoff (30s doubling to a
+   30min cap, ±20% jitter) up to `max_attempts` (default 7). Exhausted jobs
+   are dead-lettered as `failed` with sanitized error context.
+5. **Claim ownership** — Every outcome write (`sent`, `canceled`, `failed`,
+   retry) must present the `claimed_at` token of the claim it belongs to. A
+   stale writer — e.g. a very late inline attempt whose job was already
+   reclaimed after its lease expired — becomes a no-op instead of clobbering
+   the state written by the worker that now owns the job; the provider
+   idempotency key keeps the email itself exactly-once throughout.
 
 ## Job lifecycle
 
@@ -74,15 +85,18 @@ call. It is safe to call from several schedulers at once.
   `EMAIL_WORKER_POLL_INTERVAL_MS`, default `http://localhost:3000` / 15s).
 - **Docker** — `docker compose --profile worker up` starts the `email-worker`
   service alongside the app.
-- **Vercel / serverless** — schedule the endpoint with a cron, e.g. in
-  `vercel.json`:
+- **Vercel / serverless** — the repository ships a `vercel.json` that
+  schedules the endpoint daily:
 
   ```json
-  { "crons": [{ "path": "/api/cron/email-jobs", "schedule": "* * * * *" }] }
+  { "crons": [{ "path": "/api/cron/email-jobs", "schedule": "0 6 * * *" }] }
   ```
 
-  Vercel sends `Authorization: Bearer $CRON_SECRET` automatically when the
-  `CRON_SECRET` env var is set.
+  The daily schedule is the most frequent one Vercel Hobby plans allow; on a
+  Pro plan, tighten it (e.g. `*/5 * * * *`) so retries drain within minutes
+  instead of relying on the inline attempt. Vercel sends
+  `Authorization: Bearer $CRON_SECRET` automatically when the `CRON_SECRET`
+  env var is set.
 
 - **Self-hosted deployment** — run `node scripts/email-worker.mjs` as a
   long-lived process (systemd, container), or hit the endpoint from system

--- a/docs/email-queue.md
+++ b/docs/email-queue.md
@@ -60,11 +60,12 @@ same key has a unique index on `email_jobs`, so re-enqueueing is a no-op.
 **The provider-side dedupe is time-bounded**: Resend idempotency keys expire
 after 24 hours. A retry more than 24 hours after an unrecorded-but-delivered
 send (e.g. a timed-out request that actually landed) would deliver again.
-This is why production **requires a drain scheduler running every few
-minutes** (see below): with one, the whole retry schedule — 7 attempts,
-backoff capped at 30 minutes, 10-minute lease reclaims — completes within a
-few hours, comfortably inside the window. An infrequent (e.g. daily-only)
-drain would space retries ~24h apart and break the dedupe guarantee.
+Crash-abandoned processing claims are therefore reclaimable only between the
+10-minute lease expiry and a conservative 23-hour cutoff. Claims older than
+that are dead-lettered instead of retried, preventing that crash-and-outage
+path from causing duplicate delivery. Production still **requires a drain
+scheduler running every few minutes** (see below): pending retries after an
+ambiguous provider timeout must also complete inside the 24-hour window.
 
 ## Sensitive payloads
 

--- a/docs/email-queue.md
+++ b/docs/email-queue.md
@@ -16,7 +16,13 @@ of calling Resend directly from feature code.
    within the request. Failures are swallowed (the job stays queued), but the
    outcome is returned so callers report delivery truthfully: the admin invite
    flow surfaces "sent" only when the provider accepted the email and "queued"
-   otherwise, never a false success.
+   otherwise, never a false success. The attempt is bounded by a ~5s deadline
+   so a hanging provider cannot stall the admin request; the deadline does
+   not cancel the in-flight send. If the runtime keeps the process alive a
+   late success still records `sent`; on serverless runtimes that freeze
+   background work the claimed job waits out the 10-minute lease and is
+   reclaimed by a worker, with the provider idempotency key preventing a
+   double-send.
 3. **Worker drain** — A worker repeatedly claims due jobs and processes them.
    Claiming uses `SELECT ... FOR UPDATE SKIP LOCKED` plus a 10-minute
    processing lease, so any number of workers can run concurrently without

--- a/docs/email-queue.md
+++ b/docs/email-queue.md
@@ -19,11 +19,11 @@ of calling Resend directly from feature code.
    otherwise, never a false success. The attempt is bounded by a ~5s deadline
    so a hanging provider cannot stall the admin request; the deadline does
    not cancel the in-flight send (the provider call itself is bounded by the
-   15s send timeout). If the runtime keeps the process alive a late outcome
-   is still recorded as long as the attempt's claim is held; on serverless
-   runtimes that freeze background work the claimed job waits out the
-   10-minute lease and is reclaimed by a worker, with the provider
-   idempotency key preventing a double-send.
+   15s send timeout). A deadline-exceeded attempt is handed to next/server's
+   `after()`, which keeps serverless invocations alive until the late outcome
+   (sent, or the retry schedule) is recorded. Should the process die anyway,
+   the claimed job waits out the 10-minute lease and is reclaimed by a
+   worker, with the provider idempotency key preventing a double-send.
 3. **Worker drain** — A worker repeatedly claims due jobs and processes them.
    Claiming uses `SELECT ... FOR UPDATE SKIP LOCKED` plus a 10-minute
    processing lease, so any number of workers can run concurrently without
@@ -40,7 +40,8 @@ of calling Resend directly from feature code.
    stale writer — e.g. a very late inline attempt whose job was already
    reclaimed after its lease expired — becomes a no-op instead of clobbering
    the state written by the worker that now owns the job; the provider
-   idempotency key keeps the email itself exactly-once throughout.
+   idempotency key keeps the email itself single-send within Resend's
+   24-hour idempotency window (see below).
 
 ## Job lifecycle
 
@@ -55,6 +56,15 @@ pending ──claim──▶ processing ──▶ sent       (provider accepted;
 Every send passes the job's idempotency key (e.g. `account_invite/<inviteId>`)
 to Resend, so a retry after a crash cannot double-send a logical email. The
 same key has a unique index on `email_jobs`, so re-enqueueing is a no-op.
+
+**The provider-side dedupe is time-bounded**: Resend idempotency keys expire
+after 24 hours. A retry more than 24 hours after an unrecorded-but-delivered
+send (e.g. a timed-out request that actually landed) would deliver again.
+This is why production **requires a drain scheduler running every few
+minutes** (see below): with one, the whole retry schedule — 7 attempts,
+backoff capped at 30 minutes, 10-minute lease reclaims — completes within a
+few hours, comfortably inside the window. An infrequent (e.g. daily-only)
+drain would space retries ~24h apart and break the dedupe guarantee.
 
 ## Sensitive payloads
 
@@ -79,28 +89,34 @@ The drain endpoint `POST|GET /api/cron/email-jobs` requires
 `Authorization: Bearer $CRON_SECRET` and processes due jobs for up to ~50s per
 call. It is safe to call from several schedulers at once.
 
-- **Local dev** — usually unnecessary: the immediate attempt sends invites
-  inline. To process retries, run `npm run email:worker` next to `npm run dev`
-  (uses `CRON_SECRET` and optional `EMAIL_WORKER_APP_URL` /
-  `EMAIL_WORKER_POLL_INTERVAL_MS`, default `http://localhost:3000` / 15s).
-- **Docker** — `docker compose --profile worker up` starts the `email-worker`
-  service alongside the app.
-- **Vercel / serverless** — the repository ships a `vercel.json` that
-  schedules the endpoint daily:
+**Production requires a scheduler that drains every few minutes** — not just
+for latency, but for correctness: retries must stay inside Resend's 24-hour
+idempotency window (see above). Pick at least one:
 
-  ```json
-  { "crons": [{ "path": "/api/cron/email-jobs", "schedule": "0 6 * * *" }] }
-  ```
-
-  The daily schedule is the most frequent one Vercel Hobby plans allow; on a
-  Pro plan, tighten it (e.g. `*/5 * * * *`) so retries drain within minutes
-  instead of relying on the inline attempt. Vercel sends
-  `Authorization: Bearer $CRON_SECRET` automatically when the `CRON_SECRET`
-  env var is set.
-
+- **GitHub Actions (shipped, works on any Vercel plan)** — the repository
+  ships `.github/workflows/email-queue-drain.yml`, which calls the endpoint
+  every 5 minutes. To activate it, set the repository **variable**
+  `EMAIL_QUEUE_DRAIN_URL` (e.g.
+  `https://<production-host>/api/cron/email-jobs`) and the repository
+  **secret** `CRON_SECRET` (same value as the deployment env var). The
+  workflow is skipped while the variable is unset. Note GitHub disables
+  scheduled workflows after 60 days without repository activity.
+- **Vercel cron** — `vercel.json` schedules the endpoint daily
+  (`0 6 * * *`) as a backstop; that is the most frequent schedule Vercel
+  Hobby allows and is **not sufficient on its own**. On a Pro plan, tighten
+  it (e.g. `*/5 * * * *`) and the GitHub Actions workflow becomes redundant.
+  Vercel sends `Authorization: Bearer $CRON_SECRET` automatically when the
+  `CRON_SECRET` env var is set.
 - **Self-hosted deployment** — run `node scripts/email-worker.mjs` as a
   long-lived process (systemd, container), or hit the endpoint from system
   cron.
+
+For local development a worker is usually unnecessary: the immediate attempt
+sends invites inline. To process retries, run `npm run email:worker` next to
+`npm run dev` (uses `CRON_SECRET` and optional `EMAIL_WORKER_APP_URL` /
+`EMAIL_WORKER_POLL_INTERVAL_MS`, default `http://localhost:3000` / 15s), or
+`docker compose --profile worker up` to start the `email-worker` service
+alongside the app.
 
 ## Operations
 
@@ -123,6 +139,12 @@ where id = '<job id>';
 
 (For `account_invite` jobs whose secret context was already cleared, issue a
 fresh invite instead — the old one-time URL is not recoverable by design.)
+
+Manually retrying a job whose last send attempt was **more than 24 hours ago**
+is outside the provider's idempotency window: if an earlier attempt actually
+delivered without being recorded, the retry will deliver a second copy. For
+invites that is annoying rather than harmful, but check `sent_at` /
+`provider_message_id` and the Resend dashboard before re-running old jobs.
 
 ## Adding a new email type
 

--- a/drizzle/20260610233211_email_jobs.sql
+++ b/drizzle/20260610233211_email_jobs.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."email_job_status" AS ENUM('pending', 'processing', 'sent', 'failed', 'canceled');--> statement-breakpoint
+CREATE TYPE "public"."email_job_type" AS ENUM('account_invite');--> statement-breakpoint
+CREATE TABLE "email_jobs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"type" "email_job_type" NOT NULL,
+	"status" "email_job_status" DEFAULT 'pending' NOT NULL,
+	"idempotency_key" text NOT NULL,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"secret_context" "bytea",
+	"recipient_email" text NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"max_attempts" integer NOT NULL,
+	"run_after" timestamp with time zone DEFAULT now() NOT NULL,
+	"claimed_at" timestamp with time zone,
+	"sent_at" timestamp with time zone,
+	"provider_message_id" text,
+	"last_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "email_jobs_idempotency_key_unique" ON "email_jobs" USING btree ("idempotency_key");--> statement-breakpoint
+CREATE INDEX "email_jobs_status_run_after_idx" ON "email_jobs" USING btree ("status","run_after");

--- a/drizzle/meta/20260610233211_snapshot.json
+++ b/drizzle/meta/20260610233211_snapshot.json
@@ -1,0 +1,1628 @@
+{
+  "id": "daa2f008-7c5d-45c1-9ebe-76a326a3a59f",
+  "prevId": "2315f558-8402-4c36-a485-f060957cc4af",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.listing_field_definitions": {
+      "name": "listing_field_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "listing_field_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "help_text": {
+          "name": "help_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_filterable": {
+          "name": "is_filterable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listing_field_definitions_key_unique": {
+          "name": "listing_field_definitions_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_field_definitions_category_idx": {
+          "name": "listing_field_definitions_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_field_definitions_sort_order_idx": {
+          "name": "listing_field_definitions_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listing_field_definitions_created_by_user_id_users_id_fk": {
+          "name": "listing_field_definitions_created_by_user_id_users_id_fk",
+          "tableFrom": "listing_field_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "listing_field_definitions_updated_by_user_id_users_id_fk": {
+          "name": "listing_field_definitions_updated_by_user_id_users_id_fk",
+          "tableFrom": "listing_field_definitions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_jobs": {
+      "name": "email_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "email_job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "email_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "secret_context": {
+          "name": "secret_context",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_after": {
+          "name": "run_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_jobs_idempotency_key_unique": {
+          "name": "email_jobs_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_jobs_status_run_after_idx": {
+          "name": "email_jobs_status_run_after_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_after",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listing_images": {
+      "name": "listing_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_session_id": {
+          "name": "upload_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listing_images_listing_id_idx": {
+          "name": "listing_images_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_images_upload_session_id_idx": {
+          "name": "listing_images_upload_session_id_idx",
+          "columns": [
+            {
+              "expression": "upload_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_images_uploaded_by_user_id_idx": {
+          "name": "listing_images_uploaded_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listing_images_listing_id_listings_id_fk": {
+          "name": "listing_images_listing_id_listings_id_fk",
+          "tableFrom": "listing_images",
+          "tableTo": "listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listing_images_uploaded_by_user_id_users_id_fk": {
+          "name": "listing_images_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "listing_images",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listings": {
+      "name": "listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "listing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_number": {
+          "name": "unit_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "building_type": {
+          "name": "building_type",
+          "type": "listing_building_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "square_feet": {
+          "name": "square_feet",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_rent_cents": {
+          "name": "monthly_rent_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_on": {
+          "name": "available_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_term_months": {
+          "name": "lease_term_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilities_included": {
+          "name": "utilities_included",
+          "type": "utility_included[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::utility_included[]"
+        },
+        "max_income_cents": {
+          "name": "max_income_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_url": {
+          "name": "application_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_email": {
+          "name": "application_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_phone": {
+          "name": "application_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_instructions": {
+          "name": "application_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_fields": {
+          "name": "custom_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listings_property_id_idx": {
+          "name": "listings_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_status_published_at_idx": {
+          "name": "listings_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_monthly_rent_cents_idx": {
+          "name": "listings_monthly_rent_cents_idx",
+          "columns": [
+            {
+              "expression": "monthly_rent_cents",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_bedrooms_bathrooms_idx": {
+          "name": "listings_bedrooms_bathrooms_idx",
+          "columns": [
+            {
+              "expression": "bedrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bathrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_available_on_idx": {
+          "name": "listings_available_on_idx",
+          "columns": [
+            {
+              "expression": "available_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_custom_fields_gin_idx": {
+          "name": "listings_custom_fields_gin_idx",
+          "columns": [
+            {
+              "expression": "custom_fields",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listings_property_id_properties_id_fk": {
+          "name": "listings_property_id_properties_id_fk",
+          "tableFrom": "listings",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "listings_created_by_user_id_users_id_fk": {
+          "name": "listings_created_by_user_id_users_id_fk",
+          "tableFrom": "listings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "listings_updated_by_user_id_users_id_fk": {
+          "name": "listings_updated_by_user_id_users_id_fk",
+          "tableFrom": "listings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_1": {
+          "name": "street_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_2": {
+          "name": "street_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "province": {
+          "name": "province",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighborhood": {
+          "name": "neighborhood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "properties_owner_user_id_idx": {
+          "name": "properties_owner_user_id_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_city_idx": {
+          "name": "properties_city_idx",
+          "columns": [
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "properties_owner_user_id_users_id_fk": {
+          "name": "properties_owner_user_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "properties_created_by_user_id_users_id_fk": {
+          "name": "properties_created_by_user_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "properties_updated_by_user_id_users_id_fk": {
+          "name": "properties_updated_by_user_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_listings": {
+      "name": "saved_listings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_listings_user_id_idx": {
+          "name": "saved_listings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_listings_listing_id_idx": {
+          "name": "saved_listings_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_listings_user_id_users_id_fk": {
+          "name": "saved_listings_user_id_users_id_fk",
+          "tableFrom": "saved_listings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_listings_listing_id_listings_id_fk": {
+          "name": "saved_listings_listing_id_listings_id_fk",
+          "tableFrom": "saved_listings",
+          "tableTo": "listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_listings_pk": {
+          "name": "saved_listings_pk",
+          "columns": [
+            "user_id",
+            "listing_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_searches": {
+      "name": "saved_searches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_searches_user_id_idx": {
+          "name": "saved_searches_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_searches_user_id_users_id_fk": {
+          "name": "saved_searches_user_id_users_id_fk",
+          "tableFrom": "saved_searches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_invites": {
+      "name": "user_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_invites_token_hash_unique": {
+          "name": "user_invites_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_invites_user_id_idx": {
+          "name": "user_invites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_invites_email_idx": {
+          "name": "user_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_invites_created_by_user_id_idx": {
+          "name": "user_invites_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_invites_user_id_users_id_fk": {
+          "name": "user_invites_user_id_users_id_fk",
+          "tableFrom": "user_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_invites_created_by_user_id_users_id_fk": {
+          "name": "user_invites_created_by_user_id_users_id_fk",
+          "tableFrom": "user_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_auth_id": {
+          "name": "external_auth_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_accepted_at": {
+          "name": "invite_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_external_auth_id_unique": {
+          "name": "users_external_auth_id_unique",
+          "columns": [
+            {
+              "expression": "external_auth_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_status_idx": {
+          "name": "users_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.listing_field_type": {
+      "name": "listing_field_type",
+      "schema": "public",
+      "values": [
+        "boolean",
+        "number",
+        "text",
+        "select",
+        "multi_select",
+        "date"
+      ]
+    },
+    "public.email_job_status": {
+      "name": "email_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "sent",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.email_job_type": {
+      "name": "email_job_type",
+      "schema": "public",
+      "values": [
+        "account_invite"
+      ]
+    },
+    "public.listing_building_type": {
+      "name": "listing_building_type",
+      "schema": "public",
+      "values": [
+        "apartment",
+        "house",
+        "townhouse",
+        "condo"
+      ]
+    },
+    "public.listing_status": {
+      "name": "listing_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "archived"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "partner",
+        "user"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "active",
+        "suspended",
+        "deactivated"
+      ]
+    },
+    "public.utility_included": {
+      "name": "utility_included",
+      "schema": "public",
+      "values": [
+        "heat",
+        "water",
+        "electricity",
+        "gas",
+        "internet"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779735372627,
       "tag": "20260525185612_add_listing_built_in_field_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781134331494,
+      "tag": "20260610233211_email_jobs",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/accounts/account.service.ts
+++ b/lib/accounts/account.service.ts
@@ -112,8 +112,18 @@ export async function createAccountService(
     sendInviteEmail: input.sendInviteEmail === true,
   });
 
+  const messageByEmailDelivery = {
+    sent: "Account invited",
+    queued:
+      "Account invited. The invite email is queued and will be delivered automatically once the email provider is reachable.",
+    failed:
+      "Account invited, but the invite email could not be delivered. Share the invite link manually or send a new invite.",
+  } as const;
+
   return succeed({
-    message: "Account invited",
+    message: invite.emailDelivery
+      ? messageByEmailDelivery[invite.emailDelivery]
+      : "Account invited",
     data: {
       id: invite.userId,
       email: invite.email,
@@ -121,6 +131,7 @@ export async function createAccountService(
       role: input.role,
       organization: invite.organization,
       inviteUrl: invite.inviteUrl,
+      emailDelivery: invite.emailDelivery,
     },
   });
 }

--- a/lib/auth/invite-email.ts
+++ b/lib/auth/invite-email.ts
@@ -1,36 +1,22 @@
 import "server-only";
 
-import {
-  createResendClient,
-  getEmailFromAddress,
-  type TransactionalEmailSendOptions,
-} from "@/lib/email";
+import type { TransactionalEmailContent } from "@/lib/email";
 
-export async function sendInviteEmail(
-  params: {
-    email: string;
-    fullName: string;
-    inviteUrl: string;
-  } & TransactionalEmailSendOptions,
-) {
-  const resend = createResendClient();
+/**
+ * Renders the account invite email. Sending goes through the email job queue
+ * (lib/email-jobs); this module must stay free of provider calls.
+ */
+export function renderAccountInviteEmail(params: {
+  fullName: string;
+  inviteUrl: string;
+}): TransactionalEmailContent {
   const inviteUrl = getSafeInviteUrl(params.inviteUrl);
-  const result = await resend.emails.send(
-    {
-      from: getEmailFromAddress(),
-      to: params.email,
-      subject: "You’ve been invited to the Affordable Housing Portal",
-      text: `Hello ${params.fullName},\n\nYou’ve been invited to the Affordable Housing Portal. Use the link below to create your password and activate your account:\n\n${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`,
-      html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>You’ve been invited to the Affordable Housing Portal.</p><p><a href="${escapeHtml(inviteUrl)}">Create your password and activate your account</a></p><p>If you were not expecting this invite, you can ignore this email.</p>`,
-    },
-    {
-      idempotencyKey: params.idempotencyKey,
-    },
-  );
 
-  if (result.error) {
-    throw new Error(result.error.message);
-  }
+  return {
+    subject: "You’ve been invited to the Affordable Housing Portal",
+    text: `Hello ${params.fullName},\n\nYou’ve been invited to the Affordable Housing Portal. Use the link below to create your password and activate your account:\n\n${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`,
+    html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>You’ve been invited to the Affordable Housing Portal.</p><p><a href="${escapeHtml(inviteUrl)}">Create your password and activate your account</a></p><p>If you were not expecting this invite, you can ignore this email.</p>`,
+  };
 }
 
 export function getAccountInviteEmailIdempotencyKey(inviteId: string) {

--- a/lib/auth/invite-email.unit.test.ts
+++ b/lib/auth/invite-email.unit.test.ts
@@ -1,16 +1,9 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 
-import { createResendClient, getEmailFromAddress } from "@/lib/email";
-import { getAccountInviteEmailIdempotencyKey, sendInviteEmail } from "@/lib/auth/invite-email";
-
-jest.mock("@/lib/email", () => ({
-  createResendClient: jest.fn(),
-  getEmailFromAddress: jest.fn(),
-}));
-
-const createResendClientMock = jest.mocked(createResendClient);
-const getEmailFromAddressMock = jest.mocked(getEmailFromAddress);
-const sendMock = jest.fn<(...args: unknown[]) => Promise<{ data: { id: string }; error: null }>>();
+import {
+  getAccountInviteEmailIdempotencyKey,
+  renderAccountInviteEmail,
+} from "@/lib/auth/invite-email";
 
 describe("getAccountInviteEmailIdempotencyKey", () => {
   it("uses the persisted invite id as the stable logical email key", () => {
@@ -20,37 +13,36 @@ describe("getAccountInviteEmailIdempotencyKey", () => {
   });
 });
 
-describe("sendInviteEmail", () => {
-  beforeEach(() => {
-    sendMock.mockReset();
-    sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
-    createResendClientMock.mockReset();
-    createResendClientMock.mockReturnValue({
-      emails: {
-        send: sendMock,
-      },
-    } as unknown as ReturnType<typeof createResendClient>);
-    getEmailFromAddressMock.mockReset();
-    getEmailFromAddressMock.mockReturnValue("Affordable Housing Portal <no-reply@example.org>");
-  });
-
-  it("passes the invite idempotency key to Resend provider options", async () => {
-    await sendInviteEmail({
-      email: "tenant@example.org",
+describe("renderAccountInviteEmail", () => {
+  it("renders the invite link into subject, text, and html", () => {
+    const content = renderAccountInviteEmail({
       fullName: "Tenant User",
       inviteUrl: "https://housing.example.org/invite?token=abc123",
-      idempotencyKey: getAccountInviteEmailIdempotencyKey("2e42f745-44e8-4ab7-a2a2-c1f42cc8e204"),
     });
 
-    expect(sendMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: "Affordable Housing Portal <no-reply@example.org>",
-        to: "tenant@example.org",
-        subject: "You’ve been invited to the Affordable Housing Portal",
+    expect(content.subject).toBe("You’ve been invited to the Affordable Housing Portal");
+    expect(content.text).toContain("Hello Tenant User,");
+    expect(content.text).toContain("https://housing.example.org/invite?token=abc123");
+    expect(content.html).toContain('href="https://housing.example.org/invite?token=abc123"');
+  });
+
+  it("escapes HTML in the recipient name", () => {
+    const content = renderAccountInviteEmail({
+      fullName: '<img src="x">',
+      inviteUrl: "https://housing.example.org/invite?token=abc123",
+    });
+
+    expect(content.html).not.toContain('<img src="x">');
+    expect(content.html).toContain("&lt;img src=&quot;x&quot;&gt;");
+  });
+
+  it("rejects invite URLs that are not http(s)", () => {
+    expect(() =>
+      renderAccountInviteEmail({
+        fullName: "Tenant User",
+        // oxlint-disable-next-line no-script-url
+        inviteUrl: "javascript:alert(1)",
       }),
-      {
-        idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
-      },
-    );
+    ).toThrow("Invite URL must use http or https.");
   });
 });

--- a/lib/auth/invite-service.ts
+++ b/lib/auth/invite-service.ts
@@ -12,6 +12,14 @@ import { enqueueEmailJob, tryProcessEmailJobNow } from "@/lib/email-jobs/email-j
 
 const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7;
 
+/**
+ * Truthful delivery status for the invite email: "sent" only when the
+ * provider accepted it during the request, "queued" while the durable job
+ * still owns delivery, "failed" when the job already dead-lettered, and null
+ * when no email was requested.
+ */
+export type InviteEmailDelivery = "sent" | "queued" | "failed" | null;
+
 export async function createInvite(params: {
   email: string;
   fullName: string;
@@ -122,10 +130,19 @@ export async function createInvite(params: {
     };
   });
 
+  let emailDelivery: InviteEmailDelivery = null;
+
   if (result.emailJobId) {
     // Best effort so admins usually see the invite go out immediately; on
     // failure the job stays queued and the worker retries with backoff.
-    await tryProcessEmailJobNow(result.emailJobId);
+    const outcome = await tryProcessEmailJobNow(result.emailJobId);
+
+    emailDelivery =
+      outcome === "sent"
+        ? "sent"
+        : outcome === "failed" || outcome === "canceled"
+          ? "failed"
+          : "queued";
 
     const [invite] = await db
       .select()
@@ -139,5 +156,6 @@ export async function createInvite(params: {
   return {
     ...result,
     inviteUrl,
+    emailDelivery,
   };
 }

--- a/lib/auth/invite-service.ts
+++ b/lib/auth/invite-service.ts
@@ -6,8 +6,9 @@ import { and, eq, gt, isNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { lower, userInvites, users, type UserRole } from "@/db/schema";
-import { getAccountInviteEmailIdempotencyKey, sendInviteEmail } from "@/lib/auth/invite-email";
+import { getAccountInviteEmailIdempotencyKey } from "@/lib/auth/invite-email";
 import { createOpaqueToken, hashOpaqueToken } from "@/lib/auth/token";
+import { enqueueEmailJob, tryProcessEmailJobNow } from "@/lib/email-jobs/email-job-service";
 
 const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7;
 
@@ -24,6 +25,9 @@ export async function createInvite(params: {
   const token = createOpaqueToken();
   const tokenHash = hashOpaqueToken(token);
   const expiresAt = new Date(now.getTime() + INVITE_TTL_MS);
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ?? process.env.AUTH_URL ?? "http://localhost:3000";
+  const inviteUrl = new URL(`/invite?token=${token}`, baseUrl).toString();
 
   const result = await db.transaction(async (tx) => {
     const [existingUser] = await tx
@@ -89,36 +93,47 @@ export async function createInvite(params: {
       throw new Error("Failed to create invite.");
     }
 
+    // Outbox: the email job commits atomically with the invite, so a created
+    // invite can never lose its email to a provider outage. The raw token only
+    // travels inside the encrypted secret context, never as plaintext payload.
+    let emailJobId: string | null = null;
+
+    if (params.sendInviteEmail) {
+      const { job } = await enqueueEmailJob(
+        {
+          type: "account_invite",
+          payload: { inviteId: invite.id },
+          secretContext: { inviteUrl },
+          idempotencyKey: getAccountInviteEmailIdempotencyKey(invite.id),
+          recipientEmail: normalizedEmail,
+        },
+        { executor: tx },
+      );
+
+      emailJobId = job.id;
+    }
+
     return {
       invite,
       userId,
       email: normalizedEmail,
       organization,
+      emailJobId,
     };
   });
 
-  const baseUrl =
-    process.env.NEXT_PUBLIC_APP_URL ?? process.env.AUTH_URL ?? "http://localhost:3000";
-  const inviteUrl = new URL(`/invite?token=${token}`, baseUrl).toString();
+  if (result.emailJobId) {
+    // Best effort so admins usually see the invite go out immediately; on
+    // failure the job stays queued and the worker retries with backoff.
+    await tryProcessEmailJobNow(result.emailJobId);
 
-  if (params.sendInviteEmail) {
-    await sendInviteEmail({
-      email: result.email,
-      fullName: params.fullName,
-      inviteUrl,
-      idempotencyKey: getAccountInviteEmailIdempotencyKey(result.invite.id),
-    });
-
-    const sentAt = new Date();
     const [invite] = await db
-      .update(userInvites)
-      .set({
-        sentAt,
-      })
+      .select()
+      .from(userInvites)
       .where(eq(userInvites.id, result.invite.id))
-      .returning();
+      .limit(1);
 
-    result.invite = invite ?? { ...result.invite, sentAt };
+    result.invite = invite ?? result.invite;
   }
 
   return {

--- a/lib/auth/invite-store.ts
+++ b/lib/auth/invite-store.ts
@@ -1,10 +1,12 @@
 import "server-only";
 
-import { and, desc, eq, gt, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, gt, isNotNull, isNull, sql } from "drizzle-orm";
 
 import { db } from "@/db";
-import { userInvites, users, type UserRole } from "@/db/schema";
+import { emailJobs, userInvites, users, type UserRole } from "@/db/schema";
 import { hashOpaqueToken } from "@/lib/auth/token";
+
+export type InviteEmailDeliveryStatus = "sent" | "queued" | "failed";
 
 export type RecentAccountInviteRow = {
   id: string;
@@ -13,6 +15,7 @@ export type RecentAccountInviteRow = {
   role: UserRole;
   organization: string | null;
   invitedAt: Date;
+  emailDelivery: InviteEmailDeliveryStatus;
 };
 
 export type PendingAccountInviteRow = RecentAccountInviteRow & {
@@ -52,6 +55,31 @@ export async function getPendingInviteByToken(token: string) {
   return invite ?? null;
 }
 
+/**
+ * Joins an invite to its email job through the deterministic idempotency key
+ * (account_invite/<inviteId>), which is unique-indexed on email_jobs.
+ */
+const inviteEmailJobJoin = eq(
+  emailJobs.idempotencyKey,
+  sql`'account_invite/' || ${userInvites.id}::text`,
+);
+
+/**
+ * Truthful delivery state derived from the email job, not from sent_at alone:
+ * a failed or canceled job also has sent_at = null and must not read as
+ * queued. Invites with neither a job nor sent_at (manual link sharing) yield
+ * null and are excluded from email-centric lists.
+ */
+const inviteEmailDelivery = sql<InviteEmailDeliveryStatus | null>`
+  case
+    when ${emailJobs.status} in ('pending', 'processing') then 'queued'
+    when ${emailJobs.status} in ('failed', 'canceled') then 'failed'
+    when ${emailJobs.status} = 'sent' or ${userInvites.sentAt} is not null then 'sent'
+  end
+`;
+
+const inviteInvitedAtOrder = sql`coalesce(${userInvites.sentAt}, ${userInvites.createdAt})`;
+
 export async function findRecentAccountInvites(limit: number): Promise<RecentAccountInviteRow[]> {
   const rows = await db
     .select({
@@ -61,21 +89,24 @@ export async function findRecentAccountInvites(limit: number): Promise<RecentAcc
       role: users.role,
       organization: users.organization,
       sentAt: userInvites.sentAt,
+      createdAt: userInvites.createdAt,
+      emailDelivery: inviteEmailDelivery,
     })
     .from(userInvites)
     .innerJoin(users, eq(userInvites.userId, users.id))
+    .leftJoin(emailJobs, inviteEmailJobJoin)
     .where(
       and(
         isNull(userInvites.acceptedAt),
-        isNotNull(userInvites.sentAt),
         gt(userInvites.expiresAt, new Date()),
+        isNotNull(inviteEmailDelivery),
       ),
     )
-    .orderBy(desc(userInvites.sentAt), desc(userInvites.createdAt))
+    .orderBy(desc(inviteInvitedAtOrder), desc(userInvites.createdAt))
     .limit(limit);
 
   return rows.flatMap((row) => {
-    if (!row.sentAt) {
+    if (!row.emailDelivery) {
       return [];
     }
 
@@ -86,7 +117,8 @@ export async function findRecentAccountInvites(limit: number): Promise<RecentAcc
         name: row.name,
         role: row.role,
         organization: row.organization,
-        invitedAt: row.sentAt,
+        invitedAt: row.sentAt ?? row.createdAt,
+        emailDelivery: row.emailDelivery,
       },
     ];
   });
@@ -101,21 +133,24 @@ export async function findPendingAccountInvites(): Promise<PendingAccountInviteR
       role: users.role,
       organization: users.organization,
       sentAt: userInvites.sentAt,
+      createdAt: userInvites.createdAt,
       expiresAt: userInvites.expiresAt,
+      emailDelivery: inviteEmailDelivery,
     })
     .from(userInvites)
     .innerJoin(users, eq(userInvites.userId, users.id))
+    .leftJoin(emailJobs, inviteEmailJobJoin)
     .where(
       and(
         isNull(userInvites.acceptedAt),
-        isNotNull(userInvites.sentAt),
         gt(userInvites.expiresAt, new Date()),
+        isNotNull(inviteEmailDelivery),
       ),
     )
-    .orderBy(desc(userInvites.sentAt), desc(userInvites.createdAt));
+    .orderBy(desc(inviteInvitedAtOrder), desc(userInvites.createdAt));
 
   return rows.flatMap((row) => {
-    if (!row.sentAt) {
+    if (!row.emailDelivery) {
       return [];
     }
 
@@ -126,8 +161,9 @@ export async function findPendingAccountInvites(): Promise<PendingAccountInviteR
         name: row.name,
         role: row.role,
         organization: row.organization,
-        invitedAt: row.sentAt,
+        invitedAt: row.sentAt ?? row.createdAt,
         expiresAt: row.expiresAt,
+        emailDelivery: row.emailDelivery,
       },
     ];
   });

--- a/lib/email-jobs/email-job-policy.ts
+++ b/lib/email-jobs/email-job-policy.ts
@@ -1,0 +1,32 @@
+export const DEFAULT_MAX_ATTEMPTS = 7;
+
+/**
+ * A processing job whose claim is older than this is assumed to belong to a
+ * crashed worker and becomes claimable again. Provider idempotency keys keep a
+ * reclaim from double-sending if the original worker did reach Resend.
+ */
+export const PROCESSING_LEASE_MS = 10 * 60 * 1000;
+
+const BASE_RETRY_DELAY_MS = 30 * 1000;
+const MAX_RETRY_DELAY_MS = 30 * 60 * 1000;
+const RETRY_JITTER_RATIO = 0.2;
+const MAX_ERROR_LENGTH = 500;
+
+export function getRetryDelayMs(attempts: number, random: () => number = Math.random) {
+  const exponentialMs = BASE_RETRY_DELAY_MS * 2 ** Math.max(attempts - 1, 0);
+  const cappedMs = Math.min(exponentialMs, MAX_RETRY_DELAY_MS);
+  const jitterFactor = 1 + (random() * 2 - 1) * RETRY_JITTER_RATIO;
+
+  return Math.round(cappedMs * jitterFactor);
+}
+
+/**
+ * Error text is persisted for operators, so it must never leak one-time URLs
+ * (provider errors and URL parsing errors can echo the failing input back).
+ */
+export function sanitizeEmailJobError(error: unknown) {
+  const message =
+    error instanceof Error && error.message.length > 0 ? error.message : String(error);
+
+  return message.replaceAll(/token=[^&\s"']+/gi, "token=[redacted]").slice(0, MAX_ERROR_LENGTH);
+}

--- a/lib/email-jobs/email-job-policy.ts
+++ b/lib/email-jobs/email-job-policy.ts
@@ -9,6 +9,19 @@ export const DEFAULT_MAX_ATTEMPTS = 7;
  */
 export const PROCESSING_LEASE_MS = 10 * 60 * 1000;
 
+/**
+ * Stop reclaiming well before Resend's 24h idempotency window expires. The
+ * margin covers scheduler delay and the replacement provider request itself.
+ */
+export const MAX_PROCESSING_CLAIM_AGE_MS = 23 * 60 * 60 * 1000;
+
+export function getProcessingClaimCutoffs(now: Date) {
+  return {
+    leaseExpiredAtOrBefore: new Date(now.getTime() - PROCESSING_LEASE_MS),
+    staleAtOrBefore: new Date(now.getTime() - MAX_PROCESSING_CLAIM_AGE_MS),
+  };
+}
+
 const BASE_RETRY_DELAY_MS = 30 * 1000;
 const MAX_RETRY_DELAY_MS = 30 * 60 * 1000;
 const RETRY_JITTER_RATIO = 0.2;

--- a/lib/email-jobs/email-job-policy.ts
+++ b/lib/email-jobs/email-job-policy.ts
@@ -3,7 +3,9 @@ export const DEFAULT_MAX_ATTEMPTS = 7;
 /**
  * A processing job whose claim is older than this is assumed to belong to a
  * crashed worker and becomes claimable again. Provider idempotency keys keep a
- * reclaim from double-sending if the original worker did reach Resend.
+ * reclaim from double-sending if the original worker did reach Resend — valid
+ * within Resend's 24h idempotency window, which the retry schedule stays
+ * inside as long as a drain scheduler runs every few minutes.
  */
 export const PROCESSING_LEASE_MS = 10 * 60 * 1000;
 

--- a/lib/email-jobs/email-job-policy.unit.test.ts
+++ b/lib/email-jobs/email-job-policy.unit.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "@jest/globals";
 
-import { getRetryDelayMs, sanitizeEmailJobError } from "./email-job-policy";
+import {
+  getProcessingClaimCutoffs,
+  getRetryDelayMs,
+  sanitizeEmailJobError,
+} from "./email-job-policy";
 
 const NO_JITTER = () => 0.5;
+
+describe("getProcessingClaimCutoffs", () => {
+  it("reclaims expired leases only inside the provider idempotency safety window", () => {
+    const now = new Date("2026-06-11T12:00:00.000Z");
+
+    expect(getProcessingClaimCutoffs(now)).toEqual({
+      leaseExpiredAtOrBefore: new Date("2026-06-11T11:50:00.000Z"),
+      staleAtOrBefore: new Date("2026-06-10T13:00:00.000Z"),
+    });
+  });
+});
 
 describe("getRetryDelayMs", () => {
   it("doubles the delay per attempt starting at 30 seconds", () => {

--- a/lib/email-jobs/email-job-policy.unit.test.ts
+++ b/lib/email-jobs/email-job-policy.unit.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { getRetryDelayMs, sanitizeEmailJobError } from "./email-job-policy";
+
+const NO_JITTER = () => 0.5;
+
+describe("getRetryDelayMs", () => {
+  it("doubles the delay per attempt starting at 30 seconds", () => {
+    expect(getRetryDelayMs(1, NO_JITTER)).toBe(30_000);
+    expect(getRetryDelayMs(2, NO_JITTER)).toBe(60_000);
+    expect(getRetryDelayMs(3, NO_JITTER)).toBe(120_000);
+    expect(getRetryDelayMs(4, NO_JITTER)).toBe(240_000);
+  });
+
+  it("caps the delay at 30 minutes", () => {
+    expect(getRetryDelayMs(7, NO_JITTER)).toBe(30 * 60 * 1000);
+    expect(getRetryDelayMs(50, NO_JITTER)).toBe(30 * 60 * 1000);
+  });
+
+  it("applies bounded jitter of ±20%", () => {
+    expect(getRetryDelayMs(1, () => 0)).toBe(24_000);
+    expect(getRetryDelayMs(1, () => 1)).toBe(36_000);
+  });
+});
+
+describe("sanitizeEmailJobError", () => {
+  it("redacts one-time tokens embedded in error messages", () => {
+    const error = new Error(
+      'Failed to send: invalid url "https://example.org/invite?token=abc123&x=1"',
+    );
+
+    const sanitized = sanitizeEmailJobError(error);
+
+    expect(sanitized).not.toContain("abc123");
+    expect(sanitized).toContain("token=[redacted]");
+  });
+
+  it("truncates very long messages", () => {
+    const sanitized = sanitizeEmailJobError(new Error("x".repeat(2_000)));
+
+    expect(sanitized).toHaveLength(500);
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(sanitizeEmailJobError("plain failure")).toBe("plain failure");
+  });
+});

--- a/lib/email-jobs/email-job-service.ts
+++ b/lib/email-jobs/email-job-service.ts
@@ -8,8 +8,8 @@ import {
   sanitizeEmailJobError,
 } from "@/lib/email-jobs/email-job-policy";
 import {
-  claimDueEmailJobs,
   claimEmailJobById,
+  claimNextDueEmailJob,
   countEmailJobsByStatus,
   failExhaustedEmailJobs,
   findEmailJobByIdempotencyKey,
@@ -30,7 +30,6 @@ import type {
   EnqueueEmailJobResult,
 } from "@/lib/email-jobs/types";
 
-const DEFAULT_DRAIN_BATCH_SIZE = 10;
 const DEFAULT_DRAIN_TIME_BUDGET_MS = 50 * 1000;
 
 /**
@@ -72,17 +71,36 @@ export async function enqueueEmailJob(
  * Runs a job that was already claimed (status=processing, attempts bumped)
  * and records the outcome. Unexpected errors retry with bounded backoff until
  * attempts are exhausted, then the job is dead-lettered as failed.
+ *
+ * Every outcome write presents the claim's claimed_at token, so a writer
+ * whose lease expired and whose job was reclaimed cannot overwrite the new
+ * owner's state; the returned outcome then describes an attempt that was not
+ * recorded (the provider idempotency key keeps the email itself exactly-once).
  */
 export async function processClaimedEmailJob(job: EmailJob): Promise<EmailJobOutcome> {
+  const claimedAt = job.claimedAt;
+
+  if (!claimedAt) {
+    throw new Error(`Email job ${job.id} has no claim; only claimed jobs can be processed.`);
+  }
+
   try {
     const { providerMessageId } = await emailJobHandlers[job.type](job);
 
-    await markEmailJobSent(job.id, { providerMessageId });
+    warnIfClaimSuperseded(
+      await markEmailJobSent(job.id, { providerMessageId, claimedAt }),
+      job,
+      "sent",
+    );
 
     return "sent";
   } catch (error) {
     if (error instanceof EmailJobCanceledError) {
-      await markEmailJobCanceled(job.id, { reason: sanitizeEmailJobError(error) });
+      warnIfClaimSuperseded(
+        await markEmailJobCanceled(job.id, { reason: sanitizeEmailJobError(error), claimedAt }),
+        job,
+        "canceled",
+      );
 
       return "canceled";
     }
@@ -90,28 +108,50 @@ export async function processClaimedEmailJob(job: EmailJob): Promise<EmailJobOut
     const sanitizedError = sanitizeEmailJobError(error);
 
     if (job.attempts >= job.maxAttempts) {
-      await markEmailJobFailed(job.id, { error: sanitizedError });
+      warnIfClaimSuperseded(
+        await markEmailJobFailed(job.id, { error: sanitizedError, claimedAt }),
+        job,
+        "failed",
+      );
 
       return "failed";
     }
 
-    await scheduleEmailJobRetry(job.id, {
-      runAfter: new Date(Date.now() + getRetryDelayMs(job.attempts)),
-      error: sanitizedError,
-    });
+    warnIfClaimSuperseded(
+      await scheduleEmailJobRetry(job.id, {
+        runAfter: new Date(Date.now() + getRetryDelayMs(job.attempts)),
+        error: sanitizedError,
+        claimedAt,
+      }),
+      job,
+      "retried",
+    );
 
     return "retried";
+  }
+}
+
+function warnIfClaimSuperseded(recorded: boolean, job: EmailJob, outcome: EmailJobOutcome) {
+  if (!recorded) {
+    console.warn(
+      `Email job ${job.id} outcome "${outcome}" was not recorded: the claim expired and the job was reclaimed by another worker.`,
+    );
   }
 }
 
 /**
  * Claims and processes due jobs until the queue is drained or the time budget
  * is spent. Safe to run from several workers at once.
+ *
+ * Jobs are claimed strictly one at a time: a claim burns an attempt, so a
+ * batch claim would let one hung send (or a killed worker) exhaust the
+ * attempts of jobs that were never processed. With single claims, a stall
+ * costs at most the attempt of the job that actually stalled, and the time
+ * budget is re-checked before every claim.
  */
 export async function drainEmailJobs(
-  options: { batchSize?: number; timeBudgetMs?: number } = {},
+  options: { timeBudgetMs?: number } = {},
 ): Promise<DrainEmailJobsSummary> {
-  const batchSize = options.batchSize ?? DEFAULT_DRAIN_BATCH_SIZE;
   const timeBudgetMs = options.timeBudgetMs ?? DEFAULT_DRAIN_TIME_BUDGET_MS;
   const startedAt = Date.now();
 
@@ -127,18 +167,16 @@ export async function drainEmailJobs(
   summary.failed += await failExhaustedEmailJobs();
 
   while (Date.now() - startedAt < timeBudgetMs) {
-    const jobs = await claimDueEmailJobs({ limit: batchSize });
+    const job = await claimNextDueEmailJob();
 
-    if (jobs.length === 0) {
+    if (!job) {
       break;
     }
 
-    summary.claimed += jobs.length;
+    summary.claimed += 1;
 
-    for (const job of jobs) {
-      const outcome = await processClaimedEmailJob(job);
-      summary[outcome] += 1;
-    }
+    const outcome = await processClaimedEmailJob(job);
+    summary[outcome] += 1;
   }
 
   summary.backlog.pending = await countEmailJobsByStatus("pending");
@@ -158,11 +196,12 @@ const DEFAULT_IMMEDIATE_PROCESS_TIMEOUT_MS = 5_000;
  * assuming success.
  *
  * The deadline bounds the caller's request, but it does NOT cancel the
- * in-flight attempt. If the runtime keeps the process alive, a late success
- * still records sent; if the runtime freezes background work (serverless),
- * the claimed job sits in processing until the lease expires and a worker
- * reclaims it — the provider idempotency key prevents a double-send in case
- * the original attempt did reach Resend.
+ * in-flight attempt (the provider call itself is bounded by the send timeout
+ * in lib/email.ts). If the runtime keeps the process alive, a late outcome is
+ * still recorded as long as this attempt's claim is held; once the lease
+ * expires and a worker reclaims the job, the stale write becomes a no-op and
+ * the provider idempotency key prevents a double-send in case the original
+ * attempt did reach Resend.
  */
 export async function tryProcessEmailJobNow(
   jobId: string,

--- a/lib/email-jobs/email-job-service.ts
+++ b/lib/email-jobs/email-job-service.ts
@@ -1,0 +1,167 @@
+import "server-only";
+
+import { db } from "@/db";
+import type { EmailJob } from "@/db/schema";
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  getRetryDelayMs,
+  sanitizeEmailJobError,
+} from "@/lib/email-jobs/email-job-policy";
+import {
+  claimDueEmailJobs,
+  claimEmailJobById,
+  countEmailJobsByStatus,
+  failExhaustedEmailJobs,
+  findEmailJobByIdempotencyKey,
+  insertEmailJob,
+  markEmailJobCanceled,
+  markEmailJobFailed,
+  markEmailJobSent,
+  scheduleEmailJobRetry,
+  type EmailJobDbExecutor,
+} from "@/lib/email-jobs/email-job-store";
+import { EmailJobCanceledError } from "@/lib/email-jobs/errors";
+import { emailJobHandlers } from "@/lib/email-jobs/handlers";
+import { encryptSecretContext } from "@/lib/email-jobs/secret-context";
+import type {
+  DrainEmailJobsSummary,
+  EmailJobOutcome,
+  EnqueueEmailJobInput,
+  EnqueueEmailJobResult,
+} from "@/lib/email-jobs/types";
+
+const DEFAULT_DRAIN_BATCH_SIZE = 10;
+const DEFAULT_DRAIN_TIME_BUDGET_MS = 50 * 1000;
+
+/**
+ * Durably records an email to send. Pass the surrounding transaction as the
+ * executor to get outbox semantics: the job commits or rolls back together
+ * with the entity that triggered it. Re-enqueueing the same idempotency key
+ * returns the existing job instead of creating a duplicate.
+ */
+export async function enqueueEmailJob(
+  input: EnqueueEmailJobInput,
+  options?: { executor?: EmailJobDbExecutor },
+): Promise<EnqueueEmailJobResult> {
+  const executor = options?.executor ?? db;
+
+  const job = await insertEmailJob(executor, {
+    type: input.type,
+    payload: input.payload,
+    secretContext: encryptSecretContext(input.secretContext),
+    idempotencyKey: input.idempotencyKey,
+    recipientEmail: input.recipientEmail,
+    maxAttempts: input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+    runAfter: input.runAfter ?? new Date(),
+  });
+
+  if (job) {
+    return { job, created: true };
+  }
+
+  const existing = await findEmailJobByIdempotencyKey(executor, input.idempotencyKey);
+
+  if (!existing) {
+    throw new Error(`Email job ${input.idempotencyKey} could not be enqueued or found.`);
+  }
+
+  return { job: existing, created: false };
+}
+
+/**
+ * Runs a job that was already claimed (status=processing, attempts bumped)
+ * and records the outcome. Unexpected errors retry with bounded backoff until
+ * attempts are exhausted, then the job is dead-lettered as failed.
+ */
+export async function processClaimedEmailJob(job: EmailJob): Promise<EmailJobOutcome> {
+  try {
+    const { providerMessageId } = await emailJobHandlers[job.type](job);
+
+    await markEmailJobSent(job.id, { providerMessageId });
+
+    return "sent";
+  } catch (error) {
+    if (error instanceof EmailJobCanceledError) {
+      await markEmailJobCanceled(job.id, { reason: sanitizeEmailJobError(error) });
+
+      return "canceled";
+    }
+
+    const sanitizedError = sanitizeEmailJobError(error);
+
+    if (job.attempts >= job.maxAttempts) {
+      await markEmailJobFailed(job.id, { error: sanitizedError });
+
+      return "failed";
+    }
+
+    await scheduleEmailJobRetry(job.id, {
+      runAfter: new Date(Date.now() + getRetryDelayMs(job.attempts)),
+      error: sanitizedError,
+    });
+
+    return "retried";
+  }
+}
+
+/**
+ * Claims and processes due jobs until the queue is drained or the time budget
+ * is spent. Safe to run from several workers at once.
+ */
+export async function drainEmailJobs(
+  options: { batchSize?: number; timeBudgetMs?: number } = {},
+): Promise<DrainEmailJobsSummary> {
+  const batchSize = options.batchSize ?? DEFAULT_DRAIN_BATCH_SIZE;
+  const timeBudgetMs = options.timeBudgetMs ?? DEFAULT_DRAIN_TIME_BUDGET_MS;
+  const startedAt = Date.now();
+
+  const summary: DrainEmailJobsSummary = {
+    claimed: 0,
+    sent: 0,
+    retried: 0,
+    failed: 0,
+    canceled: 0,
+    backlog: { pending: 0, failed: 0 },
+  };
+
+  summary.failed += await failExhaustedEmailJobs();
+
+  while (Date.now() - startedAt < timeBudgetMs) {
+    const jobs = await claimDueEmailJobs({ limit: batchSize });
+
+    if (jobs.length === 0) {
+      break;
+    }
+
+    summary.claimed += jobs.length;
+
+    for (const job of jobs) {
+      const outcome = await processClaimedEmailJob(job);
+      summary[outcome] += 1;
+    }
+  }
+
+  summary.backlog.pending = await countEmailJobsByStatus("pending");
+  summary.backlog.failed = await countEmailJobsByStatus("failed");
+
+  return summary;
+}
+
+/**
+ * Best-effort immediate delivery right after enqueueing, so the common case
+ * does not wait for a worker poll. Failures are swallowed: the job stays in
+ * the queue and the retry/backoff machinery owns it from here.
+ */
+export async function tryProcessEmailJobNow(jobId: string) {
+  try {
+    const job = await claimEmailJobById(jobId);
+
+    if (!job) {
+      return;
+    }
+
+    await processClaimedEmailJob(job);
+  } catch (error) {
+    console.error(`Immediate processing of email job ${jobId} failed; left for the worker.`, error);
+  }
+}

--- a/lib/email-jobs/email-job-service.ts
+++ b/lib/email-jobs/email-job-service.ts
@@ -12,6 +12,7 @@ import {
   claimNextDueEmailJob,
   countEmailJobsByStatus,
   failExhaustedEmailJobs,
+  failStaleProcessingEmailJobs,
   findEmailJobByIdempotencyKey,
   insertEmailJob,
   markEmailJobCanceled,
@@ -167,6 +168,7 @@ export async function drainEmailJobs(
     backlog: { pending: 0, failed: 0 },
   };
 
+  summary.failed += await failStaleProcessingEmailJobs();
   summary.failed += await failExhaustedEmailJobs();
 
   while (Date.now() - startedAt < timeBudgetMs) {

--- a/lib/email-jobs/email-job-service.ts
+++ b/lib/email-jobs/email-job-service.ts
@@ -147,25 +147,62 @@ export async function drainEmailJobs(
   return summary;
 }
 
+const DEFAULT_IMMEDIATE_PROCESS_TIMEOUT_MS = 5_000;
+
 /**
  * Best-effort immediate delivery right after enqueueing, so the common case
  * does not wait for a worker poll. Never throws: on any error the job stays
  * in the queue and the retry/backoff machinery owns it from here. Returns the
- * job outcome, or null when the job could not be claimed or processed, so
- * callers can report delivery status truthfully instead of assuming success.
+ * job outcome, or null when the job could not be claimed or processed within
+ * the deadline, so callers can report delivery status truthfully instead of
+ * assuming success.
+ *
+ * The deadline bounds the caller's request, but it does NOT cancel the
+ * in-flight attempt. If the runtime keeps the process alive, a late success
+ * still records sent; if the runtime freezes background work (serverless),
+ * the claimed job sits in processing until the lease expires and a worker
+ * reclaims it — the provider idempotency key prevents a double-send in case
+ * the original attempt did reach Resend.
  */
-export async function tryProcessEmailJobNow(jobId: string): Promise<EmailJobOutcome | null> {
+export async function tryProcessEmailJobNow(
+  jobId: string,
+  options: { timeoutMs?: number } = {},
+): Promise<EmailJobOutcome | null> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_IMMEDIATE_PROCESS_TIMEOUT_MS;
+
   try {
-    const job = await claimEmailJobById(jobId);
+    return await withDeadline(
+      (async (): Promise<EmailJobOutcome | null> => {
+        const job = await claimEmailJobById(jobId);
 
-    if (!job) {
-      return null;
-    }
+        if (!job) {
+          return null;
+        }
 
-    return await processClaimedEmailJob(job);
+        return processClaimedEmailJob(job);
+      })(),
+      timeoutMs,
+    );
   } catch (error) {
     console.error(`Immediate processing of email job ${jobId} failed; left for the worker.`, error);
 
     return null;
   }
+}
+
+function withDeadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
 }

--- a/lib/email-jobs/email-job-service.ts
+++ b/lib/email-jobs/email-job-service.ts
@@ -149,19 +149,23 @@ export async function drainEmailJobs(
 
 /**
  * Best-effort immediate delivery right after enqueueing, so the common case
- * does not wait for a worker poll. Failures are swallowed: the job stays in
- * the queue and the retry/backoff machinery owns it from here.
+ * does not wait for a worker poll. Never throws: on any error the job stays
+ * in the queue and the retry/backoff machinery owns it from here. Returns the
+ * job outcome, or null when the job could not be claimed or processed, so
+ * callers can report delivery status truthfully instead of assuming success.
  */
-export async function tryProcessEmailJobNow(jobId: string) {
+export async function tryProcessEmailJobNow(jobId: string): Promise<EmailJobOutcome | null> {
   try {
     const job = await claimEmailJobById(jobId);
 
     if (!job) {
-      return;
+      return null;
     }
 
-    await processClaimedEmailJob(job);
+    return await processClaimedEmailJob(job);
   } catch (error) {
     console.error(`Immediate processing of email job ${jobId} failed; left for the worker.`, error);
+
+    return null;
   }
 }

--- a/lib/email-jobs/email-job-service.ts
+++ b/lib/email-jobs/email-job-service.ts
@@ -75,7 +75,10 @@ export async function enqueueEmailJob(
  * Every outcome write presents the claim's claimed_at token, so a writer
  * whose lease expired and whose job was reclaimed cannot overwrite the new
  * owner's state; the returned outcome then describes an attempt that was not
- * recorded (the provider idempotency key keeps the email itself exactly-once).
+ * recorded. The provider idempotency key keeps the email itself single-send,
+ * provided retries stay inside Resend's 24h idempotency window — which the
+ * retry policy guarantees only when a drain scheduler runs every few minutes
+ * (see docs/email-queue.md).
  */
 export async function processClaimedEmailJob(job: EmailJob): Promise<EmailJobOutcome> {
   const claimedAt = job.claimedAt;
@@ -197,11 +200,13 @@ const DEFAULT_IMMEDIATE_PROCESS_TIMEOUT_MS = 5_000;
  *
  * The deadline bounds the caller's request, but it does NOT cancel the
  * in-flight attempt (the provider call itself is bounded by the send timeout
- * in lib/email.ts). If the runtime keeps the process alive, a late outcome is
- * still recorded as long as this attempt's claim is held; once the lease
- * expires and a worker reclaims the job, the stale write becomes a no-op and
- * the provider idempotency key prevents a double-send in case the original
- * attempt did reach Resend.
+ * in lib/email.ts). When the deadline elapses first, the attempt is handed to
+ * next/server's after() so serverless runtimes keep the instance alive until
+ * the late outcome (sent, retry schedule, ...) is recorded. Should the
+ * process die anyway, the claimed job waits out the lease and is reclaimed by
+ * a worker; the stale writer's outcome is rejected by the claim-ownership
+ * guard and the provider idempotency key prevents a double-send in case the
+ * original attempt did reach Resend.
  */
 export async function tryProcessEmailJobNow(
   jobId: string,
@@ -210,23 +215,63 @@ export async function tryProcessEmailJobNow(
   const timeoutMs = options.timeoutMs ?? DEFAULT_IMMEDIATE_PROCESS_TIMEOUT_MS;
 
   try {
-    return await withDeadline(
-      (async (): Promise<EmailJobOutcome | null> => {
-        const job = await claimEmailJobById(jobId);
+    let attemptSettled = false;
 
-        if (!job) {
-          return null;
-        }
+    const attempt = (async (): Promise<EmailJobOutcome | null> => {
+      const job = await claimEmailJobById(jobId);
 
-        return processClaimedEmailJob(job);
-      })(),
-      timeoutMs,
+      if (!job) {
+        return null;
+      }
+
+      return processClaimedEmailJob(job);
+    })();
+
+    void attempt.then(
+      () => {
+        attemptSettled = true;
+      },
+      () => {
+        attemptSettled = true;
+      },
     );
+
+    const outcome = await withDeadline(attempt, timeoutMs);
+
+    if (outcome === null && !attemptSettled) {
+      keepProcessingAfterResponse(attempt);
+    }
+
+    return outcome;
   } catch (error) {
     console.error(`Immediate processing of email job ${jobId} failed; left for the worker.`, error);
 
     return null;
   }
+}
+
+/**
+ * Serverless runtimes freeze background work once the response is sent, so a
+ * deadline-exceeded inline attempt could neither record a late success nor
+ * schedule its retry until the 10-minute lease expires — and with infrequent
+ * worker schedules that drift risks leaving Resend's 24h idempotency window.
+ * after() extends the function invocation until the attempt settles. Outside
+ * a request scope (unit tests, long-lived processes) this quietly does
+ * nothing and the lease/reclaim path remains the safety net.
+ */
+function keepProcessingAfterResponse(attempt: Promise<unknown>) {
+  // Explicit extension: dynamic import() resolves ESM-style under nodenext,
+  // and next has no exports map for the bare "next/server" subpath.
+  void import("next/server.js")
+    .then(({ after }) => {
+      after(() =>
+        attempt.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+    })
+    .catch(() => {});
 }
 
 function withDeadline<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {

--- a/lib/email-jobs/email-job-service.unit.test.ts
+++ b/lib/email-jobs/email-job-service.unit.test.ts
@@ -252,6 +252,31 @@ describe("tryProcessEmailJobNow", () => {
     await expect(tryProcessEmailJobNow(job.id)).resolves.toBe("retried");
   });
 
+  it("returns null at the deadline without cancelling the in-flight attempt", async () => {
+    const job = makeJob();
+    claimEmailJobByIdMock.mockResolvedValue(job);
+
+    let finishSend: (result: { providerMessageId: string }) => void = () => {};
+    accountInviteHandlerMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishSend = resolve;
+        }),
+    );
+
+    await expect(tryProcessEmailJobNow(job.id, { timeoutMs: 10 })).resolves.toBeNull();
+    expect(markEmailJobSentMock).not.toHaveBeenCalled();
+
+    // A late success (process kept alive) still records the send; on runtimes
+    // that freeze background work, the lease + idempotency key take over.
+    finishSend({ providerMessageId: "late_123" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(markEmailJobSentMock).toHaveBeenCalledWith(job.id, {
+      providerMessageId: "late_123",
+    });
+  });
+
   it("returns null and leaves the job for the worker when it cannot be claimed", async () => {
     claimEmailJobByIdMock.mockResolvedValue(null);
 

--- a/lib/email-jobs/email-job-service.unit.test.ts
+++ b/lib/email-jobs/email-job-service.unit.test.ts
@@ -1,0 +1,264 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import type { EmailJob } from "@/db/schema";
+import { EmailJobCanceledError } from "@/lib/email-jobs/errors";
+import {
+  claimEmailJobById,
+  findEmailJobByIdempotencyKey,
+  insertEmailJob,
+  markEmailJobCanceled,
+  markEmailJobFailed,
+  markEmailJobSent,
+  scheduleEmailJobRetry,
+} from "@/lib/email-jobs/email-job-store";
+import { emailJobHandlers } from "@/lib/email-jobs/handlers";
+import {
+  claimDueEmailJobs,
+  countEmailJobsByStatus,
+  failExhaustedEmailJobs,
+} from "@/lib/email-jobs/email-job-store";
+import {
+  drainEmailJobs,
+  enqueueEmailJob,
+  processClaimedEmailJob,
+  tryProcessEmailJobNow,
+} from "@/lib/email-jobs/email-job-service";
+import { decryptSecretContext } from "@/lib/email-jobs/secret-context";
+
+jest.mock("@/db", () => ({ db: {} }));
+
+jest.mock("@/lib/email-jobs/email-job-store", () => ({
+  insertEmailJob: jest.fn(),
+  findEmailJobByIdempotencyKey: jest.fn(),
+  claimDueEmailJobs: jest.fn(),
+  claimEmailJobById: jest.fn(),
+  countEmailJobsByStatus: jest.fn(),
+  failExhaustedEmailJobs: jest.fn(),
+  markEmailJobSent: jest.fn(),
+  markEmailJobCanceled: jest.fn(),
+  markEmailJobFailed: jest.fn(),
+  scheduleEmailJobRetry: jest.fn(),
+}));
+
+jest.mock("@/lib/email-jobs/handlers", () => ({
+  emailJobHandlers: {
+    account_invite: jest.fn(),
+  },
+}));
+
+const insertEmailJobMock = jest.mocked(insertEmailJob);
+const findEmailJobByIdempotencyKeyMock = jest.mocked(findEmailJobByIdempotencyKey);
+const claimEmailJobByIdMock = jest.mocked(claimEmailJobById);
+const markEmailJobSentMock = jest.mocked(markEmailJobSent);
+const markEmailJobCanceledMock = jest.mocked(markEmailJobCanceled);
+const markEmailJobFailedMock = jest.mocked(markEmailJobFailed);
+const scheduleEmailJobRetryMock = jest.mocked(scheduleEmailJobRetry);
+const accountInviteHandlerMock = jest.mocked(emailJobHandlers.account_invite);
+
+const INVITE_ID = "2e42f745-44e8-4ab7-a2a2-c1f42cc8e204";
+const INVITE_URL = "https://housing.example.org/invite?token=raw-secret-token";
+
+function makeJob(overrides: Partial<EmailJob> = {}): EmailJob {
+  return {
+    id: "9f5be1de-8b29-44a9-9c25-3a3f6d2e3a01",
+    type: "account_invite",
+    status: "processing",
+    idempotencyKey: `account_invite/${INVITE_ID}`,
+    payload: { inviteId: INVITE_ID },
+    secretContext: Buffer.from("encrypted"),
+    recipientEmail: "tenant@example.org",
+    attempts: 1,
+    maxAttempts: 7,
+    runAfter: new Date(),
+    claimedAt: new Date(),
+    sentAt: null,
+    providerMessageId: null,
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.EMAIL_JOB_SECRET_KEY = Buffer.alloc(32, 9).toString("base64");
+});
+
+afterAll(() => {
+  delete process.env.EMAIL_JOB_SECRET_KEY;
+});
+
+describe("enqueueEmailJob", () => {
+  it("persists entity references in the payload and only encrypted secret context", async () => {
+    insertEmailJobMock.mockResolvedValue(makeJob({ status: "pending" }));
+
+    const result = await enqueueEmailJob({
+      type: "account_invite",
+      payload: { inviteId: INVITE_ID },
+      secretContext: { inviteUrl: INVITE_URL },
+      idempotencyKey: `account_invite/${INVITE_ID}`,
+      recipientEmail: "tenant@example.org",
+    });
+
+    expect(result.created).toBe(true);
+    expect(insertEmailJobMock).toHaveBeenCalledTimes(1);
+
+    const inserted = insertEmailJobMock.mock.calls[0]?.[1];
+
+    expect(inserted).toMatchObject({
+      type: "account_invite",
+      payload: { inviteId: INVITE_ID },
+      idempotencyKey: `account_invite/${INVITE_ID}`,
+      recipientEmail: "tenant@example.org",
+      maxAttempts: 7,
+    });
+
+    // The raw invite token must never be persisted as plaintext.
+    expect(JSON.stringify(inserted?.payload)).not.toContain("raw-secret-token");
+    expect(Buffer.isBuffer(inserted?.secretContext)).toBe(true);
+    expect(inserted?.secretContext?.toString("latin1")).not.toContain("raw-secret-token");
+
+    // But the worker can decrypt the invite URL back at send time.
+    expect(decryptSecretContext<{ inviteUrl: string }>(inserted?.secretContext as Buffer)).toEqual({
+      inviteUrl: INVITE_URL,
+    });
+  });
+
+  it("reuses the existing job when the idempotency key was already enqueued", async () => {
+    const existing = makeJob({ status: "pending" });
+    insertEmailJobMock.mockResolvedValue(null);
+    findEmailJobByIdempotencyKeyMock.mockResolvedValue(existing);
+
+    const result = await enqueueEmailJob({
+      type: "account_invite",
+      payload: { inviteId: INVITE_ID },
+      secretContext: { inviteUrl: INVITE_URL },
+      idempotencyKey: `account_invite/${INVITE_ID}`,
+      recipientEmail: "tenant@example.org",
+    });
+
+    expect(result).toEqual({ job: existing, created: false });
+  });
+});
+
+describe("processClaimedEmailJob", () => {
+  it("marks the job sent with the provider message id on success", async () => {
+    const job = makeJob();
+    accountInviteHandlerMock.mockResolvedValue({ providerMessageId: "email_123" });
+
+    await expect(processClaimedEmailJob(job)).resolves.toBe("sent");
+
+    expect(markEmailJobSentMock).toHaveBeenCalledWith(job.id, {
+      providerMessageId: "email_123",
+    });
+    expect(scheduleEmailJobRetryMock).not.toHaveBeenCalled();
+  });
+
+  it("schedules a bounded backoff retry on transient failure", async () => {
+    const job = makeJob({ attempts: 2 });
+    accountInviteHandlerMock.mockRejectedValue(new Error("Resend is unavailable"));
+
+    const before = Date.now();
+
+    await expect(processClaimedEmailJob(job)).resolves.toBe("retried");
+
+    expect(scheduleEmailJobRetryMock).toHaveBeenCalledTimes(1);
+    const retry = scheduleEmailJobRetryMock.mock.calls[0]?.[1];
+
+    expect(retry?.error).toBe("Resend is unavailable");
+    // Attempt 2 backs off 60s ± 20% jitter.
+    const delayMs = (retry?.runAfter.getTime() ?? 0) - before;
+    expect(delayMs).toBeGreaterThanOrEqual(48_000);
+    expect(delayMs).toBeLessThanOrEqual(73_000);
+  });
+
+  it("dead-letters the job as failed once attempts are exhausted", async () => {
+    const job = makeJob({ attempts: 7, maxAttempts: 7 });
+    accountInviteHandlerMock.mockRejectedValue(new Error("still failing"));
+
+    await expect(processClaimedEmailJob(job)).resolves.toBe("failed");
+
+    expect(markEmailJobFailedMock).toHaveBeenCalledWith(job.id, { error: "still failing" });
+    expect(scheduleEmailJobRetryMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels without retrying when the handler reports the email is obsolete", async () => {
+    const job = makeJob();
+    accountInviteHandlerMock.mockRejectedValue(
+      new EmailJobCanceledError("Invite was already accepted."),
+    );
+
+    await expect(processClaimedEmailJob(job)).resolves.toBe("canceled");
+
+    expect(markEmailJobCanceledMock).toHaveBeenCalledWith(job.id, {
+      reason: "Invite was already accepted.",
+    });
+    expect(scheduleEmailJobRetryMock).not.toHaveBeenCalled();
+    expect(markEmailJobFailedMock).not.toHaveBeenCalled();
+  });
+
+  it("redacts tokens from persisted error context", async () => {
+    const job = makeJob();
+    accountInviteHandlerMock.mockRejectedValue(new Error(`Invalid URL: ${INVITE_URL}`));
+
+    await processClaimedEmailJob(job);
+
+    const retry = scheduleEmailJobRetryMock.mock.calls[0]?.[1];
+    expect(retry?.error).not.toContain("raw-secret-token");
+    expect(retry?.error).toContain("token=[redacted]");
+  });
+});
+
+describe("drainEmailJobs", () => {
+  it("processes claimed batches until the queue is empty and reports the backlog", async () => {
+    const jobs = [makeJob(), makeJob({ id: "5d3f0a52-7d92-4cf1-86fe-2f7f63726b02" })];
+    jest.mocked(failExhaustedEmailJobs).mockResolvedValue(1);
+    jest.mocked(claimDueEmailJobs).mockResolvedValueOnce(jobs).mockResolvedValue([]);
+    jest.mocked(countEmailJobsByStatus).mockResolvedValueOnce(3).mockResolvedValueOnce(2);
+    accountInviteHandlerMock.mockResolvedValue({ providerMessageId: "email_789" });
+
+    const summary = await drainEmailJobs({ batchSize: 10 });
+
+    expect(summary).toEqual({
+      claimed: 2,
+      sent: 2,
+      retried: 0,
+      failed: 1,
+      canceled: 0,
+      backlog: { pending: 3, failed: 2 },
+    });
+  });
+});
+
+describe("tryProcessEmailJobNow", () => {
+  it("processes the job when it can be claimed", async () => {
+    const job = makeJob();
+    claimEmailJobByIdMock.mockResolvedValue(job);
+    accountInviteHandlerMock.mockResolvedValue({ providerMessageId: "email_456" });
+
+    await tryProcessEmailJobNow(job.id);
+
+    expect(markEmailJobSentMock).toHaveBeenCalledWith(job.id, {
+      providerMessageId: "email_456",
+    });
+  });
+
+  it("leaves the job for the worker when it cannot be claimed", async () => {
+    claimEmailJobByIdMock.mockResolvedValue(null);
+
+    await tryProcessEmailJobNow("missing-job");
+
+    expect(accountInviteHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("never throws when claiming fails", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    claimEmailJobByIdMock.mockRejectedValue(new Error("db unavailable"));
+
+    await expect(tryProcessEmailJobNow("job-id")).resolves.toBeUndefined();
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/lib/email-jobs/email-job-service.unit.test.ts
+++ b/lib/email-jobs/email-job-service.unit.test.ts
@@ -237,17 +237,25 @@ describe("tryProcessEmailJobNow", () => {
     claimEmailJobByIdMock.mockResolvedValue(job);
     accountInviteHandlerMock.mockResolvedValue({ providerMessageId: "email_456" });
 
-    await tryProcessEmailJobNow(job.id);
+    await expect(tryProcessEmailJobNow(job.id)).resolves.toBe("sent");
 
     expect(markEmailJobSentMock).toHaveBeenCalledWith(job.id, {
       providerMessageId: "email_456",
     });
   });
 
-  it("leaves the job for the worker when it cannot be claimed", async () => {
+  it("reports the retried outcome when the provider call fails", async () => {
+    const job = makeJob();
+    claimEmailJobByIdMock.mockResolvedValue(job);
+    accountInviteHandlerMock.mockRejectedValue(new Error("Resend is unavailable"));
+
+    await expect(tryProcessEmailJobNow(job.id)).resolves.toBe("retried");
+  });
+
+  it("returns null and leaves the job for the worker when it cannot be claimed", async () => {
     claimEmailJobByIdMock.mockResolvedValue(null);
 
-    await tryProcessEmailJobNow("missing-job");
+    await expect(tryProcessEmailJobNow("missing-job")).resolves.toBeNull();
 
     expect(accountInviteHandlerMock).not.toHaveBeenCalled();
   });
@@ -256,7 +264,7 @@ describe("tryProcessEmailJobNow", () => {
     const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     claimEmailJobByIdMock.mockRejectedValue(new Error("db unavailable"));
 
-    await expect(tryProcessEmailJobNow("job-id")).resolves.toBeUndefined();
+    await expect(tryProcessEmailJobNow("job-id")).resolves.toBeNull();
 
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();

--- a/lib/email-jobs/email-job-service.unit.test.ts
+++ b/lib/email-jobs/email-job-service.unit.test.ts
@@ -13,7 +13,7 @@ import {
 } from "@/lib/email-jobs/email-job-store";
 import { emailJobHandlers } from "@/lib/email-jobs/handlers";
 import {
-  claimDueEmailJobs,
+  claimNextDueEmailJob,
   countEmailJobsByStatus,
   failExhaustedEmailJobs,
 } from "@/lib/email-jobs/email-job-store";
@@ -30,7 +30,7 @@ jest.mock("@/db", () => ({ db: {} }));
 jest.mock("@/lib/email-jobs/email-job-store", () => ({
   insertEmailJob: jest.fn(),
   findEmailJobByIdempotencyKey: jest.fn(),
-  claimDueEmailJobs: jest.fn(),
+  claimNextDueEmailJob: jest.fn(),
   claimEmailJobById: jest.fn(),
   countEmailJobsByStatus: jest.fn(),
   failExhaustedEmailJobs: jest.fn(),
@@ -57,6 +57,7 @@ const accountInviteHandlerMock = jest.mocked(emailJobHandlers.account_invite);
 
 const INVITE_ID = "2e42f745-44e8-4ab7-a2a2-c1f42cc8e204";
 const INVITE_URL = "https://housing.example.org/invite?token=raw-secret-token";
+const CLAIMED_AT = new Date("2026-06-11T12:00:00.000Z");
 
 function makeJob(overrides: Partial<EmailJob> = {}): EmailJob {
   return {
@@ -70,7 +71,7 @@ function makeJob(overrides: Partial<EmailJob> = {}): EmailJob {
     attempts: 1,
     maxAttempts: 7,
     runAfter: new Date(),
-    claimedAt: new Date(),
+    claimedAt: CLAIMED_AT,
     sentAt: null,
     providerMessageId: null,
     lastError: null,
@@ -83,6 +84,12 @@ function makeJob(overrides: Partial<EmailJob> = {}): EmailJob {
 beforeEach(() => {
   jest.clearAllMocks();
   process.env.EMAIL_JOB_SECRET_KEY = Buffer.alloc(32, 9).toString("base64");
+
+  // Outcome writes report whether the claim was still owned; default to yes.
+  markEmailJobSentMock.mockResolvedValue(true);
+  markEmailJobCanceledMock.mockResolvedValue(true);
+  markEmailJobFailedMock.mockResolvedValue(true);
+  scheduleEmailJobRetryMock.mockResolvedValue(true);
 });
 
 afterAll(() => {
@@ -151,8 +158,29 @@ describe("processClaimedEmailJob", () => {
 
     expect(markEmailJobSentMock).toHaveBeenCalledWith(job.id, {
       providerMessageId: "email_123",
+      claimedAt: CLAIMED_AT,
     });
     expect(scheduleEmailJobRetryMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to process a job that carries no claim", async () => {
+    const job = makeJob({ claimedAt: null });
+
+    await expect(processClaimedEmailJob(job)).rejects.toThrow("only claimed jobs can be processed");
+
+    expect(accountInviteHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("warns instead of clobbering state when the claim was superseded", async () => {
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const job = makeJob();
+    accountInviteHandlerMock.mockResolvedValue({ providerMessageId: "email_123" });
+    markEmailJobSentMock.mockResolvedValue(false);
+
+    await expect(processClaimedEmailJob(job)).resolves.toBe("sent");
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("was not recorded"));
+    consoleWarnSpy.mockRestore();
   });
 
   it("schedules a bounded backoff retry on transient failure", async () => {
@@ -167,6 +195,7 @@ describe("processClaimedEmailJob", () => {
     const retry = scheduleEmailJobRetryMock.mock.calls[0]?.[1];
 
     expect(retry?.error).toBe("Resend is unavailable");
+    expect(retry?.claimedAt).toBe(CLAIMED_AT);
     // Attempt 2 backs off 60s ± 20% jitter.
     const delayMs = (retry?.runAfter.getTime() ?? 0) - before;
     expect(delayMs).toBeGreaterThanOrEqual(48_000);
@@ -179,7 +208,10 @@ describe("processClaimedEmailJob", () => {
 
     await expect(processClaimedEmailJob(job)).resolves.toBe("failed");
 
-    expect(markEmailJobFailedMock).toHaveBeenCalledWith(job.id, { error: "still failing" });
+    expect(markEmailJobFailedMock).toHaveBeenCalledWith(job.id, {
+      error: "still failing",
+      claimedAt: CLAIMED_AT,
+    });
     expect(scheduleEmailJobRetryMock).not.toHaveBeenCalled();
   });
 
@@ -193,6 +225,7 @@ describe("processClaimedEmailJob", () => {
 
     expect(markEmailJobCanceledMock).toHaveBeenCalledWith(job.id, {
       reason: "Invite was already accepted.",
+      claimedAt: CLAIMED_AT,
     });
     expect(scheduleEmailJobRetryMock).not.toHaveBeenCalled();
     expect(markEmailJobFailedMock).not.toHaveBeenCalled();
@@ -211,15 +244,23 @@ describe("processClaimedEmailJob", () => {
 });
 
 describe("drainEmailJobs", () => {
-  it("processes claimed batches until the queue is empty and reports the backlog", async () => {
-    const jobs = [makeJob(), makeJob({ id: "5d3f0a52-7d92-4cf1-86fe-2f7f63726b02" })];
+  it("claims and processes jobs one at a time until the queue is empty", async () => {
+    const first = makeJob();
+    const second = makeJob({ id: "5d3f0a52-7d92-4cf1-86fe-2f7f63726b02" });
     jest.mocked(failExhaustedEmailJobs).mockResolvedValue(1);
-    jest.mocked(claimDueEmailJobs).mockResolvedValueOnce(jobs).mockResolvedValue([]);
+    jest
+      .mocked(claimNextDueEmailJob)
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+      .mockResolvedValue(null);
     jest.mocked(countEmailJobsByStatus).mockResolvedValueOnce(3).mockResolvedValueOnce(2);
     accountInviteHandlerMock.mockResolvedValue({ providerMessageId: "email_789" });
 
-    const summary = await drainEmailJobs({ batchSize: 10 });
+    const summary = await drainEmailJobs();
 
+    // One claim per job: a hung send can only burn the attempt of the job it
+    // is actually processing, never those of jobs claimed alongside it.
+    expect(jest.mocked(claimNextDueEmailJob)).toHaveBeenCalledTimes(3);
     expect(summary).toEqual({
       claimed: 2,
       sent: 2,
@@ -228,6 +269,16 @@ describe("drainEmailJobs", () => {
       canceled: 0,
       backlog: { pending: 3, failed: 2 },
     });
+  });
+
+  it("stops claiming once the time budget is spent", async () => {
+    jest.mocked(failExhaustedEmailJobs).mockResolvedValue(0);
+    jest.mocked(countEmailJobsByStatus).mockResolvedValue(0);
+
+    const summary = await drainEmailJobs({ timeBudgetMs: 0 });
+
+    expect(jest.mocked(claimNextDueEmailJob)).not.toHaveBeenCalled();
+    expect(summary.claimed).toBe(0);
   });
 });
 
@@ -241,6 +292,7 @@ describe("tryProcessEmailJobNow", () => {
 
     expect(markEmailJobSentMock).toHaveBeenCalledWith(job.id, {
       providerMessageId: "email_456",
+      claimedAt: CLAIMED_AT,
     });
   });
 
@@ -267,13 +319,15 @@ describe("tryProcessEmailJobNow", () => {
     await expect(tryProcessEmailJobNow(job.id, { timeoutMs: 10 })).resolves.toBeNull();
     expect(markEmailJobSentMock).not.toHaveBeenCalled();
 
-    // A late success (process kept alive) still records the send; on runtimes
-    // that freeze background work, the lease + idempotency key take over.
+    // A late success (process kept alive) still records the send while this
+    // attempt's claim is held; after a lease-expiry reclaim the write becomes
+    // a no-op and the idempotency key keeps the email exactly-once.
     finishSend({ providerMessageId: "late_123" });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(markEmailJobSentMock).toHaveBeenCalledWith(job.id, {
       providerMessageId: "late_123",
+      claimedAt: CLAIMED_AT,
     });
   });
 

--- a/lib/email-jobs/email-job-service.unit.test.ts
+++ b/lib/email-jobs/email-job-service.unit.test.ts
@@ -16,6 +16,7 @@ import {
   claimNextDueEmailJob,
   countEmailJobsByStatus,
   failExhaustedEmailJobs,
+  failStaleProcessingEmailJobs,
 } from "@/lib/email-jobs/email-job-store";
 import {
   drainEmailJobs,
@@ -34,6 +35,7 @@ jest.mock("@/lib/email-jobs/email-job-store", () => ({
   claimEmailJobById: jest.fn(),
   countEmailJobsByStatus: jest.fn(),
   failExhaustedEmailJobs: jest.fn(),
+  failStaleProcessingEmailJobs: jest.fn(),
   markEmailJobSent: jest.fn(),
   markEmailJobCanceled: jest.fn(),
   markEmailJobFailed: jest.fn(),
@@ -247,6 +249,7 @@ describe("drainEmailJobs", () => {
   it("claims and processes jobs one at a time until the queue is empty", async () => {
     const first = makeJob();
     const second = makeJob({ id: "5d3f0a52-7d92-4cf1-86fe-2f7f63726b02" });
+    jest.mocked(failStaleProcessingEmailJobs).mockResolvedValue(1);
     jest.mocked(failExhaustedEmailJobs).mockResolvedValue(1);
     jest
       .mocked(claimNextDueEmailJob)
@@ -265,13 +268,14 @@ describe("drainEmailJobs", () => {
       claimed: 2,
       sent: 2,
       retried: 0,
-      failed: 1,
+      failed: 2,
       canceled: 0,
       backlog: { pending: 3, failed: 2 },
     });
   });
 
   it("stops claiming once the time budget is spent", async () => {
+    jest.mocked(failStaleProcessingEmailJobs).mockResolvedValue(0);
     jest.mocked(failExhaustedEmailJobs).mockResolvedValue(0);
     jest.mocked(countEmailJobsByStatus).mockResolvedValue(0);
 

--- a/lib/email-jobs/email-job-store.ts
+++ b/lib/email-jobs/email-job-store.ts
@@ -1,0 +1,210 @@
+import "server-only";
+
+import { and, asc, count, eq, inArray, lt, lte, or, sql } from "drizzle-orm";
+
+import { db } from "@/db";
+import { emailJobs, type EmailJob, type EmailJobStatus, type NewEmailJob } from "@/db/schema";
+import { PROCESSING_LEASE_MS } from "@/lib/email-jobs/email-job-policy";
+
+type Database = typeof db;
+
+/** The shared db client or a transaction, so enqueues can join an outbox transaction. */
+export type EmailJobDbExecutor = Database | Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+export async function insertEmailJob(executor: EmailJobDbExecutor, values: NewEmailJob) {
+  const [job] = await executor
+    .insert(emailJobs)
+    .values(values)
+    .onConflictDoNothing({ target: emailJobs.idempotencyKey })
+    .returning();
+
+  return job ?? null;
+}
+
+export async function findEmailJobByIdempotencyKey(
+  executor: EmailJobDbExecutor,
+  idempotencyKey: string,
+) {
+  const [job] = await executor
+    .select()
+    .from(emailJobs)
+    .where(eq(emailJobs.idempotencyKey, idempotencyKey))
+    .limit(1);
+
+  return job ?? null;
+}
+
+function claimableEmailJobsFilter(now: Date) {
+  const leaseExpiredBefore = new Date(now.getTime() - PROCESSING_LEASE_MS);
+
+  return and(
+    lt(emailJobs.attempts, emailJobs.maxAttempts),
+    or(
+      and(eq(emailJobs.status, "pending"), lte(emailJobs.runAfter, now)),
+      and(eq(emailJobs.status, "processing"), lte(emailJobs.claimedAt, leaseExpiredBefore)),
+    ),
+  );
+}
+
+/**
+ * Atomically claims due jobs for one worker. SELECT ... FOR UPDATE SKIP LOCKED
+ * lets concurrent workers claim disjoint sets, and lease-expired processing
+ * jobs from crashed workers become claimable again.
+ */
+export async function claimDueEmailJobs(params: { limit: number; now?: Date }) {
+  const now = params.now ?? new Date();
+
+  return db.transaction(async (tx): Promise<EmailJob[]> => {
+    const due = await tx
+      .select({ id: emailJobs.id })
+      .from(emailJobs)
+      .where(claimableEmailJobsFilter(now))
+      .orderBy(asc(emailJobs.runAfter))
+      .limit(params.limit)
+      .for("update", { skipLocked: true });
+
+    if (due.length === 0) {
+      return [];
+    }
+
+    return tx
+      .update(emailJobs)
+      .set({
+        status: "processing",
+        claimedAt: now,
+        attempts: sql`${emailJobs.attempts} + 1`,
+        updatedAt: now,
+      })
+      .where(
+        inArray(
+          emailJobs.id,
+          due.map((row) => row.id),
+        ),
+      )
+      .returning();
+  });
+}
+
+export async function claimEmailJobById(jobId: string, now = new Date()) {
+  return db.transaction(async (tx): Promise<EmailJob | null> => {
+    const [due] = await tx
+      .select({ id: emailJobs.id })
+      .from(emailJobs)
+      .where(and(eq(emailJobs.id, jobId), claimableEmailJobsFilter(now)))
+      .limit(1)
+      .for("update", { skipLocked: true });
+
+    if (!due) {
+      return null;
+    }
+
+    const [job] = await tx
+      .update(emailJobs)
+      .set({
+        status: "processing",
+        claimedAt: now,
+        attempts: sql`${emailJobs.attempts} + 1`,
+        updatedAt: now,
+      })
+      .where(eq(emailJobs.id, due.id))
+      .returning();
+
+    return job ?? null;
+  });
+}
+
+/**
+ * Dead-letters processing jobs that exhausted their attempts and whose lease
+ * expired (worker crashed on the final attempt), so they stay visible as
+ * failed instead of being stuck in processing forever.
+ */
+export async function failExhaustedEmailJobs(now = new Date()) {
+  const leaseExpiredBefore = new Date(now.getTime() - PROCESSING_LEASE_MS);
+
+  const failed = await db
+    .update(emailJobs)
+    .set({
+      status: "failed",
+      secretContext: null,
+      lastError: "Worker lease expired after the final attempt.",
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(emailJobs.status, "processing"),
+        lte(emailJobs.claimedAt, leaseExpiredBefore),
+        sql`${emailJobs.attempts} >= ${emailJobs.maxAttempts}`,
+      ),
+    )
+    .returning({ id: emailJobs.id });
+
+  return failed.length;
+}
+
+export async function markEmailJobSent(
+  jobId: string,
+  params: { providerMessageId: string | null; sentAt?: Date },
+) {
+  const sentAt = params.sentAt ?? new Date();
+
+  await db
+    .update(emailJobs)
+    .set({
+      status: "sent",
+      sentAt,
+      providerMessageId: params.providerMessageId,
+      secretContext: null,
+      lastError: null,
+      updatedAt: sentAt,
+    })
+    .where(eq(emailJobs.id, jobId));
+}
+
+export async function markEmailJobCanceled(jobId: string, params: { reason: string }) {
+  await db
+    .update(emailJobs)
+    .set({
+      status: "canceled",
+      secretContext: null,
+      lastError: params.reason,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(emailJobs.id, jobId), eq(emailJobs.status, "processing")));
+}
+
+export async function markEmailJobFailed(jobId: string, params: { error: string }) {
+  await db
+    .update(emailJobs)
+    .set({
+      status: "failed",
+      secretContext: null,
+      lastError: params.error,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(emailJobs.id, jobId), eq(emailJobs.status, "processing")));
+}
+
+export async function scheduleEmailJobRetry(
+  jobId: string,
+  params: { runAfter: Date; error: string },
+) {
+  await db
+    .update(emailJobs)
+    .set({
+      status: "pending",
+      runAfter: params.runAfter,
+      claimedAt: null,
+      lastError: params.error,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(emailJobs.id, jobId), eq(emailJobs.status, "processing")));
+}
+
+export async function countEmailJobsByStatus(status: EmailJobStatus) {
+  const [row] = await db
+    .select({ value: count() })
+    .from(emailJobs)
+    .where(eq(emailJobs.status, status));
+
+  return row?.value ?? 0;
+}

--- a/lib/email-jobs/email-job-store.ts
+++ b/lib/email-jobs/email-job-store.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
-import { and, asc, count, eq, lt, lte, or, sql } from "drizzle-orm";
+import { and, asc, count, eq, gt, lt, lte, or, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { emailJobs, type EmailJob, type EmailJobStatus, type NewEmailJob } from "@/db/schema";
-import { PROCESSING_LEASE_MS } from "@/lib/email-jobs/email-job-policy";
+import { getProcessingClaimCutoffs } from "@/lib/email-jobs/email-job-policy";
 
 type Database = typeof db;
 
@@ -35,13 +35,17 @@ export async function findEmailJobByIdempotencyKey(
 }
 
 function claimableEmailJobsFilter(now: Date) {
-  const leaseExpiredBefore = new Date(now.getTime() - PROCESSING_LEASE_MS);
+  const { leaseExpiredAtOrBefore, staleAtOrBefore } = getProcessingClaimCutoffs(now);
 
   return and(
     lt(emailJobs.attempts, emailJobs.maxAttempts),
     or(
       and(eq(emailJobs.status, "pending"), lte(emailJobs.runAfter, now)),
-      and(eq(emailJobs.status, "processing"), lte(emailJobs.claimedAt, leaseExpiredBefore)),
+      and(
+        eq(emailJobs.status, "processing"),
+        lte(emailJobs.claimedAt, leaseExpiredAtOrBefore),
+        gt(emailJobs.claimedAt, staleAtOrBefore),
+      ),
     ),
   );
 }
@@ -118,7 +122,7 @@ export async function claimEmailJobById(jobId: string, now = new Date()) {
  * failed instead of being stuck in processing forever.
  */
 export async function failExhaustedEmailJobs(now = new Date()) {
-  const leaseExpiredBefore = new Date(now.getTime() - PROCESSING_LEASE_MS);
+  const { leaseExpiredAtOrBefore } = getProcessingClaimCutoffs(now);
 
   const failed = await db
     .update(emailJobs)
@@ -131,10 +135,31 @@ export async function failExhaustedEmailJobs(now = new Date()) {
     .where(
       and(
         eq(emailJobs.status, "processing"),
-        lte(emailJobs.claimedAt, leaseExpiredBefore),
+        lte(emailJobs.claimedAt, leaseExpiredAtOrBefore),
         sql`${emailJobs.attempts} >= ${emailJobs.maxAttempts}`,
       ),
     )
+    .returning({ id: emailJobs.id });
+
+  return failed.length;
+}
+
+/**
+ * Dead-letters abandoned claims before retrying them could fall outside the
+ * provider's idempotency window and deliver the same logical email twice.
+ */
+export async function failStaleProcessingEmailJobs(now = new Date()) {
+  const { staleAtOrBefore } = getProcessingClaimCutoffs(now);
+
+  const failed = await db
+    .update(emailJobs)
+    .set({
+      status: "failed",
+      secretContext: null,
+      lastError: "Worker claim exceeded the provider idempotency safety window; not retried.",
+      updatedAt: now,
+    })
+    .where(and(eq(emailJobs.status, "processing"), lte(emailJobs.claimedAt, staleAtOrBefore)))
     .returning({ id: emailJobs.id });
 
   return failed.length;

--- a/lib/email-jobs/email-job-store.ts
+++ b/lib/email-jobs/email-job-store.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, asc, count, eq, inArray, lt, lte, or, sql } from "drizzle-orm";
+import { and, asc, count, eq, lt, lte, or, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { emailJobs, type EmailJob, type EmailJobStatus, type NewEmailJob } from "@/db/schema";
@@ -47,27 +47,29 @@ function claimableEmailJobsFilter(now: Date) {
 }
 
 /**
- * Atomically claims due jobs for one worker. SELECT ... FOR UPDATE SKIP LOCKED
- * lets concurrent workers claim disjoint sets, and lease-expired processing
- * jobs from crashed workers become claimable again.
+ * Atomically claims the single most overdue job. SELECT ... FOR UPDATE SKIP
+ * LOCKED lets concurrent workers claim disjoint jobs, and lease-expired
+ * processing jobs from crashed workers become claimable again.
+ *
+ * Deliberately claims one job at a time: claiming a batch would bump attempts
+ * on jobs the worker never reaches if an earlier send hangs or the process is
+ * killed, eventually dead-lettering emails that were never tried.
  */
-export async function claimDueEmailJobs(params: { limit: number; now?: Date }) {
-  const now = params.now ?? new Date();
-
-  return db.transaction(async (tx): Promise<EmailJob[]> => {
-    const due = await tx
+export async function claimNextDueEmailJob(now = new Date()) {
+  return db.transaction(async (tx): Promise<EmailJob | null> => {
+    const [due] = await tx
       .select({ id: emailJobs.id })
       .from(emailJobs)
       .where(claimableEmailJobsFilter(now))
       .orderBy(asc(emailJobs.runAfter))
-      .limit(params.limit)
+      .limit(1)
       .for("update", { skipLocked: true });
 
-    if (due.length === 0) {
-      return [];
+    if (!due) {
+      return null;
     }
 
-    return tx
+    const [job] = await tx
       .update(emailJobs)
       .set({
         status: "processing",
@@ -75,13 +77,10 @@ export async function claimDueEmailJobs(params: { limit: number; now?: Date }) {
         attempts: sql`${emailJobs.attempts} + 1`,
         updatedAt: now,
       })
-      .where(
-        inArray(
-          emailJobs.id,
-          due.map((row) => row.id),
-        ),
-      )
+      .where(eq(emailJobs.id, due.id))
       .returning();
+
+    return job ?? null;
   });
 }
 
@@ -141,13 +140,28 @@ export async function failExhaustedEmailJobs(now = new Date()) {
   return failed.length;
 }
 
+/**
+ * A claim is identified by the claimed_at timestamp the claiming transaction
+ * wrote. Outcome writes must present it, so a writer whose claim was reclaimed
+ * after its lease expired (e.g. a very late inline attempt) becomes a no-op
+ * instead of clobbering the state of whichever worker now owns the job.
+ * Returns whether the write landed.
+ */
+function ownsClaim(jobId: string, claimedAt: Date) {
+  return and(
+    eq(emailJobs.id, jobId),
+    eq(emailJobs.status, "processing"),
+    eq(emailJobs.claimedAt, claimedAt),
+  );
+}
+
 export async function markEmailJobSent(
   jobId: string,
-  params: { providerMessageId: string | null; sentAt?: Date },
+  params: { providerMessageId: string | null; claimedAt: Date; sentAt?: Date },
 ) {
   const sentAt = params.sentAt ?? new Date();
 
-  await db
+  const updated = await db
     .update(emailJobs)
     .set({
       status: "sent",
@@ -157,11 +171,17 @@ export async function markEmailJobSent(
       lastError: null,
       updatedAt: sentAt,
     })
-    .where(eq(emailJobs.id, jobId));
+    .where(ownsClaim(jobId, params.claimedAt))
+    .returning({ id: emailJobs.id });
+
+  return updated.length > 0;
 }
 
-export async function markEmailJobCanceled(jobId: string, params: { reason: string }) {
-  await db
+export async function markEmailJobCanceled(
+  jobId: string,
+  params: { reason: string; claimedAt: Date },
+) {
+  const updated = await db
     .update(emailJobs)
     .set({
       status: "canceled",
@@ -169,11 +189,17 @@ export async function markEmailJobCanceled(jobId: string, params: { reason: stri
       lastError: params.reason,
       updatedAt: new Date(),
     })
-    .where(and(eq(emailJobs.id, jobId), eq(emailJobs.status, "processing")));
+    .where(ownsClaim(jobId, params.claimedAt))
+    .returning({ id: emailJobs.id });
+
+  return updated.length > 0;
 }
 
-export async function markEmailJobFailed(jobId: string, params: { error: string }) {
-  await db
+export async function markEmailJobFailed(
+  jobId: string,
+  params: { error: string; claimedAt: Date },
+) {
+  const updated = await db
     .update(emailJobs)
     .set({
       status: "failed",
@@ -181,14 +207,17 @@ export async function markEmailJobFailed(jobId: string, params: { error: string 
       lastError: params.error,
       updatedAt: new Date(),
     })
-    .where(and(eq(emailJobs.id, jobId), eq(emailJobs.status, "processing")));
+    .where(ownsClaim(jobId, params.claimedAt))
+    .returning({ id: emailJobs.id });
+
+  return updated.length > 0;
 }
 
 export async function scheduleEmailJobRetry(
   jobId: string,
-  params: { runAfter: Date; error: string },
+  params: { runAfter: Date; error: string; claimedAt: Date },
 ) {
-  await db
+  const updated = await db
     .update(emailJobs)
     .set({
       status: "pending",
@@ -197,7 +226,10 @@ export async function scheduleEmailJobRetry(
       lastError: params.error,
       updatedAt: new Date(),
     })
-    .where(and(eq(emailJobs.id, jobId), eq(emailJobs.status, "processing")));
+    .where(ownsClaim(jobId, params.claimedAt))
+    .returning({ id: emailJobs.id });
+
+  return updated.length > 0;
 }
 
 export async function countEmailJobsByStatus(status: EmailJobStatus) {

--- a/lib/email-jobs/errors.ts
+++ b/lib/email-jobs/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Thrown by a job handler when a job should stop without sending and without
+ * retrying, e.g. because the underlying entity was accepted, superseded, or
+ * expired. The job ends up canceled, not failed.
+ */
+export class EmailJobCanceledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EmailJobCanceledError";
+  }
+}

--- a/lib/email-jobs/handlers.ts
+++ b/lib/email-jobs/handlers.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import { and, eq, isNull } from "drizzle-orm";
+
+import { db } from "@/db";
+import { userInvites, users, type EmailJob } from "@/db/schema";
+import { renderAccountInviteEmail } from "@/lib/auth/invite-email";
+import { sendTransactionalEmail } from "@/lib/email";
+import { EmailJobCanceledError } from "@/lib/email-jobs/errors";
+import { decryptSecretContext } from "@/lib/email-jobs/secret-context";
+import type {
+  AccountInviteEmailJobSecretContext,
+  EmailJobHandlerRegistry,
+  EmailJobHandlerResult,
+} from "@/lib/email-jobs/types";
+
+async function handleAccountInviteEmailJob(job: EmailJob): Promise<EmailJobHandlerResult> {
+  const inviteId = job.payload.inviteId;
+
+  if (!inviteId) {
+    throw new EmailJobCanceledError("Job payload is missing the invite reference.");
+  }
+
+  const [row] = await db
+    .select({
+      invite: userInvites,
+      fullName: users.fullName,
+    })
+    .from(userInvites)
+    .innerJoin(users, eq(userInvites.userId, users.id))
+    .where(eq(userInvites.id, inviteId))
+    .limit(1);
+
+  if (!row) {
+    throw new EmailJobCanceledError("Invite no longer exists.");
+  }
+
+  if (row.invite.acceptedAt) {
+    throw new EmailJobCanceledError("Invite was already accepted.");
+  }
+
+  if (row.invite.expiresAt <= new Date()) {
+    throw new EmailJobCanceledError("Invite expired or was superseded before the email was sent.");
+  }
+
+  if (!job.secretContext) {
+    throw new EmailJobCanceledError("Invite URL is no longer available for this job.");
+  }
+
+  const { inviteUrl } = decryptSecretContext<AccountInviteEmailJobSecretContext>(job.secretContext);
+
+  const content = renderAccountInviteEmail({
+    fullName: row.fullName,
+    inviteUrl,
+  });
+
+  const providerMessageId = await sendTransactionalEmail({
+    to: row.invite.email,
+    ...content,
+    idempotencyKey: job.idempotencyKey,
+  });
+
+  await db
+    .update(userInvites)
+    .set({ sentAt: new Date() })
+    .where(and(eq(userInvites.id, inviteId), isNull(userInvites.sentAt)));
+
+  return { providerMessageId };
+}
+
+export const emailJobHandlers: EmailJobHandlerRegistry = {
+  account_invite: handleAccountInviteEmailJob,
+};

--- a/lib/email-jobs/handlers.ts
+++ b/lib/email-jobs/handlers.ts
@@ -5,7 +5,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { db } from "@/db";
 import { userInvites, users, type EmailJob } from "@/db/schema";
 import { renderAccountInviteEmail } from "@/lib/auth/invite-email";
-import { sendTransactionalEmail } from "@/lib/email";
+import { sendTransactionalEmail, TransactionalEmailProviderError } from "@/lib/email";
 import { EmailJobCanceledError } from "@/lib/email-jobs/errors";
 import { decryptSecretContext } from "@/lib/email-jobs/secret-context";
 import type {
@@ -54,11 +54,27 @@ async function handleAccountInviteEmailJob(job: EmailJob): Promise<EmailJobHandl
     inviteUrl,
   });
 
-  const providerMessageId = await sendTransactionalEmail({
-    to: row.invite.email,
-    ...content,
-    idempotencyKey: job.idempotencyKey,
-  });
+  let providerMessageId: string | null;
+
+  try {
+    providerMessageId = await sendTransactionalEmail({
+      to: row.invite.email,
+      ...content,
+      idempotencyKey: job.idempotencyKey,
+    });
+  } catch (error) {
+    if (
+      !(error instanceof TransactionalEmailProviderError) ||
+      error.providerCode !== "invalid_idempotent_request"
+    ) {
+      throw error;
+    }
+
+    // Resend only returns this when the key already belongs to a previously
+    // accepted email with a different payload. Treat that prior send as the
+    // successful outcome instead of retrying the mismatched request forever.
+    providerMessageId = null;
+  }
 
   await db
     .update(userInvites)

--- a/lib/email-jobs/handlers.unit.test.ts
+++ b/lib/email-jobs/handlers.unit.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import type { EmailJob } from "@/db/schema";
+import { TransactionalEmailProviderError, sendTransactionalEmail } from "@/lib/email";
+import { emailJobHandlers } from "@/lib/email-jobs/handlers";
+import { encryptSecretContext } from "@/lib/email-jobs/secret-context";
+
+type SelectedInviteRow = {
+  invite: {
+    id: string;
+    email: string;
+    acceptedAt: Date | null;
+    expiresAt: Date;
+  };
+  fullName: string;
+};
+
+const selectLimitMock = jest.fn<(limit: number) => Promise<SelectedInviteRow[]>>();
+const updateWhereMock = jest.fn<(_where: unknown) => Promise<void>>();
+
+jest.mock("@/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({
+            limit: selectLimitMock,
+          }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: updateWhereMock,
+      }),
+    }),
+  },
+}));
+
+jest.mock("@/lib/email", () => {
+  class MockTransactionalEmailProviderError extends Error {
+    constructor(
+      message: string,
+      readonly providerCode: string,
+      readonly statusCode: number | null,
+    ) {
+      super(message);
+      this.name = "TransactionalEmailProviderError";
+    }
+  }
+
+  return {
+    TransactionalEmailProviderError: MockTransactionalEmailProviderError,
+    sendTransactionalEmail: jest.fn(),
+  };
+});
+
+const sendTransactionalEmailMock = jest.mocked(sendTransactionalEmail);
+const INVITE_ID = "2e42f745-44e8-4ab7-a2a2-c1f42cc8e204";
+const originalEmailJobSecretKey = process.env.EMAIL_JOB_SECRET_KEY;
+
+function makeJob(): EmailJob {
+  return {
+    id: "9f5be1de-8b29-44a9-9c25-3a3f6d2e3a01",
+    type: "account_invite",
+    status: "processing",
+    idempotencyKey: `account_invite/${INVITE_ID}`,
+    payload: { inviteId: INVITE_ID },
+    secretContext: encryptSecretContext({
+      inviteUrl: "https://housing.example.org/invite?token=raw-secret-token",
+    }),
+    recipientEmail: "tenant@example.org",
+    attempts: 2,
+    maxAttempts: 7,
+    runAfter: new Date(),
+    claimedAt: new Date(),
+    sentAt: null,
+    providerMessageId: null,
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.EMAIL_JOB_SECRET_KEY = Buffer.alloc(32, 9).toString("base64");
+  selectLimitMock.mockResolvedValue([
+    {
+      invite: {
+        id: INVITE_ID,
+        email: "tenant@example.org",
+        acceptedAt: null,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+      fullName: "Tenant Example",
+    },
+  ]);
+  updateWhereMock.mockResolvedValue(undefined);
+});
+
+afterAll(() => {
+  if (originalEmailJobSecretKey === undefined) {
+    delete process.env.EMAIL_JOB_SECRET_KEY;
+  } else {
+    process.env.EMAIL_JOB_SECRET_KEY = originalEmailJobSecretKey;
+  }
+});
+
+describe("account invite email job handler", () => {
+  it("treats a mismatched idempotent replay as a prior successful delivery", async () => {
+    sendTransactionalEmailMock.mockRejectedValue(
+      new TransactionalEmailProviderError(
+        "Same idempotency key used with a different request payload.",
+        "invalid_idempotent_request",
+        409,
+      ),
+    );
+
+    await expect(emailJobHandlers.account_invite(makeJob())).resolves.toEqual({
+      providerMessageId: null,
+    });
+    expect(updateWhereMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps ordinary provider errors eligible for queue retries", async () => {
+    const providerError = new TransactionalEmailProviderError(
+      "Resend is unavailable.",
+      "application_error",
+      500,
+    );
+    sendTransactionalEmailMock.mockRejectedValue(providerError);
+
+    await expect(emailJobHandlers.account_invite(makeJob())).rejects.toBe(providerError);
+    expect(updateWhereMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/email-jobs/secret-context.ts
+++ b/lib/email-jobs/secret-context.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from "node:crypto";
+
+const FORMAT_VERSION = 1;
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const KEY_LENGTH = 32;
+const HKDF_INFO = "email-job-secret-context";
+
+/**
+ * Uses EMAIL_JOB_SECRET_KEY (32 bytes, base64, e.g. `openssl rand -base64 32`)
+ * when set; otherwise derives a dedicated key from AUTH_SECRET. Rotating the
+ * effective key makes pending jobs undecryptable; they fail with a clear error
+ * after retries are exhausted.
+ */
+function getSecretContextKey() {
+  const configured = process.env.EMAIL_JOB_SECRET_KEY;
+
+  if (configured) {
+    const key = Buffer.from(configured, "base64");
+
+    if (key.length !== KEY_LENGTH) {
+      throw new Error(
+        "EMAIL_JOB_SECRET_KEY must decode to 32 bytes of base64. Generate one with `openssl rand -base64 32`.",
+      );
+    }
+
+    return key;
+  }
+
+  const authSecret = process.env.AUTH_SECRET;
+
+  if (!authSecret) {
+    throw new Error("Set EMAIL_JOB_SECRET_KEY or AUTH_SECRET to protect email job payloads.");
+  }
+
+  return Buffer.from(hkdfSync("sha256", authSecret, "", HKDF_INFO, KEY_LENGTH));
+}
+
+export function encryptSecretContext(value: object) {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv("aes-256-gcm", getSecretContextKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(value), "utf8"), cipher.final()]);
+
+  return Buffer.concat([Buffer.from([FORMAT_VERSION]), iv, cipher.getAuthTag(), ciphertext]);
+}
+
+export function decryptSecretContext<T>(encrypted: Buffer): T {
+  if (encrypted.length < 1 + IV_LENGTH + AUTH_TAG_LENGTH || encrypted[0] !== FORMAT_VERSION) {
+    throw new Error("Email job secret context has an unsupported format.");
+  }
+
+  const iv = encrypted.subarray(1, 1 + IV_LENGTH);
+  const authTag = encrypted.subarray(1 + IV_LENGTH, 1 + IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = encrypted.subarray(1 + IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv("aes-256-gcm", getSecretContextKey(), iv);
+  decipher.setAuthTag(authTag);
+
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+
+  return JSON.parse(plaintext.toString("utf8")) as T;
+}

--- a/lib/email-jobs/secret-context.unit.test.ts
+++ b/lib/email-jobs/secret-context.unit.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+import { decryptSecretContext, encryptSecretContext } from "./secret-context";
+
+const SECRET_KEY = Buffer.alloc(32, 7).toString("base64");
+const INVITE_URL = "https://housing.example.org/invite?token=super-secret-token";
+
+const originalEnv = {
+  emailJobSecretKey: process.env.EMAIL_JOB_SECRET_KEY,
+  authSecret: process.env.AUTH_SECRET,
+};
+
+describe("secret context encryption", () => {
+  beforeEach(() => {
+    process.env.EMAIL_JOB_SECRET_KEY = SECRET_KEY;
+    delete process.env.AUTH_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalEnv.emailJobSecretKey === undefined) {
+      delete process.env.EMAIL_JOB_SECRET_KEY;
+    } else {
+      process.env.EMAIL_JOB_SECRET_KEY = originalEnv.emailJobSecretKey;
+    }
+
+    if (originalEnv.authSecret === undefined) {
+      delete process.env.AUTH_SECRET;
+    } else {
+      process.env.AUTH_SECRET = originalEnv.authSecret;
+    }
+  });
+
+  it("round-trips a secret context object", () => {
+    const encrypted = encryptSecretContext({ inviteUrl: INVITE_URL });
+
+    expect(decryptSecretContext<{ inviteUrl: string }>(encrypted)).toEqual({
+      inviteUrl: INVITE_URL,
+    });
+  });
+
+  it("never stores the plaintext secret in the encrypted buffer", () => {
+    const encrypted = encryptSecretContext({ inviteUrl: INVITE_URL });
+    const rawBytes = encrypted.toString("latin1");
+
+    expect(rawBytes).not.toContain("super-secret-token");
+    expect(rawBytes).not.toContain("inviteUrl");
+  });
+
+  it("produces different ciphertexts for the same value (random IV)", () => {
+    const first = encryptSecretContext({ inviteUrl: INVITE_URL });
+    const second = encryptSecretContext({ inviteUrl: INVITE_URL });
+
+    expect(first.equals(second)).toBe(false);
+  });
+
+  it("rejects tampered ciphertext", () => {
+    const encrypted = encryptSecretContext({ inviteUrl: INVITE_URL });
+    const lastIndex = encrypted.length - 1;
+    encrypted[lastIndex] = (encrypted[lastIndex] ?? 0) ^ 0xff;
+
+    expect(() => decryptSecretContext(encrypted)).toThrow();
+  });
+
+  it("rejects buffers with an unknown format version", () => {
+    const encrypted = encryptSecretContext({ inviteUrl: INVITE_URL });
+    encrypted[0] = 99;
+
+    expect(() => decryptSecretContext(encrypted)).toThrow(
+      "Email job secret context has an unsupported format.",
+    );
+  });
+
+  it("rejects keys that are not 32 bytes", () => {
+    process.env.EMAIL_JOB_SECRET_KEY = Buffer.alloc(16, 1).toString("base64");
+
+    expect(() => encryptSecretContext({ inviteUrl: INVITE_URL })).toThrow(
+      "EMAIL_JOB_SECRET_KEY must decode to 32 bytes of base64",
+    );
+  });
+
+  it("falls back to a key derived from AUTH_SECRET", () => {
+    delete process.env.EMAIL_JOB_SECRET_KEY;
+    process.env.AUTH_SECRET = "auth-secret-for-tests";
+
+    const encrypted = encryptSecretContext({ inviteUrl: INVITE_URL });
+
+    expect(decryptSecretContext<{ inviteUrl: string }>(encrypted)).toEqual({
+      inviteUrl: INVITE_URL,
+    });
+  });
+
+  it("requires some key material", () => {
+    delete process.env.EMAIL_JOB_SECRET_KEY;
+    delete process.env.AUTH_SECRET;
+
+    expect(() => encryptSecretContext({ inviteUrl: INVITE_URL })).toThrow(
+      "Set EMAIL_JOB_SECRET_KEY or AUTH_SECRET",
+    );
+  });
+});

--- a/lib/email-jobs/types.ts
+++ b/lib/email-jobs/types.ts
@@ -1,0 +1,54 @@
+import type { EmailJob, EmailJobType } from "@/db/schema";
+
+/**
+ * Per-type job data. `payload` holds only stable entity references that are
+ * safe to persist as plaintext JSON. `secretContext` holds send-time data that
+ * cannot be re-derived at processing time (raw tokens, one-time links); it is
+ * encrypted before it reaches Postgres and deleted once the job completes.
+ */
+export type EmailJobDescriptor = {
+  type: "account_invite";
+  payload: { inviteId: string };
+  secretContext: { inviteUrl: string };
+};
+
+export type AccountInviteEmailJobSecretContext = Extract<
+  EmailJobDescriptor,
+  { type: "account_invite" }
+>["secretContext"];
+
+export type EnqueueEmailJobInput = EmailJobDescriptor & {
+  /** Stable key for the logical email; dedupes enqueues and provider sends. */
+  idempotencyKey: string;
+  recipientEmail: string;
+  runAfter?: Date;
+  maxAttempts?: number;
+};
+
+export type EnqueueEmailJobResult = {
+  job: EmailJob;
+  /** False when an existing job with the same idempotency key was reused. */
+  created: boolean;
+};
+
+export type EmailJobOutcome = "sent" | "retried" | "failed" | "canceled";
+
+export type EmailJobHandlerResult = {
+  providerMessageId: string | null;
+};
+
+export type EmailJobHandler = (job: EmailJob) => Promise<EmailJobHandlerResult>;
+
+export type EmailJobHandlerRegistry = Record<EmailJobType, EmailJobHandler>;
+
+export type DrainEmailJobsSummary = {
+  claimed: number;
+  sent: number;
+  retried: number;
+  failed: number;
+  canceled: number;
+  backlog: {
+    pending: number;
+    failed: number;
+  };
+};

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { Resend } from "resend";
+import { Resend, type ErrorResponse } from "resend";
 
 export type TransactionalEmailSendOptions = {
   /**
@@ -40,6 +40,17 @@ export type TransactionalEmailContent = {
   html: string;
 };
 
+export class TransactionalEmailProviderError extends Error {
+  constructor(
+    message: string,
+    readonly providerCode: ErrorResponse["name"],
+    readonly statusCode: number | null,
+  ) {
+    super(message);
+    this.name = "TransactionalEmailProviderError";
+  }
+}
+
 /**
  * Single Resend call site for transactional email. Only the email job worker
  * should call this; feature code enqueues jobs via lib/email-jobs instead.
@@ -77,7 +88,11 @@ export async function sendTransactionalEmail(
   );
 
   if (result.error) {
-    throw new Error(result.error.message);
+    throw new TransactionalEmailProviderError(
+      result.error.message,
+      result.error.name,
+      result.error.statusCode,
+    );
   }
 
   return result.data?.id ?? null;

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -8,7 +8,11 @@ export type TransactionalEmailSendOptions = {
    * Do not use a random per-attempt value or provider retries can duplicate sends.
    */
   idempotencyKey: string;
+  /** Hard upper bound on the provider call; the attempt fails past it. */
+  timeoutMs?: number;
 };
+
+const DEFAULT_SEND_TIMEOUT_MS = 15_000;
 
 export function getEmailFromAddress() {
   const from = process.env.EMAIL_FROM;
@@ -39,6 +43,12 @@ export type TransactionalEmailContent = {
 /**
  * Single Resend call site for transactional email. Only the email job worker
  * should call this; feature code enqueues jobs via lib/email-jobs instead.
+ *
+ * The send is raced against a hard deadline so a hanging provider connection
+ * cannot stall a worker or a drain call. The SDK does not expose an abort
+ * signal, so the abandoned request may still deliver; that is safe because
+ * the retry reuses the same idempotency key (Resend dedupes) and stale job
+ * outcome writes require claim ownership.
  */
 export async function sendTransactionalEmail(
   params: {
@@ -47,17 +57,22 @@ export async function sendTransactionalEmail(
     TransactionalEmailSendOptions,
 ) {
   const resend = createResendClient();
-  const result = await resend.emails.send(
-    {
-      from: getEmailFromAddress(),
-      to: params.to,
-      subject: params.subject,
-      text: params.text,
-      html: params.html,
-    },
-    {
-      idempotencyKey: params.idempotencyKey,
-    },
+  const timeoutMs = params.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+
+  const result = await withSendTimeout(
+    resend.emails.send(
+      {
+        from: getEmailFromAddress(),
+        to: params.to,
+        subject: params.subject,
+        text: params.text,
+        html: params.html,
+      },
+      {
+        idempotencyKey: params.idempotencyKey,
+      },
+    ),
+    timeoutMs,
   );
 
   if (result.error) {
@@ -65,4 +80,22 @@ export async function sendTransactionalEmail(
   }
 
   return result.data?.id ?? null;
+}
+
+async function withSendTimeout<T>(send: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      send,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Email provider did not respond within ${timeoutMs}ms.`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -47,8 +47,9 @@ export type TransactionalEmailContent = {
  * The send is raced against a hard deadline so a hanging provider connection
  * cannot stall a worker or a drain call. The SDK does not expose an abort
  * signal, so the abandoned request may still deliver; that is safe because
- * the retry reuses the same idempotency key (Resend dedupes) and stale job
- * outcome writes require claim ownership.
+ * the retry reuses the same idempotency key (Resend dedupes for 24h, which
+ * the retry schedule stays inside given a few-minutes drain scheduler) and
+ * stale job outcome writes require claim ownership.
  */
 export async function sendTransactionalEmail(
   params: {

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -29,3 +29,40 @@ export function createResendClient() {
 
   return new Resend(apiKey);
 }
+
+export type TransactionalEmailContent = {
+  subject: string;
+  text: string;
+  html: string;
+};
+
+/**
+ * Single Resend call site for transactional email. Only the email job worker
+ * should call this; feature code enqueues jobs via lib/email-jobs instead.
+ */
+export async function sendTransactionalEmail(
+  params: {
+    to: string;
+  } & TransactionalEmailContent &
+    TransactionalEmailSendOptions,
+) {
+  const resend = createResendClient();
+  const result = await resend.emails.send(
+    {
+      from: getEmailFromAddress(),
+      to: params.to,
+      subject: params.subject,
+      text: params.text,
+      html: params.html,
+    },
+    {
+      idempotencyKey: params.idempotencyKey,
+    },
+  );
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  return result.data?.id ?? null;
+}

--- a/lib/email.unit.test.ts
+++ b/lib/email.unit.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { Resend } from "resend";
+
+import { sendTransactionalEmail } from "@/lib/email";
+
+jest.mock("resend", () => ({
+  Resend: jest.fn(),
+}));
+
+type SendResult = { data: { id: string } | null; error: { message: string } | null };
+
+const sendMock = jest.fn<(...args: unknown[]) => Promise<SendResult>>();
+
+// jest.mocked() insists the constructor returns a deeply mocked Resend; a
+// structural cast keeps the stub minimal.
+const resendConstructorMock = Resend as unknown as {
+  mockImplementation(implementation: () => unknown): void;
+};
+
+const originalEnv = {
+  resendApiKey: process.env.RESEND_API_KEY,
+  emailFrom: process.env.EMAIL_FROM,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resendConstructorMock.mockImplementation(() => ({ emails: { send: sendMock } }));
+  process.env.RESEND_API_KEY = "re_test_key";
+  process.env.EMAIL_FROM = "Affordable Housing Portal <no-reply@example.org>";
+});
+
+afterAll(() => {
+  if (originalEnv.resendApiKey === undefined) {
+    delete process.env.RESEND_API_KEY;
+  } else {
+    process.env.RESEND_API_KEY = originalEnv.resendApiKey;
+  }
+
+  if (originalEnv.emailFrom === undefined) {
+    delete process.env.EMAIL_FROM;
+  } else {
+    process.env.EMAIL_FROM = originalEnv.emailFrom;
+  }
+});
+
+const SEND_PARAMS = {
+  to: "tenant@example.org",
+  subject: "You’ve been invited",
+  text: "Hello",
+  html: "<p>Hello</p>",
+  idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+};
+
+describe("sendTransactionalEmail", () => {
+  it("forwards the idempotency key to Resend provider options", async () => {
+    sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
+
+    await expect(sendTransactionalEmail(SEND_PARAMS)).resolves.toBe("email_123");
+
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "Affordable Housing Portal <no-reply@example.org>",
+        to: "tenant@example.org",
+        subject: "You’ve been invited",
+      }),
+      { idempotencyKey: SEND_PARAMS.idempotencyKey },
+    );
+  });
+
+  it("throws when the provider reports an error", async () => {
+    sendMock.mockResolvedValue({ data: null, error: { message: "Invalid recipient" } });
+
+    await expect(sendTransactionalEmail(SEND_PARAMS)).rejects.toThrow("Invalid recipient");
+  });
+
+  it("fails the attempt when the provider exceeds the send timeout", async () => {
+    // A hanging connection: the SDK promise never settles.
+    sendMock.mockImplementation(() => new Promise<never>(() => {}));
+
+    await expect(sendTransactionalEmail({ ...SEND_PARAMS, timeoutMs: 25 })).rejects.toThrow(
+      "Email provider did not respond within 25ms.",
+    );
+  });
+});

--- a/lib/email.unit.test.ts
+++ b/lib/email.unit.test.ts
@@ -2,13 +2,16 @@ import { afterAll, beforeEach, describe, expect, it, jest } from "@jest/globals"
 
 import { Resend } from "resend";
 
-import { sendTransactionalEmail } from "@/lib/email";
+import { sendTransactionalEmail, TransactionalEmailProviderError } from "@/lib/email";
 
 jest.mock("resend", () => ({
   Resend: jest.fn(),
 }));
 
-type SendResult = { data: { id: string } | null; error: { message: string } | null };
+type SendResult = {
+  data: { id: string } | null;
+  error: { message: string; name: string; statusCode: number | null } | null;
+};
 
 const sendMock = jest.fn<(...args: unknown[]) => Promise<SendResult>>();
 
@@ -69,9 +72,17 @@ describe("sendTransactionalEmail", () => {
   });
 
   it("throws when the provider reports an error", async () => {
-    sendMock.mockResolvedValue({ data: null, error: { message: "Invalid recipient" } });
+    sendMock.mockResolvedValue({
+      data: null,
+      error: { message: "Invalid recipient", name: "validation_error", statusCode: 422 },
+    });
 
-    await expect(sendTransactionalEmail(SEND_PARAMS)).rejects.toThrow("Invalid recipient");
+    await expect(sendTransactionalEmail(SEND_PARAMS)).rejects.toMatchObject({
+      message: "Invalid recipient",
+      name: "TransactionalEmailProviderError",
+      providerCode: "validation_error",
+      statusCode: 422,
+    } satisfies Partial<TransactionalEmailProviderError>);
   });
 
   it("fails the attempt when the provider exceeds the send timeout", async () => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:seed": "node --env-file-if-exists=.env.local --experimental-strip-types db/seed.ts",
     "db:seed:secrets": "infisical run --env=dev -- node --experimental-strip-types db/seed.ts",
     "db:studio": "drizzle-kit studio",
+    "email:worker": "node --env-file-if-exists=.env.local scripts/email-worker.mjs",
     "start": "next start",
     "start:secrets": "infisical run --env=dev -- next start",
     "lint": "oxlint . -c .oxlintrc.json",

--- a/scripts/email-worker.mjs
+++ b/scripts/email-worker.mjs
@@ -10,6 +10,7 @@
 const appUrl = process.env.EMAIL_WORKER_APP_URL ?? "http://localhost:3000";
 const cronSecret = process.env.CRON_SECRET;
 const pollIntervalMs = Number(process.env.EMAIL_WORKER_POLL_INTERVAL_MS ?? 15_000);
+const drainRequestTimeoutMs = 90_000;
 
 if (!cronSecret) {
   console.error("CRON_SECRET is not set. The worker cannot authenticate against the app.");
@@ -38,6 +39,7 @@ process.on("SIGTERM", () => requestStop("SIGTERM"));
 async function drainOnce() {
   const response = await fetch(drainUrl, {
     method: "POST",
+    signal: AbortSignal.timeout(drainRequestTimeoutMs),
     headers: {
       authorization: `Bearer ${cronSecret}`,
     },

--- a/scripts/email-worker.mjs
+++ b/scripts/email-worker.mjs
@@ -1,0 +1,81 @@
+/**
+ * Long-running email queue worker. Polls the protected drain endpoint so all
+ * queue logic runs inside the Next.js runtime (lib/* uses the "@/" alias and
+ * server-only, which plain Node cannot import directly).
+ *
+ * Usage: npm run email:worker (requires the app and CRON_SECRET).
+ * Multiple workers are safe; job claiming uses FOR UPDATE SKIP LOCKED.
+ */
+
+const appUrl = process.env.EMAIL_WORKER_APP_URL ?? "http://localhost:3000";
+const cronSecret = process.env.CRON_SECRET;
+const pollIntervalMs = Number(process.env.EMAIL_WORKER_POLL_INTERVAL_MS ?? 15_000);
+
+if (!cronSecret) {
+  console.error("CRON_SECRET is not set. The worker cannot authenticate against the app.");
+  process.exit(1);
+}
+
+if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 1_000) {
+  console.error("EMAIL_WORKER_POLL_INTERVAL_MS must be a number >= 1000.");
+  process.exit(1);
+}
+
+const drainUrl = new URL("/api/cron/email-jobs", appUrl).toString();
+
+let stopped = false;
+let wakeUp;
+
+function requestStop(signal) {
+  console.info(`Received ${signal}, finishing current drain before exiting.`);
+  stopped = true;
+  wakeUp?.();
+}
+
+process.on("SIGINT", () => requestStop("SIGINT"));
+process.on("SIGTERM", () => requestStop("SIGTERM"));
+
+async function drainOnce() {
+  const response = await fetch(drainUrl, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${cronSecret}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Drain endpoint responded with ${response.status}.`);
+  }
+
+  return response.json();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    wakeUp = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+  });
+}
+
+console.info(`Email worker polling ${drainUrl} every ${pollIntervalMs}ms.`);
+
+while (!stopped) {
+  try {
+    const summary = await drainOnce();
+
+    if (summary.claimed > 0 || summary.backlog.failed > 0) {
+      console.info(`[${new Date().toISOString()}] drained:`, JSON.stringify(summary));
+    }
+  } catch (error) {
+    console.error(`[${new Date().toISOString()}] drain failed:`, error.message ?? error);
+  }
+
+  if (!stopped) {
+    await sleep(pollIntervalMs);
+  }
+}
+
+console.info("Email worker stopped.");

--- a/shared/schemas/account-management.ts
+++ b/shared/schemas/account-management.ts
@@ -66,6 +66,8 @@ export const accountByIdResponseSchema = z.object({
   data: accountResponseDataSchema,
 });
 
+export const inviteEmailDeliverySchema = z.enum(["sent", "queued", "failed"]).nullable();
+
 export const createAccountResponseSchema = z.object({
   message: z.string(),
   data: z.object({
@@ -75,6 +77,7 @@ export const createAccountResponseSchema = z.object({
     role: accountRoleSchema,
     organization: z.string().nullable().optional(),
     inviteUrl: z.url(),
+    emailDelivery: inviteEmailDeliverySchema,
   }),
 });
 

--- a/shared/schemas/account-management.ts
+++ b/shared/schemas/account-management.ts
@@ -92,6 +92,7 @@ export const accountInviteSchema = z.object({
   role: accountRoleSchema,
   organization: z.string().nullable(),
   invitedAt: z.string(),
+  emailDelivery: z.enum(["sent", "queued", "failed"]),
 });
 
 export const accountInviteListResponseSchema = z.object({

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/email-jobs",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a durable Postgres-backed outbox for transactional email with explicit pending, processing, sent, failed, and canceled states
- migrate account invites to enqueue atomically with invite creation and process through a shared email-job service
- add bounded retries, processing leases, concurrent claiming with `FOR UPDATE SKIP LOCKED`, and stable Resend idempotency keys
- encrypt one-time invite URLs with AES-256-GCM and clear secret context when jobs reach a terminal state

## User and operational impact

- invite creation no longer fails after database records are committed when Resend is unavailable
- the admin UI reports sent, queued, and failed delivery states truthfully and exposes the manual invite link when immediate delivery permanently fails
- the inline attempt is bounded to about five seconds; late completion remains safe through leases and provider idempotency
- queued and failed delivery states are derived from `email_jobs` for all admins rather than maintained only in client cache
- workers can run through the protected cron endpoint, the polling script, or the Docker Compose worker profile

## Security

Job payloads contain stable entity references only. Raw invite URLs are stored in encrypted `secret_context`, errors are sanitized, and sensitive context is removed on terminal outcomes.

## Validation

- 98 unit tests pass
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- pre-commit and pre-push hooks pass

## Follow-up

Real PostgreSQL integration coverage for concurrent claiming, lease recovery, and the invite-delivery status join should be added separately with the repository's first integration-test database harness.

Closes #285