### PR TITLE
feat: classify provider errors and support aborts in the email send layer

### DIFF
--- a/lib/auth/invite-email.ts
+++ b/lib/auth/invite-email.ts
@@ -7,11 +7,13 @@ export async function sendInviteEmail(
     email: string;
     fullName: string;
     inviteUrl: string;
+    signal?: AbortSignal;
   } & TransactionalEmailSendOptions,
 ) {
   const inviteUrl = getSafeInviteUrl(params.inviteUrl);
-  await sendEmail({
+  return await sendEmail({
     to: params.email,
+    signal: params.signal,
     subject: "You’ve been invited to the Affordable Housing Portal",
     text: `Hello ${params.fullName},\n\nYou’ve been invited to the Affordable Housing Portal. Use the link below to create your password and activate your account:\n\n${inviteUrl}\n\nIf you were not expecting this invite, you can ignore this email.`,
     html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>You’ve been invited to the Affordable Housing Portal.</p><p><a href="${escapeHtml(inviteUrl)}">Create your password and activate your account</a></p><p>If you were not expecting this invite, you can ignore this email.</p>`,

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { Resend } from "resend";
+import { Resend, type ErrorResponse } from "resend";
 
 export type TransactionalEmailSendOptions = {
   /**
@@ -30,14 +30,18 @@ export type SendEmailParams = {
  * daily_quota_exceeded, monthly_quota_exceeded).
  */
 export class EmailSendError extends Error {
-  readonly code: string | null;
+  readonly code: ErrorResponse["name"] | null;
   readonly statusCode: number | null;
   /** Parsed from the provider's Retry-After response header, when present. */
   readonly retryAfterSeconds: number | null;
 
   constructor(
     message: string,
-    details: { code: string | null; statusCode: number | null; retryAfterSeconds: number | null },
+    details: {
+      code: ErrorResponse["name"] | null;
+      statusCode: number | null;
+      retryAfterSeconds: number | null;
+    },
   ) {
     super(message);
     this.name = "EmailSendError";
@@ -48,7 +52,7 @@ export class EmailSendError extends Error {
 }
 
 export async function sendEmail(params: SendEmailParams) {
-  throwIfAborted(params.signal);
+  params.signal?.throwIfAborted();
 
   const resend = createResendClient();
   const result = await rejectOnAbort(
@@ -78,12 +82,6 @@ export async function sendEmail(params: SendEmailParams) {
   return result.data;
 }
 
-function throwIfAborted(signal: AbortSignal | undefined) {
-  if (signal?.aborted) {
-    throw new Error("Email send aborted before it started.");
-  }
-}
-
 /**
  * The Resend SDK does not accept an AbortSignal, so the in-flight request is
  * left to settle on its own; this only stops the caller from waiting on (and
@@ -94,8 +92,10 @@ function rejectOnAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined):
     return promise;
   }
 
+  signal.throwIfAborted();
+
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(new Error("Email send aborted while in flight."));
+    const onAbort = () => reject(signal.reason);
     signal.addEventListener("abort", onAbort, { once: true });
     promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
   });

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -15,28 +15,112 @@ export type SendEmailParams = {
   subject: string;
   text: string;
   html: string;
+  /**
+   * Rejects the send when aborted (the queue worker passes its job signal so
+   * an expired job stops before mutating any state). The provider request
+   * itself cannot be cancelled; the idempotency key keeps a late delivery
+   * safe to retry.
+   */
+  signal?: AbortSignal;
 } & TransactionalEmailSendOptions;
 
+/**
+ * Provider failure with enough structure for the email queue worker to pick a
+ * retry strategy: `code` is Resend's error name (such as rate_limit_exceeded,
+ * daily_quota_exceeded, monthly_quota_exceeded).
+ */
+export class EmailSendError extends Error {
+  readonly code: string | null;
+  readonly statusCode: number | null;
+  /** Parsed from the provider's Retry-After response header, when present. */
+  readonly retryAfterSeconds: number | null;
+
+  constructor(
+    message: string,
+    details: { code: string | null; statusCode: number | null; retryAfterSeconds: number | null },
+  ) {
+    super(message);
+    this.name = "EmailSendError";
+    this.code = details.code;
+    this.statusCode = details.statusCode;
+    this.retryAfterSeconds = details.retryAfterSeconds;
+  }
+}
+
 export async function sendEmail(params: SendEmailParams) {
+  throwIfAborted(params.signal);
+
   const resend = createResendClient();
-  const result = await resend.emails.send(
-    {
-      from: getEmailFromAddress(),
-      to: params.to,
-      subject: params.subject,
-      text: params.text,
-      html: params.html,
-    },
-    {
-      idempotencyKey: params.idempotencyKey,
-    },
+  const result = await rejectOnAbort(
+    resend.emails.send(
+      {
+        from: getEmailFromAddress(),
+        to: params.to,
+        subject: params.subject,
+        text: params.text,
+        html: params.html,
+      },
+      {
+        idempotencyKey: params.idempotencyKey,
+      },
+    ),
+    params.signal,
   );
 
   if (result.error) {
-    throw new Error(result.error.message);
+    throw new EmailSendError(result.error.message, {
+      code: result.error.name ?? null,
+      statusCode: result.error.statusCode ?? null,
+      retryAfterSeconds: parseRetryAfterSeconds(result.headers),
+    });
   }
 
   return result.data;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined) {
+  if (signal?.aborted) {
+    throw new Error("Email send aborted before it started.");
+  }
+}
+
+/**
+ * The Resend SDK does not accept an AbortSignal, so the in-flight request is
+ * left to settle on its own; this only stops the caller from waiting on (and
+ * acting after) an abort.
+ */
+function rejectOnAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error("Email send aborted while in flight."));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+  });
+}
+
+/**
+ * Retry-After is either delay-seconds or an HTTP-date (RFC 9110); header name
+ * casing is not guaranteed.
+ */
+function parseRetryAfterSeconds(headers: Record<string, string> | null | undefined) {
+  const value = Object.entries(headers ?? {})
+    .find(([name]) => name.toLowerCase() === "retry-after")?.[1]
+    ?.trim();
+
+  if (!value) {
+    return null;
+  }
+
+  if (/^\d+$/.test(value)) {
+    return Number.parseInt(value, 10);
+  }
+
+  const resetAt = Date.parse(value);
+
+  return Number.isNaN(resetAt) ? null : Math.max(0, Math.ceil((resetAt - Date.now()) / 1000));
 }
 
 function getEmailFromAddress() {

--- a/lib/email.unit.test.ts
+++ b/lib/email.unit.test.ts
@@ -1,14 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { Resend } from "resend";
 
-import { sendEmail } from "@/lib/email";
+import { EmailSendError, sendEmail } from "@/lib/email";
 
-const sendMock =
-  jest.fn<
-    (
-      ...args: unknown[]
-    ) => Promise<{ data: { id: string } | null; error: { message: string } | null }>
-  >();
+const sendMock = jest.fn<
+  (...args: unknown[]) => Promise<{
+    data: { id: string } | null;
+    error: { message: string; name?: string; statusCode?: number } | null;
+    headers?: Record<string, string> | null;
+  }>
+>();
 
 jest.mock("resend", () => ({
   Resend: jest.fn(() => ({
@@ -78,5 +79,82 @@ describe("sendEmail", () => {
         idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
       }),
     ).rejects.toThrow("Daily quota exceeded");
+  });
+
+  it("throws a structured EmailSendError with Retry-After parsed case-insensitively", async () => {
+    sendMock.mockResolvedValue({
+      data: null,
+      error: { message: "Too many requests", name: "rate_limit_exceeded", statusCode: 429 },
+      headers: { "Retry-After": "120" },
+    });
+
+    const error = await sendEmail({
+      to: "tenant@example.org",
+      subject: "Subject line",
+      text: "Plain text body",
+      html: "<p>HTML body</p>",
+      idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+    }).catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(EmailSendError);
+    expect(error).toMatchObject({
+      code: "rate_limit_exceeded",
+      statusCode: 429,
+      retryAfterSeconds: 120,
+    });
+  });
+
+  it("parses an HTTP-date Retry-After into delay seconds", async () => {
+    sendMock.mockResolvedValue({
+      data: null,
+      error: { message: "Too many requests", name: "rate_limit_exceeded", statusCode: 429 },
+      headers: { "retry-after": new Date(Date.now() + 90_000).toUTCString() },
+    });
+
+    const error = (await sendEmail({
+      to: "tenant@example.org",
+      subject: "Subject line",
+      text: "Plain text body",
+      html: "<p>HTML body</p>",
+      idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+    }).catch((thrown: unknown) => thrown)) as EmailSendError;
+
+    expect(error.retryAfterSeconds).toBeGreaterThanOrEqual(85);
+    expect(error.retryAfterSeconds).toBeLessThanOrEqual(91);
+  });
+
+  it("rejects without calling the provider when the signal is already aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      sendEmail({
+        to: "tenant@example.org",
+        subject: "Subject line",
+        text: "Plain text body",
+        html: "<p>HTML body</p>",
+        idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+        signal: abortController.signal,
+      }),
+    ).rejects.toThrow("aborted before it started");
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("stops waiting on an in-flight send when the signal aborts", async () => {
+    sendMock.mockReturnValue(new Promise(() => {}));
+    const abortController = new AbortController();
+
+    const pendingSend = sendEmail({
+      to: "tenant@example.org",
+      subject: "Subject line",
+      text: "Plain text body",
+      html: "<p>HTML body</p>",
+      idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+      signal: abortController.signal,
+    });
+    abortController.abort();
+
+    await expect(pendingSend).rejects.toThrow("aborted while in flight");
   });
 });

--- a/lib/email.unit.test.ts
+++ b/lib/email.unit.test.ts
@@ -136,7 +136,7 @@ describe("sendEmail", () => {
         idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
         signal: abortController.signal,
       }),
-    ).rejects.toThrow("aborted before it started");
+    ).rejects.toMatchObject({ name: "AbortError" });
 
     expect(sendMock).not.toHaveBeenCalled();
   });
@@ -155,6 +155,26 @@ describe("sendEmail", () => {
     });
     abortController.abort();
 
-    await expect(pendingSend).rejects.toThrow("aborted while in flight");
+    await expect(pendingSend).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("rejects if the signal aborts before the in-flight listener is attached", async () => {
+    const abortController = new AbortController();
+    const abortReason = new Error("Email job expired.");
+    sendMock.mockImplementation(() => {
+      abortController.abort(abortReason);
+      return new Promise(() => {});
+    });
+
+    await expect(
+      sendEmail({
+        to: "tenant@example.org",
+        subject: "Subject line",
+        text: "Plain text body",
+        html: "<p>HTML body</p>",
+        idempotencyKey: "account_invite/2e42f745-44e8-4ab7-a2a2-c1f42cc8e204",
+        signal: abortController.signal,
+      }),
+    ).rejects.toBe(abortReason);
   });
 });


### PR DESCRIPTION
## Summary

Part 1 of 3 splitting #300 (the pg-boss email queue, #285) into reviewable pieces. This PR is the provider layer only:

- `EmailSendError` carries Resend's error name (`rate_limit_exceeded`, `daily_quota_exceeded`, `monthly_quota_exceeded`, …), the HTTP status code, and a parsed `Retry-After` header, giving the upcoming queue worker enough structure to pick a retry strategy.
- `sendEmail()` accepts an optional `AbortSignal` and rejects when aborted, so a caller (the worker passes its job signal) can stop a send before mutating any state. The provider request itself cannot be cancelled; the idempotency key (#286) keeps a late delivery safe to retry.
- `sendInviteEmail()` passes the signal through and returns the provider result.

No behavior change for existing callers; `createInvite` still sends inline until part 3.

**Stack:** this PR → #302 (queue core) → #303 (invite wiring). Part of #285.

## Testing

- `npm run typecheck`, `npm run lint`, and the unit suite pass; `lib/email.unit.test.ts` covers error classification, Retry-After parsing, and abort behavior.

