### PR TITLE
refactor: add shared transactional email service for invite emails

### DIFF
--- a/lib/auth/invite-email.ts
+++ b/lib/auth/invite-email.ts
@@ -1,10 +1,6 @@
 import "server-only";
 
-import {
-  createResendClient,
-  getEmailFromAddress,
-  type TransactionalEmailSendOptions,
-} from "@/lib/email";
+import { sendEmail, type TransactionalEmailSendOptions } from "@/lib/email";
 
 export async function sendInviteEmail(
   params: {
@@ -13,24 +9,14 @@ export async function sendInviteEmail(
     inviteUrl: string;
   } & TransactionalEmailSendOptions,
 ) {
-  const resend = createResendClient();
   const inviteUrl = getSafeInviteUrl(params.inviteUrl);
-  const result = await resend.emails.send(
-    {
-      from: getEmailFromAddress(),
-      to: params.email,
-      subject: "You’ve been invited to the Affordable Housing Portal",
-      text: `Hello ${params.fullName},\n\nYou’ve been invited to the Affordable Housing Portal. Use the link below to create your password and activate your account:\n\n${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`,
-      html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>You’ve been invited to the Affordable Housing Portal.</p><p><a href="${escapeHtml(inviteUrl)}">Create your password and activate your account</a></p><p>If you were not expecting this invite, you can ignore this email.</p>`,
-    },
-    {
-      idempotencyKey: params.idempotencyKey,
-    },
-  );
-
-  if (result.error) {
-    throw new Error(result.error.message);
-  }
+  await sendEmail({
+    to: params.email,
+    subject: "You’ve been invited to the Affordable Housing Portal",
+    text: `Hello ${params.fullName},\n\nYou’ve been invited to the Affordable Housing Portal. Use the link below to create your password and activate your account:\n\n${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`,
+    html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>You’ve been invited to the Affordable Housing Portal.</p><p><a href="${escapeHtml(inviteUrl)}">Create your password and activate your account</a></p><p>If you were not expecting this invite, you can ignore this email.</p>`,
+    idempotencyKey: params.idempotencyKey,
+  });
 }
 
 export function getAccountInviteEmailIdempotencyKey(inviteId: string) {

--- a/lib/auth/invite-email.unit.test.ts
+++ b/lib/auth/invite-email.unit.test.ts
@@ -1,16 +1,13 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 
-import { createResendClient, getEmailFromAddress } from "@/lib/email";
 import { getAccountInviteEmailIdempotencyKey, sendInviteEmail } from "@/lib/auth/invite-email";
+import { sendEmail } from "@/lib/email";
 
 jest.mock("@/lib/email", () => ({
-  createResendClient: jest.fn(),
-  getEmailFromAddress: jest.fn(),
+  sendEmail: jest.fn(),
 }));
 
-const createResendClientMock = jest.mocked(createResendClient);
-const getEmailFromAddressMock = jest.mocked(getEmailFromAddress);
-const sendMock = jest.fn<(...args: unknown[]) => Promise<{ data: { id: string }; error: null }>>();
+const sendEmailMock = jest.mocked(sendEmail);
 
 describe("getAccountInviteEmailIdempotencyKey", () => {
   it("uses the persisted invite id as the stable logical email key", () => {
@@ -22,19 +19,11 @@ describe("getAccountInviteEmailIdempotencyKey", () => {
 
 describe("sendInviteEmail", () => {
   beforeEach(() => {
-    sendMock.mockReset();
-    sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
-    createResendClientMock.mockReset();
-    createResendClientMock.mockReturnValue({
-      emails: {
-        send: sendMock,
-      },
-    } as unknown as ReturnType<typeof createResendClient>);
-    getEmailFromAddressMock.mockReset();
-    getEmailFromAddressMock.mockReturnValue("Affordable Housing Portal <no-reply@example.org>");
+    sendEmailMock.mockReset();
+    sendEmailMock.mockResolvedValue({ id: "email_123" });
   });
 
-  it("passes the invite idempotency key to Resend provider options", async () => {
+  it("sends the composed invite email through the shared email service", async () => {
     await sendInviteEmail({
       email: "tenant@example.org",
       fullName: "Tenant User",
@@ -42,15 +31,26 @@ describe("sendInviteEmail", () => {
       idempotencyKey: getAccountInviteEmailIdempotencyKey("2e42f745-44e8-4ab7-a2a2-c1f42cc8e204"),
     });
 
-    expect(sendMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: "Affordable Housing Portal <no-reply@example.org>",
-        to: "tenant@example.org",
-        subject: "You’ve been invited to the Affordable Housing Portal",
+    expect(sendEmailMock).toHaveBeenCalledWith({
+      to: "tenant@example.org",
+      subject: "You’ve been invited to the Affordable Housing Portal",
+      text: expect.stringContaining("https://housing.example.org/invite?token=abc123"),
+      html: expect.stringContaining("https://housing.example.org/invite?token=abc123"),
+      idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+    });
+  });
+
+  it("rejects invite URLs that are not http or https", async () => {
+    await expect(
+      sendInviteEmail({
+        email: "tenant@example.org",
+        fullName: "Tenant User",
+        // oxlint-disable-next-line no-script-url
+        inviteUrl: "javascript:alert(1)",
+        idempotencyKey: getAccountInviteEmailIdempotencyKey("2e42f745-44e8-4ab7-a2a2-c1f42cc8e204"),
       }),
-      {
-        idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
-      },
-    );
+    ).rejects.toThrow("Invite URL must use http or https.");
+
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 });

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -10,7 +10,36 @@ export type TransactionalEmailSendOptions = {
   idempotencyKey: string;
 };
 
-export function getEmailFromAddress() {
+export type SendEmailParams = {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+} & TransactionalEmailSendOptions;
+
+export async function sendEmail(params: SendEmailParams) {
+  const resend = createResendClient();
+  const result = await resend.emails.send(
+    {
+      from: getEmailFromAddress(),
+      to: params.to,
+      subject: params.subject,
+      text: params.text,
+      html: params.html,
+    },
+    {
+      idempotencyKey: params.idempotencyKey,
+    },
+  );
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  return result.data;
+}
+
+function getEmailFromAddress() {
   const from = process.env.EMAIL_FROM;
 
   if (!from) {
@@ -20,7 +49,7 @@ export function getEmailFromAddress() {
   return from;
 }
 
-export function createResendClient() {
+function createResendClient() {
   const apiKey = process.env.RESEND_API_KEY;
 
   if (!apiKey) {

--- a/lib/email.unit.test.ts
+++ b/lib/email.unit.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { Resend } from "resend";
+
+import { sendEmail } from "@/lib/email";
+
+const sendMock =
+  jest.fn<
+    (
+      ...args: unknown[]
+    ) => Promise<{ data: { id: string } | null; error: { message: string } | null }>
+  >();
+
+jest.mock("resend", () => ({
+  Resend: jest.fn(() => ({
+    emails: {
+      send: (...args: unknown[]) => sendMock(...args),
+    },
+  })),
+}));
+
+const ResendMock = jest.mocked(Resend);
+
+const ORIGINAL_ENV = process.env;
+
+describe("sendEmail", () => {
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      RESEND_API_KEY: "re_test_key",
+      EMAIL_FROM: "Affordable Housing Portal <no-reply@example.org>",
+    };
+    ResendMock.mockClear();
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("sends through Resend with the configured sender and the idempotency key in provider options", async () => {
+    const result = await sendEmail({
+      to: "tenant@example.org",
+      subject: "Subject line",
+      text: "Plain text body",
+      html: "<p>HTML body</p>",
+      idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+    });
+
+    expect(ResendMock).toHaveBeenCalledWith("re_test_key");
+    expect(sendMock).toHaveBeenCalledWith(
+      {
+        from: "Affordable Housing Portal <no-reply@example.org>",
+        to: "tenant@example.org",
+        subject: "Subject line",
+        text: "Plain text body",
+        html: "<p>HTML body</p>",
+      },
+      {
+        idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+      },
+    );
+    expect(result).toEqual({ id: "email_123" });
+  });
+
+  it("surfaces provider errors to the caller", async () => {
+    sendMock.mockResolvedValue({
+      data: null,
+      error: { message: "Daily quota exceeded" },
+    });
+
+    await expect(
+      sendEmail({
+        to: "tenant@example.org",
+        subject: "Subject line",
+        text: "Plain text body",
+        html: "<p>HTML body</p>",
+        idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+      }),
+    ).rejects.toThrow("Daily quota exceeded");
+  });
+});


### PR DESCRIPTION
## Summary

Implements #298: extracts a shared, server-only transactional email service so future features (password resets, notifications) send email the same way invites do.

- `lib/email.ts` now exposes `sendEmail({ to, subject, text, html, idempotencyKey })`, which owns Resend client creation and the configured `EMAIL_FROM` sender, passes the idempotency key via Resend's provider options, throws on provider errors, and returns the provider success data. Client/sender helpers became module-private.
- `lib/auth/invite-email.ts` now only composes the invite content (keeping URL-protocol validation and HTML escaping) and delegates delivery to `sendEmail` — it no longer imports the Resend SDK. Delivery remains synchronous.

## Tests

- New `lib/email.unit.test.ts` mocks the `resend` package and verifies the provider call: client built from `RESEND_API_KEY`, configured sender, idempotency key in provider options, and provider errors surfaced as thrown exceptions.
- `lib/auth/invite-email.unit.test.ts` rewritten to mock the shared service, verifying the invite flow passes its composed content and stable `account_invite/<inviteId>` key through `sendEmail`, plus rejection of non-http(s) invite URLs before any send.

All 72 unit tests pass; lint, format, typecheck, and `next build` are clean.

Closes #298