### PR TITLE
feat: deliver invite emails through the queue and surface submission status

### DIFF
--- a/app/(admin)/admin/users/page.tsx
+++ b/app/(admin)/admin/users/page.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
-import { findPendingAccountInvites } from "@/lib/auth/invite-store";
+import { findPendingAccountInvites, type PendingAccountInviteRow } from "@/lib/auth/invite-store";
+import { inviteStatusLabels } from "@/components/admin-invite/types";
 import { getAccountsService } from "@/lib/accounts/account.service";
 import { cn } from "@/lib/utils";
 import type { AccountListResponse } from "@/shared/schemas/account-management";
@@ -93,6 +94,10 @@ function roleBadgeVariant(role: AccountListResponse["data"][number]["role"]) {
     case "user":
       return "outline" as const;
   }
+}
+
+function inviteEmailBadgeVariant(status: PendingAccountInviteRow["status"]) {
+  return status === "failed" ? ("destructive" as const) : ("outline" as const);
 }
 
 function statusBadgeVariant(status: AccountListResponse["data"][number]["status"]) {
@@ -254,7 +259,9 @@ export default async function AdminUsersPage() {
                     <Badge variant={roleBadgeVariant(invite.role)}>{formatRole(invite.role)}</Badge>
                   </DesktopDataCell>
                   <DesktopDataCell>
-                    <Badge variant="outline">Pending</Badge>
+                    <Badge variant={inviteEmailBadgeVariant(invite.status)}>
+                      {inviteStatusLabels[invite.status]}
+                    </Badge>
                   </DesktopDataCell>
                   <DesktopDataCell muted>
                     {formatDateTime(invite.invitedAt.toISOString())}
@@ -287,7 +294,9 @@ export default async function AdminUsersPage() {
                         <Badge variant={roleBadgeVariant(invite.role)}>
                           {formatRole(invite.role)}
                         </Badge>
-                        <Badge variant="outline">Pending</Badge>
+                        <Badge variant={inviteEmailBadgeVariant(invite.status)}>
+                          {inviteStatusLabels[invite.status]}
+                        </Badge>
                       </>
                     }
                   />

--- a/app/admin/invite/actions.ts
+++ b/app/admin/invite/actions.ts
@@ -53,14 +53,14 @@ export async function sendAdminInviteAction(
     }
 
     return {
-      status: "sent",
+      status: "queued",
       message: result.value.message,
       invite: {
         id: result.value.data.id,
         email: result.value.data.email.trim().toLowerCase(),
         role: result.value.data.role,
         invitedAt: new Date().toISOString(),
-        status: "sent",
+        status: "queued",
       },
     };
   } catch (error) {

--- a/components/admin-invite/AdminInviteForm.tsx
+++ b/components/admin-invite/AdminInviteForm.tsx
@@ -43,7 +43,7 @@ export function AdminInviteForm({ onResult }: AdminInviteFormProps) {
 
     onResult(state);
 
-    if (state.status === "sent") {
+    if (state.status !== "error") {
       setName("");
       setEmail("");
       setOrganization("");

--- a/components/admin-invite/InviteResultBanner.tsx
+++ b/components/admin-invite/InviteResultBanner.tsx
@@ -10,7 +10,7 @@ export function InviteResultBanner({ result }: InviteResultBannerProps) {
     return null;
   }
 
-  const isSuccess = result.status === "sent";
+  const isSuccess = result.status !== "error";
 
   return (
     <AlertBanner variant={isSuccess ? "success" : "error"} size="sm">

--- a/components/admin-invite/RecentInvitesList.tsx
+++ b/components/admin-invite/RecentInvitesList.tsx
@@ -2,7 +2,7 @@ import verbiage from "@/content/verbiage.json";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import type { InviteRecord } from "@/components/admin-invite/types";
-import { inviteRoleLabels } from "@/components/admin-invite/types";
+import { inviteRoleLabels, inviteStatusLabels } from "@/components/admin-invite/types";
 
 type RecentInvitesListProps = {
   invites: InviteRecord[];
@@ -40,7 +40,9 @@ export function RecentInvitesList({ invites }: RecentInvitesListProps) {
               </div>
               <div className="flex items-center gap-2">
                 <Badge variant="outline">{inviteRoleLabels[invite.role]}</Badge>
-                <Badge variant="secondary">{invite.status}</Badge>
+                <Badge variant={invite.status === "failed" ? "destructive" : "secondary"}>
+                  {inviteStatusLabels[invite.status]}
+                </Badge>
               </div>
             </li>
           ))}

--- a/components/admin-invite/invite-records.ts
+++ b/components/admin-invite/invite-records.ts
@@ -9,6 +9,6 @@ export function buildInviteRecordFromAccountInvite(
     email: invite.email.trim().toLowerCase(),
     role: invite.role,
     invitedAt: invite.invitedAt,
-    status: "sent",
+    status: invite.status,
   };
 }

--- a/components/admin-invite/types.ts
+++ b/components/admin-invite/types.ts
@@ -22,14 +22,28 @@ export type InviteFormValues = {
   organization: string;
 };
 
-export type InviteStatus = "sent" | "error";
+/**
+ * Email delivery state of an invite: "queued" until the worker delivers
+ * ("sent") or the job permanently fails ("failed"); "not_requested" when the
+ * invite URL is shared manually instead.
+ */
+export type InviteEmailStatus = "not_requested" | "queued" | "failed" | "sent";
+
+export const inviteStatusLabels: Record<InviteEmailStatus, string> = {
+  not_requested: verbiage.adminInvite.status.notRequested,
+  queued: verbiage.adminInvite.status.queued,
+  failed: verbiage.adminInvite.status.failed,
+  sent: verbiage.adminInvite.status.sent,
+};
+
+export type InviteStatus = InviteEmailStatus | "error";
 
 export type InviteRecord = {
   id: string;
   email: string;
   role: InviteRole;
   invitedAt: string;
-  status: InviteStatus;
+  status: InviteEmailStatus;
 };
 
 export type InviteActionResult = {

--- a/components/admin-invite/types.ts
+++ b/components/admin-invite/types.ts
@@ -23,17 +23,17 @@ export type InviteFormValues = {
 };
 
 /**
- * Email delivery state of an invite: "queued" until the worker delivers
- * ("sent") or the job permanently fails ("failed"); "not_requested" when the
- * invite URL is shared manually instead.
+ * Email submission state of an invite: "queued" until Resend accepts the
+ * request ("submitted") or the job permanently fails ("failed");
+ * "not_requested" when the invite URL is shared manually instead.
  */
-export type InviteEmailStatus = "not_requested" | "queued" | "failed" | "sent";
+export type InviteEmailStatus = "not_requested" | "queued" | "failed" | "submitted";
 
 export const inviteStatusLabels: Record<InviteEmailStatus, string> = {
   not_requested: verbiage.adminInvite.status.notRequested,
   queued: verbiage.adminInvite.status.queued,
   failed: verbiage.adminInvite.status.failed,
-  sent: verbiage.adminInvite.status.sent,
+  submitted: verbiage.adminInvite.status.submitted,
 };
 
 export type InviteStatus = InviteEmailStatus | "error";

--- a/components/admin-invite/useAdminInvite.ts
+++ b/components/admin-invite/useAdminInvite.ts
@@ -43,7 +43,7 @@ export function useAdminInvite(input?: {
     (result: InviteActionResult) => {
       setLastResult(result);
 
-      if (result.status !== "sent") {
+      if (result.status === "error") {
         return;
       }
 

--- a/content/verbiage.json
+++ b/content/verbiage.json
@@ -31,6 +31,12 @@
       "admin": "Admin",
       "partner": "Housing Lister",
       "user": "Housing Searcher"
+    },
+    "status": {
+      "notRequested": "No email requested",
+      "queued": "Email queued",
+      "failed": "Email failed",
+      "sent": "Email sent"
     }
   }
 }

--- a/content/verbiage.json
+++ b/content/verbiage.json
@@ -36,7 +36,7 @@
       "notRequested": "No email requested",
       "queued": "Email queued",
       "failed": "Email failed",
-      "sent": "Email sent"
+      "submitted": "Email submitted"
     }
   }
 }

--- a/lib/accounts/account.service.ts
+++ b/lib/accounts/account.service.ts
@@ -113,7 +113,10 @@ export async function createAccountService(
   });
 
   return succeed({
-    message: "Account invited",
+    message:
+      input.sendInviteEmail === true
+        ? "Account invited. The invite email is queued for delivery."
+        : "Account invited",
     data: {
       id: invite.userId,
       email: invite.email,

--- a/lib/auth/invite-service.ts
+++ b/lib/auth/invite-service.ts
@@ -6,8 +6,9 @@ import { and, eq, gt, isNull } from "drizzle-orm";
 
 import { db } from "@/db";
 import { lower, userInvites, users, type UserRole } from "@/db/schema";
-import { getAccountInviteEmailIdempotencyKey, sendInviteEmail } from "@/lib/auth/invite-email";
 import { createOpaqueToken, hashOpaqueToken } from "@/lib/auth/token";
+import { buildAccountInviteEmailJob } from "@/lib/email-queue/email-job";
+import { enqueueEmail } from "@/lib/email-queue/queue";
 
 const INVITE_TTL_MS = 1000 * 60 * 60 * 24 * 7;
 
@@ -24,6 +25,9 @@ export async function createInvite(params: {
   const token = createOpaqueToken();
   const tokenHash = hashOpaqueToken(token);
   const expiresAt = new Date(now.getTime() + INVITE_TTL_MS);
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ?? process.env.AUTH_URL ?? "http://localhost:3000";
+  const inviteUrl = new URL(`/invite?token=${token}`, baseUrl).toString();
 
   const result = await db.transaction(async (tx) => {
     const [existingUser] = await tx
@@ -81,12 +85,20 @@ export async function createInvite(params: {
         tokenHash,
         expiresAt,
         sentAt: null,
+        emailQueuedAt: params.sendInviteEmail ? now : null,
         createdByUserId: params.invitedByUserId,
       })
       .returning();
 
     if (!invite) {
       throw new Error("Failed to create invite.");
+    }
+
+    // Enqueue in the same transaction as the invite so a committed invite can
+    // never lose its email job. The email is queued, not sent: the worker
+    // delivers it and sets sentAt afterwards.
+    if (params.sendInviteEmail) {
+      await enqueueEmail(tx, buildAccountInviteEmailJob({ inviteId: invite.id, inviteUrl }));
     }
 
     return {
@@ -96,30 +108,6 @@ export async function createInvite(params: {
       organization,
     };
   });
-
-  const baseUrl =
-    process.env.NEXT_PUBLIC_APP_URL ?? process.env.AUTH_URL ?? "http://localhost:3000";
-  const inviteUrl = new URL(`/invite?token=${token}`, baseUrl).toString();
-
-  if (params.sendInviteEmail) {
-    await sendInviteEmail({
-      email: result.email,
-      fullName: params.fullName,
-      inviteUrl,
-      idempotencyKey: getAccountInviteEmailIdempotencyKey(result.invite.id),
-    });
-
-    const sentAt = new Date();
-    const [invite] = await db
-      .update(userInvites)
-      .set({
-        sentAt,
-      })
-      .where(eq(userInvites.id, result.invite.id))
-      .returning();
-
-    result.invite = invite ?? { ...result.invite, sentAt };
-  }
 
   return {
     ...result,

--- a/lib/auth/invite-service.ts
+++ b/lib/auth/invite-service.ts
@@ -96,7 +96,7 @@ export async function createInvite(params: {
 
     // Enqueue in the same transaction as the invite so a committed invite can
     // never lose its email job. The email is queued, not sent: the worker
-    // delivers it and sets sentAt afterwards.
+    // submits it to the provider and then sets the legacy sentAt field.
     if (params.sendInviteEmail) {
       await enqueueEmail(tx, buildAccountInviteEmailJob({ inviteId: invite.id, inviteUrl }));
     }

--- a/lib/auth/invite-store.ts
+++ b/lib/auth/invite-store.ts
@@ -1,10 +1,18 @@
 import "server-only";
 
-import { and, desc, eq, gt, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, sql } from "drizzle-orm";
 
 import { db } from "@/db";
 import { userInvites, users, type UserRole } from "@/db/schema";
 import { hashOpaqueToken } from "@/lib/auth/token";
+
+/**
+ * Email delivery state of an invite, derived from persisted columns:
+ * "sent" (worker delivered, sentAt set), "failed" (job dead-lettered,
+ * emailFailedAt set), "queued" (job enqueued, emailQueuedAt set), or
+ * "not_requested" (no email; the invite URL is shared manually).
+ */
+export type AccountInviteEmailStatus = "not_requested" | "queued" | "failed" | "sent";
 
 export type RecentAccountInviteRow = {
   id: string;
@@ -13,6 +21,7 @@ export type RecentAccountInviteRow = {
   role: UserRole;
   organization: string | null;
   invitedAt: Date;
+  status: AccountInviteEmailStatus;
 };
 
 export type PendingAccountInviteRow = RecentAccountInviteRow & {
@@ -52,6 +61,12 @@ export async function getPendingInviteByToken(token: string) {
   return invite ?? null;
 }
 
+/**
+ * Invites whose email has not been delivered yet are included too, so an
+ * invite stays visible between enqueue and delivery ("queued"), after its
+ * email job permanently failed ("failed"), and when no invite email was
+ * requested and the URL is shared manually ("not_requested").
+ */
 export async function findRecentAccountInvites(limit: number): Promise<RecentAccountInviteRow[]> {
   const rows = await db
     .select({
@@ -61,35 +76,17 @@ export async function findRecentAccountInvites(limit: number): Promise<RecentAcc
       role: users.role,
       organization: users.organization,
       sentAt: userInvites.sentAt,
+      emailQueuedAt: userInvites.emailQueuedAt,
+      emailFailedAt: userInvites.emailFailedAt,
+      createdAt: userInvites.createdAt,
     })
     .from(userInvites)
     .innerJoin(users, eq(userInvites.userId, users.id))
-    .where(
-      and(
-        isNull(userInvites.acceptedAt),
-        isNotNull(userInvites.sentAt),
-        gt(userInvites.expiresAt, new Date()),
-      ),
-    )
-    .orderBy(desc(userInvites.sentAt), desc(userInvites.createdAt))
+    .where(and(isNull(userInvites.acceptedAt), gt(userInvites.expiresAt, new Date())))
+    .orderBy(desc(sql`coalesce(${userInvites.sentAt}, ${userInvites.createdAt})`))
     .limit(limit);
 
-  return rows.flatMap((row) => {
-    if (!row.sentAt) {
-      return [];
-    }
-
-    return [
-      {
-        id: row.id,
-        email: row.email,
-        name: row.name,
-        role: row.role,
-        organization: row.organization,
-        invitedAt: row.sentAt,
-      },
-    ];
-  });
+  return rows.map(toAccountInviteRow);
 }
 
 export async function findPendingAccountInvites(): Promise<PendingAccountInviteRow[]> {
@@ -101,36 +98,55 @@ export async function findPendingAccountInvites(): Promise<PendingAccountInviteR
       role: users.role,
       organization: users.organization,
       sentAt: userInvites.sentAt,
+      emailQueuedAt: userInvites.emailQueuedAt,
+      emailFailedAt: userInvites.emailFailedAt,
+      createdAt: userInvites.createdAt,
       expiresAt: userInvites.expiresAt,
     })
     .from(userInvites)
     .innerJoin(users, eq(userInvites.userId, users.id))
-    .where(
-      and(
-        isNull(userInvites.acceptedAt),
-        isNotNull(userInvites.sentAt),
-        gt(userInvites.expiresAt, new Date()),
-      ),
-    )
-    .orderBy(desc(userInvites.sentAt), desc(userInvites.createdAt));
+    .where(and(isNull(userInvites.acceptedAt), gt(userInvites.expiresAt, new Date())))
+    .orderBy(desc(sql`coalesce(${userInvites.sentAt}, ${userInvites.createdAt})`));
 
-  return rows.flatMap((row) => {
-    if (!row.sentAt) {
-      return [];
-    }
+  return rows.map((row) => ({ ...toAccountInviteRow(row), expiresAt: row.expiresAt }));
+}
 
-    return [
-      {
-        id: row.id,
-        email: row.email,
-        name: row.name,
-        role: row.role,
-        organization: row.organization,
-        invitedAt: row.sentAt,
-        expiresAt: row.expiresAt,
-      },
-    ];
-  });
+function toAccountInviteRow(row: {
+  id: string;
+  email: string;
+  name: string;
+  role: UserRole;
+  organization: string | null;
+  sentAt: Date | null;
+  emailQueuedAt: Date | null;
+  emailFailedAt: Date | null;
+  createdAt: Date;
+}): RecentAccountInviteRow {
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    role: row.role,
+    organization: row.organization,
+    invitedAt: row.sentAt ?? row.createdAt,
+    status: toEmailStatus(row),
+  };
+}
+
+function toEmailStatus(row: {
+  sentAt: Date | null;
+  emailQueuedAt: Date | null;
+  emailFailedAt: Date | null;
+}): AccountInviteEmailStatus {
+  if (row.sentAt) {
+    return "sent";
+  }
+
+  if (row.emailFailedAt) {
+    return "failed";
+  }
+
+  return row.emailQueuedAt ? "queued" : "not_requested";
 }
 
 /**

--- a/lib/auth/invite-store.ts
+++ b/lib/auth/invite-store.ts
@@ -7,12 +7,13 @@ import { userInvites, users, type UserRole } from "@/db/schema";
 import { hashOpaqueToken } from "@/lib/auth/token";
 
 /**
- * Email delivery state of an invite, derived from persisted columns:
- * "sent" (worker delivered, sentAt set), "failed" (job dead-lettered,
- * emailFailedAt set), "queued" (job enqueued, emailQueuedAt set), or
- * "not_requested" (no email; the invite URL is shared manually).
+ * Email submission state of an invite, derived from persisted columns:
+ * "submitted" (provider accepted the request; legacy sentAt set), "failed"
+ * (job dead-lettered, emailFailedAt set), "queued" (job enqueued,
+ * emailQueuedAt set), or "not_requested" (no email; the invite URL is shared
+ * manually). Recipient-server delivery is not currently tracked.
  */
-export type AccountInviteEmailStatus = "not_requested" | "queued" | "failed" | "sent";
+export type AccountInviteEmailStatus = "not_requested" | "queued" | "failed" | "submitted";
 
 export type RecentAccountInviteRow = {
   id: string;
@@ -62,10 +63,10 @@ export async function getPendingInviteByToken(token: string) {
 }
 
 /**
- * Invites whose email has not been delivered yet are included too, so an
- * invite stays visible between enqueue and delivery ("queued"), after its
- * email job permanently failed ("failed"), and when no invite email was
- * requested and the URL is shared manually ("not_requested").
+ * Invites whose email has not been submitted yet are included too, so an
+ * invite stays visible between enqueue and provider acceptance ("queued"),
+ * after its email job permanently failed ("failed"), and when no invite email
+ * was requested and the URL is shared manually ("not_requested").
  */
 export async function findRecentAccountInvites(limit: number): Promise<RecentAccountInviteRow[]> {
   const rows = await db
@@ -139,7 +140,7 @@ function toEmailStatus(row: {
   emailFailedAt: Date | null;
 }): AccountInviteEmailStatus {
   if (row.sentAt) {
-    return "sent";
+    return "submitted";
   }
 
   if (row.emailFailedAt) {

--- a/shared/schemas/account-management.ts
+++ b/shared/schemas/account-management.ts
@@ -90,11 +90,11 @@ export const accountInviteSchema = z.object({
   organization: z.string().nullable(),
   invitedAt: z.string(),
   /**
-   * Email delivery state: "queued" until the worker delivers ("sent") or the
-   * job permanently fails ("failed"); "not_requested" when no invite email
-   * was asked for and the invite URL is shared manually.
+   * Email submission state: "queued" until the provider accepts the request
+   * ("submitted") or the job permanently fails ("failed"); "not_requested"
+   * when no email was asked for. Recipient-server delivery is not tracked.
    */
-  status: z.enum(["not_requested", "queued", "failed", "sent"]),
+  status: z.enum(["not_requested", "queued", "failed", "submitted"]),
 });
 
 export const accountInviteListResponseSchema = z.object({

--- a/shared/schemas/account-management.ts
+++ b/shared/schemas/account-management.ts
@@ -89,6 +89,12 @@ export const accountInviteSchema = z.object({
   role: accountRoleSchema,
   organization: z.string().nullable(),
   invitedAt: z.string(),
+  /**
+   * Email delivery state: "queued" until the worker delivers ("sent") or the
+   * job permanently fails ("failed"); "not_requested" when no invite email
+   * was asked for and the invite URL is shared manually.
+   */
+  status: z.enum(["not_requested", "queued", "failed", "sent"]),
 });
 
 export const accountInviteListResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Part 3 of 3 splitting #300 (#285). Wires invite emails into the queue from #302 and keeps the admin lists truthful now that provider submission is asynchronous.

### Enqueue side
- `createInvite` enqueues the invite email job **in the same transaction** that writes the invite (via the `fromDrizzle` adapter from #302), so a committed invite can never lose its email job and a rolled-back transaction leaves no job behind. The inline `sendInviteEmail` call and post-submission `sentAt` update are gone; the worker is now the only sender.

### Admin lists / UX
- Admin invite lists previously filtered on `sentAt IS NOT NULL`, which would hide queued-but-unsubmitted invites and never surface permanent queue failures. They now include those invites and derive an explicit status — `queued` / `submitted` / `failed` / `not_requested` — from the persisted queue columns, sorted by `coalesce(sentAt, createdAt)`.
- Successful invite creation reports **"queued"**, not "sent". After Resend accepts the API request, the worker sets the legacy `sentAt` field and the UI reports **"Email submitted"**. This does not confirm recipient-server delivery; delivered, bounced, failed, and suppressed webhook outcomes are not currently reconciled.

**Stack:** #301 → #302 → this PR. Closes #285.

## Testing

- `npm run typecheck`, `npm run lint`, the full unit suite (116 tests / 18 suites), and `npm run build` pass.

