### PR TITLE
feat: display included utilities on listing details

### DIFF
--- a/app/listings/[id]/page.tsx
+++ b/app/listings/[id]/page.tsx
@@ -30,6 +30,7 @@ export default async function ListingDetailsPage({ params }: Readonly<PageProps>
       beds={details.beds}
       baths={details.baths}
       sqft={details.sqft}
+      utilitiesIncluded={details.utilitiesIncluded}
       images={details.images}
       timeAgo={details.timeAgo}
       features={details.features}

--- a/components/listing-details/ListingDetails.tsx
+++ b/components/listing-details/ListingDetails.tsx
@@ -3,19 +3,13 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { CardHeader, CardTitle, CardContent, Card } from "../ui/card";
 import { buildAddress } from "@/lib/address";
-import { UTILITY_INCLUDED_VALUES } from "@/shared/schemas/listings";
+import {
+  UTILITY_INCLUDED_LABELS,
+  UTILITY_INCLUDED_VALUES,
+  type UtilityIncluded,
+} from "@/shared/schemas/listings";
 import Link from "next/link";
 import { ListingApplyButton } from "./ListingApplyButton";
-
-type UtilityIncluded = (typeof UTILITY_INCLUDED_VALUES)[number];
-
-const UTILITY_LABELS: Record<UtilityIncluded, string> = {
-  heat: "Heat",
-  water: "Water",
-  electricity: "Electricity",
-  gas: "Gas",
-  internet: "Internet",
-};
 
 type ListingFeature = {
   name: string;
@@ -92,7 +86,7 @@ export function ListingDetails({
       value:
         utilitiesIncluded && utilitiesIncluded.length > 0
           ? UTILITY_INCLUDED_VALUES.filter((utility) => utilitiesIncluded.includes(utility))
-              .map((utility) => UTILITY_LABELS[utility])
+              .map((utility) => UTILITY_INCLUDED_LABELS[utility])
               .join(", ")
           : "None listed",
     },

--- a/components/listing-details/ListingDetails.tsx
+++ b/components/listing-details/ListingDetails.tsx
@@ -91,7 +91,9 @@ export function ListingDetails({
       label: "Utilities Included",
       value:
         utilitiesIncluded && utilitiesIncluded.length > 0
-          ? utilitiesIncluded.map((utility) => UTILITY_LABELS[utility]).join(", ")
+          ? UTILITY_INCLUDED_VALUES.filter((utility) => utilitiesIncluded.includes(utility))
+              .map((utility) => UTILITY_LABELS[utility])
+              .join(", ")
           : "None listed",
     },
     { label: "Posted", value: timeAgo },

--- a/components/listing-details/ListingDetails.tsx
+++ b/components/listing-details/ListingDetails.tsx
@@ -3,8 +3,19 @@ import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { CardHeader, CardTitle, CardContent, Card } from "../ui/card";
 import { buildAddress } from "@/lib/address";
+import { UTILITY_INCLUDED_VALUES } from "@/shared/schemas/listings";
 import Link from "next/link";
 import { ListingApplyButton } from "./ListingApplyButton";
+
+type UtilityIncluded = (typeof UTILITY_INCLUDED_VALUES)[number];
+
+const UTILITY_LABELS: Record<UtilityIncluded, string> = {
+  heat: "Heat",
+  water: "Water",
+  electricity: "Electricity",
+  gas: "Gas",
+  internet: "Internet",
+};
 
 type ListingFeature = {
   name: string;
@@ -33,6 +44,7 @@ export interface ListingDetailProps {
   beds: number;
   baths: number;
   sqft: number;
+  utilitiesIncluded?: UtilityIncluded[];
   contactName?: string;
   contactEmail?: string;
   contactPhone?: string;
@@ -51,6 +63,7 @@ export function ListingDetails({
   beds,
   baths,
   sqft,
+  utilitiesIncluded,
   contactName,
   contactEmail,
   contactPhone,
@@ -74,6 +87,13 @@ export function ListingDetails({
     { label: "Bedrooms", value: String(beds) },
     { label: "Bathrooms", value: String(baths) },
     { label: "Square Feet", value: `${sqft.toLocaleString()} sqft` },
+    {
+      label: "Utilities Included",
+      value:
+        utilitiesIncluded && utilitiesIncluded.length > 0
+          ? utilitiesIncluded.map((utility) => UTILITY_LABELS[utility]).join(", ")
+          : "None listed",
+    },
     { label: "Posted", value: timeAgo },
   ];
   const contactRows = [

--- a/components/listing-details/ListingDetails.unit.test.tsx
+++ b/components/listing-details/ListingDetails.unit.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "@jest/globals";
+
+import { ListingDetails } from "./ListingDetails";
+
+const baseProps = {
+  price: 1500,
+  street1: "123 Main St",
+  city: "Waterloo",
+  beds: 2,
+  baths: 1,
+  sqft: 900,
+  images: [],
+  timeAgo: "2 days ago",
+  features: [],
+};
+
+describe("ListingDetails", () => {
+  it("renders the included utilities as a readable list", () => {
+    render(<ListingDetails {...baseProps} utilitiesIncluded={["heat", "water", "internet"]} />);
+
+    expect(screen.queryByText("Utilities Included")).not.toBeNull();
+    expect(screen.queryByText("Heat, Water, Internet")).not.toBeNull();
+  });
+
+  it("shows an explicit empty state when no utilities are included", () => {
+    render(<ListingDetails {...baseProps} utilitiesIncluded={[]} />);
+
+    expect(screen.queryByText("Utilities Included")).not.toBeNull();
+    expect(screen.queryByText("None listed")).not.toBeNull();
+  });
+
+  it("shows the empty state when utilities data is missing", () => {
+    render(<ListingDetails {...baseProps} />);
+
+    expect(screen.queryByText("None listed")).not.toBeNull();
+  });
+});

--- a/components/listing-details/ListingDetails.unit.test.tsx
+++ b/components/listing-details/ListingDetails.unit.test.tsx
@@ -16,8 +16,8 @@ const baseProps = {
 };
 
 describe("ListingDetails", () => {
-  it("renders the included utilities as a readable list", () => {
-    render(<ListingDetails {...baseProps} utilitiesIncluded={["heat", "water", "internet"]} />);
+  it("renders the included utilities in a consistent order", () => {
+    render(<ListingDetails {...baseProps} utilitiesIncluded={["internet", "water", "heat"]} />);
 
     expect(screen.queryByText("Utilities Included")).not.toBeNull();
     expect(screen.queryByText("Heat, Water, Internet")).not.toBeNull();

--- a/components/listing-form-preview/ListingFormPreview.tsx
+++ b/components/listing-form-preview/ListingFormPreview.tsx
@@ -74,6 +74,7 @@ export function ListingFormPreview({
           beds={formData.bedrooms}
           baths={formData.bathrooms}
           sqft={formData.squareFeet || 0}
+          utilitiesIncluded={formData.utilitiesIncluded}
           contactName={formData.contactName}
           contactEmail={formData.contactEmail}
           contactPhone={formData.contactPhone}

--- a/lib/listings/listing.service.ts
+++ b/lib/listings/listing.service.ts
@@ -618,6 +618,7 @@ async function buildListingDetailsResponse(listing: ListingRecord): Promise<List
     beds: listing.bedrooms,
     baths: listing.bathrooms,
     sqft: getListingSquareFeet(listing.squareFeet),
+    utilitiesIncluded: [...listing.utilitiesIncluded],
     accessibilityFeatures: getDisplayAccessibilityFeatures(
       listing.customFields,
       featureDefinitions,

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -116,6 +116,7 @@ export const listingDetailsSchema = z.object({
   beds: z.number().int().min(0),
   baths: z.number().min(0),
   sqft: z.number().int().min(0),
+  utilitiesIncluded: z.array(utilityIncludedSchema).optional(),
   accessibilityFeatures: z.array(listingFeatureSchema).optional(),
   images: z.array(listingImageSchema),
   timeAgo: nonEmptyString,

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -11,6 +11,14 @@ const nonEmptyString = requiredTrimmedString();
 const listingStatusSchema = z.enum(["draft", "published", "archived"]);
 export const LISTING_BUILDING_TYPE_VALUES = ["apartment", "house", "townhouse", "condo"] as const;
 export const UTILITY_INCLUDED_VALUES = ["heat", "water", "electricity", "gas", "internet"] as const;
+export type UtilityIncluded = (typeof UTILITY_INCLUDED_VALUES)[number];
+export const UTILITY_INCLUDED_LABELS = {
+  heat: "Heat",
+  water: "Water",
+  electricity: "Electricity",
+  gas: "Gas",
+  internet: "Internet",
+} satisfies Record<UtilityIncluded, string>;
 const listingBuildingTypeSchema = z.enum(LISTING_BUILDING_TYPE_VALUES);
 const utilityIncludedSchema = z.enum(UTILITY_INCLUDED_VALUES);
 const listingLeaseTermMonthsSchema = z.number().int().positive();


### PR DESCRIPTION
Closes #311

## What

Surfaces the already-collected `utilitiesIncluded` field on the listing details page.

- Added `utilitiesIncluded` to `listingDetailsSchema` and the details read model built in `listing.service.ts`.
- Rendered a "Utilities Included" row in the Rental Details card (`ListingDetails.tsx`), with human-readable labels (Heat, Water, Electricity, Gas, Internet).
- Explicit "None listed" empty state so searchers can distinguish "no utilities included" from missing data.
- Wired the field through both consumers: the listing details page and the listing-form preview.
- Added unit tests for the populated, empty, and missing cases.

## Why

From the July 2026 stakeholder survey (respondent L.A., Property Manager): "utility requirements" was named as missing listing information — but the data was already being captured by the form and stored in the DB, just never displayed.

## Test plan

- [x] `jest --testPathPatterns listing-details` (6 passing)
- [x] `tsc --noEmit`
- [x] `npm run lint`
- [ ] Visual check on a seeded listing (utilities render in Rental Details card)