### PR TITLE
feat: always show an apply path on listing details

### DIFF
--- a/components/listing-details/ListingDetails.apply.unit.test.tsx
+++ b/components/listing-details/ListingDetails.apply.unit.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "@jest/globals";
+
+import { ListingDetails } from "./ListingDetails";
+
+const baseProps = {
+  price: 1500,
+  street1: "123 Main St",
+  city: "Waterloo",
+  beds: 2,
+  baths: 1,
+  sqft: 900,
+  images: [],
+  timeAgo: "2 days ago",
+  features: [],
+};
+
+const contactProps = {
+  contactName: "Alex Morgan",
+  contactEmail: "alex@example.org",
+  contactPhone: "519-555-0100",
+};
+
+describe("ListingDetails apply section", () => {
+  it("shows the apply button when the listing has an application URL", () => {
+    render(
+      <ListingDetails
+        {...baseProps}
+        {...contactProps}
+        applicationUrl="https://example.org/apply"
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Apply" })).not.toBeNull();
+  });
+
+  it("tells searchers to contact the lister when there is no application URL", () => {
+    render(<ListingDetails {...baseProps} {...contactProps} />);
+
+    expect(screen.queryByRole("button", { name: "Apply" })).toBeNull();
+    expect(
+      screen.queryByText("No online application — contact the lister directly to apply."),
+    ).not.toBeNull();
+    expect(screen.queryByText("Alex Morgan")).not.toBeNull();
+  });
+
+  it("explains when the lister has provided no contact or application details", () => {
+    render(<ListingDetails {...baseProps} />);
+
+    expect(screen.queryByRole("button", { name: "Apply" })).toBeNull();
+    expect(
+      screen.queryByText(
+        "The lister hasn't provided contact or application details for this listing yet. Please check back later.",
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/components/listing-details/ListingDetails.tsx
+++ b/components/listing-details/ListingDetails.tsx
@@ -163,17 +163,18 @@ export function ListingDetails({
           </CardContent>
         </Card>
 
-        {(contactRows.length > 0 || applicationUrl) && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Contact Info</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <dl
-                className={`grid grid-cols-1 gap-3 sm:grid-cols-2 ${
-                  applicationUrl ? "lg:grid-cols-4" : "lg:grid-cols-3"
-                }`}
-              >
+        <Card>
+          <CardHeader>
+            <CardTitle>Contact Info</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {contactRows.length === 0 && !applicationUrl ? (
+              <p className="text-sm text-muted-foreground">
+                The lister hasn&apos;t provided contact or application details for this listing yet.
+                Please check back later.
+              </p>
+            ) : (
+              <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
                 {contactRows.map((row) => (
                   <div key={row.label} className="min-w-0 bg-background p-3">
                     <dt className="text-xs uppercase tracking-wide text-muted-foreground">
@@ -190,20 +191,24 @@ export function ListingDetails({
                     </dd>
                   </div>
                 ))}
-                {applicationUrl ? (
-                  <div className="min-w-0 bg-background p-3">
-                    <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-                      Application
-                    </dt>
-                    <dd className="mt-1">
+                <div className="min-w-0 bg-background p-3">
+                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Application
+                  </dt>
+                  <dd className="mt-1">
+                    {applicationUrl ? (
                       <ListingApplyButton applicationUrl={applicationUrl} />
-                    </dd>
-                  </div>
-                ) : null}
+                    ) : (
+                      <p className="text-sm font-medium text-foreground">
+                        No online application — contact the lister directly to apply.
+                      </p>
+                    )}
+                  </dd>
+                </div>
               </dl>
-            </CardContent>
-          </Card>
-        )}
+            )}
+          </CardContent>
+        </Card>
       </div>
     </WrapperElement>
   );

--- a/db/seeds/mock-listings.ts
+++ b/db/seeds/mock-listings.ts
@@ -128,7 +128,10 @@ export const mockListingSeedListings: SeedListing[] = [
       leaseTermMonths: 12,
       utilitiesIncluded: ["heat", "water"],
       maxIncomeCents: 7800000,
-      applicationUrl: "https://example.com/apply/main-st-apartments",
+      // Demo destinations must be absolute HTTPS (schema requires z.httpUrl) and
+      // must actually resolve so testers don't hit a 404; example.com only
+      // serves its root page, so the listing slug goes in the query string.
+      applicationUrl: "https://example.com/?demo-application=main-st-apartments",
       applicationEmail: "leasing@waterloocoop.example.com",
       applicationPhone: "519-555-0100",
       customFields: {
@@ -196,7 +199,7 @@ export const mockListingSeedListings: SeedListing[] = [
       leaseTermMonths: 12,
       utilitiesIncluded: ["water"],
       maxIncomeCents: 6200000,
-      applicationUrl: "https://example.com/apply/king-east-lofts",
+      applicationUrl: "https://example.com/?demo-application=king-east-lofts",
       applicationEmail: "leasing@waterloocoop.example.com",
       applicationPhone: "519-555-0100",
       customFields: {},
@@ -253,7 +256,7 @@ export const mockListingSeedListings: SeedListing[] = [
       leaseTermMonths: 6,
       utilitiesIncluded: ["water"],
       maxIncomeCents: null,
-      applicationUrl: "https://example.com/apply/erb-street-townhomes",
+      applicationUrl: "https://example.com/?demo-application=erb-street-townhomes",
       applicationEmail: "housing@civichomes.example.com",
       applicationPhone: "519-555-0142",
       customFields: {
@@ -371,7 +374,7 @@ export const mockListingSeedListings: SeedListing[] = [
       leaseTermMonths: 12,
       utilitiesIncluded: ["heat", "water", "electricity"],
       maxIncomeCents: 6400000,
-      applicationUrl: "https://example.com/apply/queen-south-residences",
+      applicationUrl: "https://example.com/?demo-application=queen-south-residences",
       applicationEmail: "leasing@waterloocoop.example.com",
       applicationPhone: "519-555-0100",
       customFields: {

--- a/db/seeds/mock-listings.ts
+++ b/db/seeds/mock-listings.ts
@@ -128,7 +128,7 @@ export const mockListingSeedListings: SeedListing[] = [
       leaseTermMonths: 12,
       utilitiesIncluded: ["heat", "water"],
       maxIncomeCents: 7800000,
-      applicationUrl: null,
+      applicationUrl: "https://example.com/apply/main-st-apartments",
       applicationEmail: "leasing@waterloocoop.example.com",
       applicationPhone: "519-555-0100",
       customFields: {
@@ -253,7 +253,7 @@ export const mockListingSeedListings: SeedListing[] = [
       leaseTermMonths: 6,
       utilitiesIncluded: ["water"],
       maxIncomeCents: null,
-      applicationUrl: null,
+      applicationUrl: "https://example.com/apply/erb-street-townhomes",
       applicationEmail: "housing@civichomes.example.com",
       applicationPhone: "519-555-0142",
       customFields: {
@@ -371,7 +371,7 @@ export const mockListingSeedListings: SeedListing[] = [
       leaseTermMonths: 12,
       utilitiesIncluded: ["heat", "water", "electricity"],
       maxIncomeCents: 6400000,
-      applicationUrl: null,
+      applicationUrl: "https://example.com/apply/queen-south-residences",
       applicationEmail: "leasing@waterloocoop.example.com",
       applicationPhone: "519-555-0100",
       customFields: {


### PR DESCRIPTION
Closes #313

## What

Removes the apply dead end on listing details.

- The Contact Info card now always renders (previously it was hidden entirely when a listing had neither contact rows nor an application URL).
- The Application cell always renders:
  - **Has `applicationUrl`** → Apply button (unchanged behavior).
  - **No URL, has contact info** → "No online application — contact the lister directly to apply."
  - **Neither** → explicit empty state: "The lister hasn't provided contact or application details for this listing yet. Please check back later."
- Seeds most demo listings with application URLs so usability testers can actually exercise the apply flow; **12 Cedar Lane Suites intentionally keeps `applicationUrl: null`** so the fallback path stays visible in demos.
- Unit tests for all three states.

## Why

From the July 2026 stakeholder survey (respondent L.A., Property Manager): both apply-flow questions rated **1/5** with the comment "could not test the apply function." Most seeded listings had `applicationUrl: null`, and such listings showed no apply affordance or explanation at all.

## Out of scope (deliberately)

Requiring an application URL or contact info at listing creation/publish — that adds lister friction and is queued for the stakeholder follow-up (#315) before we commit to it.

## Test plan

- [x] `jest --testPathPatterns listing-details` (6 passing)
- [x] `tsc --noEmit`
- [x] Lint (via pre-commit hooks)
- [ ] Visual check: re-seed and confirm Apply button on seeded listings, fallback on 12 Cedar Lane Suites

## Note for reviewers

Independent of #316, but both add a `ListingDetails` unit test file — this one is named `ListingDetails.apply.unit.test.tsx` to avoid a merge conflict; worth consolidating into one file after both land.