### PR TITLE
feat: allow listers to duplicate a listing as a new draft

### DIFF
--- a/app/api/listings/[id]/duplicate/handlers.ts
+++ b/app/api/listings/[id]/duplicate/handlers.ts
@@ -1,0 +1,24 @@
+import { TypedNextResponse, type TypedNextRequest } from "next-rest-framework";
+
+import { mapDomainErrorToHttpResponse } from "@/lib/http/map-domain-error";
+import { duplicateListingByIdService } from "@/lib/listings/listing.service";
+import type { DuplicateListingResponse, ListingParams } from "@/shared/schemas/listings";
+
+type DuplicateListingRouteContext = {
+  params: ListingParams;
+};
+
+export async function duplicateListingByIdHandler(
+  _request: TypedNextRequest<"POST">,
+  { params }: DuplicateListingRouteContext,
+) {
+  const result = await duplicateListingByIdService(params.id);
+
+  if (!result.ok) {
+    return mapDomainErrorToHttpResponse(result.error);
+  }
+
+  return TypedNextResponse.json<DuplicateListingResponse, 201, "application/json">(result.value, {
+    status: 201,
+  });
+}

--- a/app/api/listings/[id]/duplicate/handlers.ts
+++ b/app/api/listings/[id]/duplicate/handlers.ts
@@ -2,17 +2,22 @@ import { TypedNextResponse, type TypedNextRequest } from "next-rest-framework";
 
 import { mapDomainErrorToHttpResponse } from "@/lib/http/map-domain-error";
 import { duplicateListingByIdService } from "@/lib/listings/listing.service";
-import type { DuplicateListingResponse, ListingParams } from "@/shared/schemas/listings";
+import type {
+  DuplicateListingInput,
+  DuplicateListingResponse,
+  ListingParams,
+} from "@/shared/schemas/listings";
 
 type DuplicateListingRouteContext = {
   params: ListingParams;
 };
 
 export async function duplicateListingByIdHandler(
-  _request: TypedNextRequest<"POST">,
+  request: TypedNextRequest<"POST", "application/json", DuplicateListingInput>,
   { params }: DuplicateListingRouteContext,
 ) {
-  const result = await duplicateListingByIdService(params.id);
+  const body = await request.json();
+  const result = await duplicateListingByIdService(params.id, body);
 
   if (!result.ok) {
     return mapDomainErrorToHttpResponse(result.error);

--- a/app/api/listings/[id]/duplicate/route.ts
+++ b/app/api/listings/[id]/duplicate/route.ts
@@ -1,0 +1,18 @@
+import { route, routeOperation } from "next-rest-framework";
+
+import { errorMessageSchema } from "@/shared/schemas/common";
+import { duplicateListingResponseSchema, listingParamsSchema } from "@/shared/schemas/listings";
+import { duplicateListingByIdHandler } from "./handlers";
+
+export const { POST } = route({
+  duplicateListingById: routeOperation({ method: "POST" })
+    .input({ params: listingParamsSchema })
+    .outputs([
+      { status: 201, contentType: "application/json", body: duplicateListingResponseSchema },
+      { status: 401, contentType: "application/json", body: errorMessageSchema },
+      { status: 403, contentType: "application/json", body: errorMessageSchema },
+      { status: 404, contentType: "application/json", body: errorMessageSchema },
+      { status: 400, contentType: "application/json", body: errorMessageSchema },
+    ])
+    .handler(duplicateListingByIdHandler),
+});

--- a/app/api/listings/[id]/duplicate/route.ts
+++ b/app/api/listings/[id]/duplicate/route.ts
@@ -1,12 +1,20 @@
 import { route, routeOperation } from "next-rest-framework";
 
 import { errorMessageSchema } from "@/shared/schemas/common";
-import { duplicateListingResponseSchema, listingParamsSchema } from "@/shared/schemas/listings";
+import {
+  duplicateListingResponseSchema,
+  duplicateListingSchema,
+  listingParamsSchema,
+} from "@/shared/schemas/listings";
 import { duplicateListingByIdHandler } from "./handlers";
 
 export const { POST } = route({
   duplicateListingById: routeOperation({ method: "POST" })
-    .input({ params: listingParamsSchema })
+    .input({
+      contentType: "application/json",
+      body: duplicateListingSchema,
+      params: listingParamsSchema,
+    })
     .outputs([
       { status: 201, contentType: "application/json", body: duplicateListingResponseSchema },
       { status: 401, contentType: "application/json", body: errorMessageSchema },

--- a/app/my-listings/DuplicateListingDialog.tsx
+++ b/app/my-listings/DuplicateListingDialog.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useId, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Copy01Icon, InformationCircleIcon } from "@hugeicons/core-free-icons";
+
+import { AlertBanner } from "@/components/ui/alert-banner";
+import { Button } from "@/components/ui/button";
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPanel,
+  DialogTitle,
+  useDialogOpenerFocus,
+} from "@/components/ui/dialog-shell";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Switch } from "@/components/ui/switch";
+import {
+  DEFAULT_LISTING_DUPLICATE_COPY_PHOTOS,
+  DEFAULT_LISTING_DUPLICATE_SCOPE,
+  type ListingDuplicateScope,
+} from "@/shared/schemas/listings";
+
+export type DuplicateListingSelection = {
+  scope: ListingDuplicateScope;
+  copyPhotos: boolean;
+};
+
+type DuplicateListingDialogProps = {
+  listing: {
+    title: string;
+    unitNumber?: string;
+    imageCount: number;
+  };
+  isDuplicating: boolean;
+  errorMessage?: string | null;
+  onCancel: () => void;
+  onConfirm: (selection: DuplicateListingSelection) => void;
+};
+
+const SCOPE_OPTIONS: Array<{
+  value: ListingDuplicateScope;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "all",
+    label: "All fields",
+    description: "Building information, unit details, and accessibility features.",
+  },
+  {
+    value: "building",
+    label: "Building information only",
+    description: "Address, building details, contact information, and shared amenities.",
+  },
+  {
+    value: "unit",
+    label: "Unit information only",
+    description: "Rent, bedrooms, lease details, and unit features.",
+  },
+];
+
+export function DuplicateListingDialog({
+  listing,
+  isDuplicating,
+  errorMessage,
+  onCancel,
+  onConfirm,
+}: DuplicateListingDialogProps) {
+  const restoreFocusToOpener = useDialogOpenerFocus();
+  const scopeLabelId = useId();
+  const photosLabelId = useId();
+  const [scope, setScope] = useState<ListingDuplicateScope>(DEFAULT_LISTING_DUPLICATE_SCOPE);
+  const [copyPhotos, setCopyPhotos] = useState(DEFAULT_LISTING_DUPLICATE_COPY_PHOTOS);
+  const sourceLabel = getDuplicateSourceLabel(listing);
+  const hasPhotos = listing.imageCount > 0;
+
+  function handleOpenChange(open: boolean) {
+    if (!open && !isDuplicating) {
+      onCancel();
+    }
+  }
+
+  function handleDismiss(event: Event) {
+    event.stopPropagation();
+
+    if (isDuplicating) {
+      event.preventDefault();
+    }
+  }
+
+  return (
+    <DialogOverlay open onOpenChange={handleOpenChange}>
+      <DialogPanel
+        className="max-w-lg"
+        onCloseAutoFocus={restoreFocusToOpener}
+        onEscapeKeyDown={handleDismiss}
+        onInteractOutside={handleDismiss}
+      >
+        <DialogHeader className="border-b-0 pb-0">
+          <DialogTitle>Duplicate listing</DialogTitle>
+          <DialogDescription>
+            Create a new draft from {sourceLabel}. You can review and edit it before publishing.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 px-6 py-5">
+          {errorMessage ? (
+            <AlertBanner variant="error" size="default" className="rounded-lg">
+              {errorMessage}
+            </AlertBanner>
+          ) : null}
+
+          <div className="space-y-3">
+            <p id={scopeLabelId} className="text-sm font-medium">
+              What would you like to copy?
+            </p>
+            <RadioGroup
+              aria-labelledby={scopeLabelId}
+              value={scope}
+              onValueChange={(value) => setScope(value as ListingDuplicateScope)}
+              disabled={isDuplicating}
+            >
+              {SCOPE_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className="flex cursor-pointer items-start gap-3 text-sm has-disabled:cursor-not-allowed has-disabled:opacity-70"
+                >
+                  <RadioGroupItem value={option.value} className="mt-0.5" />
+                  <span className="space-y-1">
+                    <span className="block font-medium">{option.label}</span>
+                    <span className="block text-muted-foreground">{option.description}</span>
+                  </span>
+                </label>
+              ))}
+            </RadioGroup>
+          </div>
+
+          <div className="flex items-start justify-between gap-6">
+            <div className="space-y-1 text-sm">
+              <p id={photosLabelId} className="font-medium">
+                Copy photos?
+              </p>
+              <p className="text-muted-foreground">
+                {hasPhotos
+                  ? `The ${listing.imageCount} ${pluralizePhotos(listing.imageCount)} from ${sourceLabel} will be added to the new draft.`
+                  : `${sourceLabel} has no photos to copy.`}
+              </p>
+            </div>
+            <Switch
+              aria-labelledby={photosLabelId}
+              checked={copyPhotos && hasPhotos}
+              onCheckedChange={setCopyPhotos}
+              disabled={isDuplicating || !hasPhotos}
+            />
+          </div>
+
+          <p className="flex items-start gap-3 border-t border-border pt-5 text-sm">
+            <HugeiconsIcon
+              icon={InformationCircleIcon}
+              className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+            <span>
+              {buildDuplicateListingSummary({
+                scope,
+                copyPhotos: copyPhotos && hasPhotos,
+                photoCount: listing.imageCount,
+              })}
+            </span>
+          </p>
+        </div>
+
+        <DialogFooter className="border-t border-border">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            onClick={onCancel}
+            disabled={isDuplicating}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="lg"
+            disabled={isDuplicating}
+            onClick={() => onConfirm({ scope, copyPhotos: copyPhotos && hasPhotos })}
+          >
+            <HugeiconsIcon icon={Copy01Icon} className="size-4" aria-hidden />
+            {isDuplicating ? "Duplicating..." : "Duplicate as draft"}
+          </Button>
+        </DialogFooter>
+      </DialogPanel>
+    </DialogOverlay>
+  );
+}
+
+export function buildDuplicateListingSummary(input: {
+  scope: ListingDuplicateScope;
+  copyPhotos: boolean;
+  photoCount: number;
+}) {
+  const sentences: string[] = [];
+
+  if (input.scope === "building") {
+    sentences.push("Building information will be copied. Unit details will be left blank.");
+  } else if (input.scope === "unit") {
+    sentences.push("Unit information will be copied. Building details will be left blank.");
+  } else {
+    sentences.push("All fields will be copied.");
+  }
+
+  if (input.photoCount === 0) {
+    sentences.push("There are no photos to copy.");
+  } else if (input.copyPhotos) {
+    sentences.push(
+      `${input.photoCount} ${pluralizePhotos(input.photoCount)} will be copied to the new draft.`,
+    );
+  } else {
+    sentences.push("Photos will not be copied.");
+  }
+
+  if (input.scope !== "building") {
+    // Kept out of the copy for the building-only scope, where every unit field
+    // is already blank.
+    sentences.push("The unit number and availability date will be left blank.");
+  }
+
+  return sentences.join(" ");
+}
+
+function getDuplicateSourceLabel(listing: { title: string; unitNumber?: string }) {
+  if (listing.unitNumber) {
+    return `Unit ${listing.unitNumber}`;
+  }
+
+  return listing.title;
+}
+
+function pluralizePhotos(count: number) {
+  return count === 1 ? "photo" : "photos";
+}

--- a/app/my-listings/DuplicateListingDialog.unit.test.tsx
+++ b/app/my-listings/DuplicateListingDialog.unit.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { DuplicateListingDialog } from "./DuplicateListingDialog";
+
+const listing = {
+  title: "Sunny 2BR near uptown",
+  unitNumber: "204",
+  imageCount: 8,
+};
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof DuplicateListingDialog>> = {},
+) {
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
+
+  render(
+    <DuplicateListingDialog
+      listing={listing}
+      isDuplicating={false}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+      {...overrides}
+    />,
+  );
+
+  return { onCancel, onConfirm };
+}
+
+describe("DuplicateListingDialog", () => {
+  it("describes the source listing and defaults to copying all fields without photos", () => {
+    renderDialog();
+
+    expect(
+      screen.queryByText(
+        "Create a new draft from Unit 204. You can review and edit it before publishing.",
+      ),
+    ).not.toBeNull();
+    expect(
+      screen.queryByText("The 8 photos from Unit 204 will be added to the new draft."),
+    ).not.toBeNull();
+    expect(screen.getByRole("radio", { name: /All fields/ }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("switch", { name: "Copy photos?" }).getAttribute("aria-checked")).toBe(
+      "false",
+    );
+    expect(
+      screen.queryByText(
+        "All fields will be copied. Photos will not be copied. The unit number and availability date will be left blank.",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("summarizes what a building-only copy leaves blank", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByRole("radio", { name: /Building information only/ }));
+
+    expect(
+      screen.queryByText(
+        "Building information will be copied. Unit details will be left blank. Photos will not be copied.",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("confirms with the selected scope and photo choice", () => {
+    const { onConfirm } = renderDialog();
+
+    fireEvent.click(screen.getByRole("radio", { name: /Unit information only/ }));
+    fireEvent.click(screen.getByRole("switch", { name: "Copy photos?" }));
+
+    expect(
+      screen.queryByText(
+        "Unit information will be copied. Building details will be left blank. 8 photos will be copied to the new draft. The unit number and availability date will be left blank.",
+      ),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Duplicate as draft" }));
+
+    expect(onConfirm).toHaveBeenCalledWith({ scope: "unit", copyPhotos: true });
+  });
+
+  it("disables the photo toggle when the listing has no photos", () => {
+    renderDialog({ listing: { ...listing, imageCount: 0 } });
+
+    const photoSwitch = screen.getByRole("switch", { name: "Copy photos?" });
+
+    expect(photoSwitch.hasAttribute("disabled")).toBe(true);
+    expect(screen.queryByText("Unit 204 has no photos to copy.")).not.toBeNull();
+    expect(
+      screen.queryByText(
+        "All fields will be copied. There are no photos to copy. The unit number and availability date will be left blank.",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("surfaces a failed duplicate without closing the dialog", () => {
+    renderDialog({ errorMessage: "Unable to duplicate listing." });
+
+    expect(screen.queryByText("Unable to duplicate listing.")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Duplicate as draft" })).not.toBeNull();
+  });
+});

--- a/app/my-listings/DuplicateListingDialog.unit.test.tsx
+++ b/app/my-listings/DuplicateListingDialog.unit.test.tsx
@@ -95,11 +95,4 @@ describe("DuplicateListingDialog", () => {
       ),
     ).not.toBeNull();
   });
-
-  it("surfaces a failed duplicate without closing the dialog", () => {
-    renderDialog({ errorMessage: "Unable to duplicate listing." });
-
-    expect(screen.queryByText("Unable to duplicate listing.")).not.toBeNull();
-    expect(screen.queryByRole("button", { name: "Duplicate as draft" })).not.toBeNull();
-  });
 });

--- a/app/my-listings/MyListingsClient.tsx
+++ b/app/my-listings/MyListingsClient.tsx
@@ -115,6 +115,25 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
     },
   });
 
+  const duplicateMutation = useMutation({
+    mutationFn: async ({ listingId }: { listingId: string }) => {
+      const response = await fetch(`/api/listings/${listingId}/duplicate`, {
+        method: "POST",
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { message?: string } | null;
+        throw new Error(payload?.message ?? "Unable to duplicate listing.");
+      }
+
+      return { listingId };
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["listings"] });
+      router.refresh();
+    },
+  });
+
   useEffect(() => {
     setNow(new Date());
 
@@ -145,11 +164,9 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
 
   return (
     <div className="space-y-4">
-      {statusMutation.error ? (
+      {statusMutation.error || duplicateMutation.error ? (
         <AlertBanner variant="error" size="default" className="rounded-lg">
-          {statusMutation.error instanceof Error
-            ? statusMutation.error.message
-            : "Unable to update listing. Please try again."}
+          {getMutationErrorMessage(statusMutation.error ?? duplicateMutation.error)}
         </AlertBanner>
       ) : null}
 
@@ -160,6 +177,8 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
             statusMutation.isPending && statusMutation.variables?.listingId === listing.id;
           const pendingLabel =
             statusMutation.variables?.nextStatus === "archived" ? "Deleting..." : "Restoring...";
+          const isDuplicating =
+            duplicateMutation.isPending && duplicateMutation.variables?.listingId === listing.id;
 
           return (
             <Card key={listing.id}>
@@ -226,6 +245,16 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
                         <Button
                           type="button"
                           variant="outline"
+                          disabled={isDuplicating}
+                          onClick={() => {
+                            duplicateMutation.mutate({ listingId: listing.id });
+                          }}
+                        >
+                          {isDuplicating ? "Duplicating..." : "Duplicate"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
                           disabled={isMutating}
                           onClick={() => {
                             if (
@@ -272,6 +301,10 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
       </div>
     </div>
   );
+}
+
+function getMutationErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Unable to update listing. Please try again.";
 }
 
 function sortListings(listings: MyListingItem[]) {

--- a/app/my-listings/MyListingsClient.tsx
+++ b/app/my-listings/MyListingsClient.tsx
@@ -12,6 +12,10 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertBanner } from "@/components/ui/alert-banner";
 import { EmptyState } from "@/components/ui/empty-state";
+import {
+  DuplicateListingDialog,
+  type DuplicateListingSelection,
+} from "@/app/my-listings/DuplicateListingDialog";
 
 type MyListingItem = {
   id: string;
@@ -20,10 +24,12 @@ type MyListingItem = {
   price: number;
   address: string;
   city: string;
+  unitNumber?: string;
   beds: number;
   baths: number;
   sqft: number;
   imageUrl?: string;
+  imageCount: number;
   updatedAt: string;
   publishedAt?: string;
   editUrl: string;
@@ -51,6 +57,7 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
   const router = useRouter();
   const queryClient = useQueryClient();
   const [now, setNow] = useState(() => new Date(renderedAt));
+  const [duplicateTarget, setDuplicateTarget] = useState<MyListingItem | null>(null);
   const listingsQuery = useQuery({
     queryKey: queryKeys.myListings(),
     queryFn: () => sortListings(initialListings),
@@ -116,9 +123,17 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
   });
 
   const duplicateMutation = useMutation({
-    mutationFn: async ({ listingId }: { listingId: string }) => {
+    mutationFn: async ({
+      listingId,
+      selection,
+    }: {
+      listingId: string;
+      selection: DuplicateListingSelection;
+    }) => {
       const response = await fetch(`/api/listings/${listingId}/duplicate`, {
         method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(selection),
       });
 
       if (!response.ok) {
@@ -129,6 +144,7 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
       return { listingId };
     },
     onSuccess: () => {
+      setDuplicateTarget(null);
       void queryClient.invalidateQueries({ queryKey: ["listings"] });
       router.refresh();
     },
@@ -164,9 +180,9 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
 
   return (
     <div className="space-y-4">
-      {statusMutation.error || duplicateMutation.error ? (
+      {statusMutation.error ? (
         <AlertBanner variant="error" size="default" className="rounded-lg">
-          {getMutationErrorMessage(statusMutation.error ?? duplicateMutation.error)}
+          {getMutationErrorMessage(statusMutation.error)}
         </AlertBanner>
       ) : null}
 
@@ -247,7 +263,8 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
                           variant="outline"
                           disabled={isDuplicating}
                           onClick={() => {
-                            duplicateMutation.mutate({ listingId: listing.id });
+                            duplicateMutation.reset();
+                            setDuplicateTarget(listing);
                           }}
                         >
                           {isDuplicating ? "Duplicating..." : "Duplicate"}
@@ -299,6 +316,23 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
           );
         })}
       </div>
+
+      {duplicateTarget ? (
+        <DuplicateListingDialog
+          listing={duplicateTarget}
+          isDuplicating={duplicateMutation.isPending}
+          errorMessage={
+            duplicateMutation.error ? getMutationErrorMessage(duplicateMutation.error) : null
+          }
+          onCancel={() => {
+            duplicateMutation.reset();
+            setDuplicateTarget(null);
+          }}
+          onConfirm={(selection) => {
+            duplicateMutation.mutate({ listingId: duplicateTarget.id, selection });
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "relative flex size-4 shrink-0 items-center justify-center rounded-full border border-input transition-shadow outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive dark:bg-input/30 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="grid place-content-center"
+      >
+        <span className="size-1.5 rounded-full bg-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-transparent bg-input transition-colors outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 data-checked:bg-primary",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block size-5 translate-x-0.5 rounded-full bg-background shadow-sm ring-1 ring-border/40 transition-transform data-checked:translate-x-[1.375rem]"
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/lib/listings/listing.repository.ts
+++ b/lib/listings/listing.repository.ts
@@ -419,6 +419,107 @@ export async function createDraftListing(input: { actorUserId: string }) {
   });
 }
 
+export async function duplicateListingGraph(input: {
+  listingId: ListingIdParam;
+  actorUserId: string;
+  title: string;
+}) {
+  return db.transaction(async (tx) => {
+    const [source] = await tx
+      .select()
+      .from(listings)
+      .where(eq(listings.id, input.listingId))
+      .limit(1);
+
+    if (!source) {
+      throw new Error("Failed to load listing to duplicate.");
+    }
+
+    const [sourceProperty] = await tx
+      .select()
+      .from(properties)
+      .where(eq(properties.id, source.propertyId))
+      .limit(1);
+
+    if (!sourceProperty) {
+      throw new Error("Failed to load property to duplicate.");
+    }
+
+    const [property] = await tx
+      .insert(properties)
+      .values({
+        ownerUserId: sourceProperty.ownerUserId,
+        name: sourceProperty.name,
+        street1: sourceProperty.street1,
+        street2: sourceProperty.street2,
+        city: sourceProperty.city,
+        province: sourceProperty.province,
+        postalCode: sourceProperty.postalCode,
+        country: sourceProperty.country,
+        neighborhood: sourceProperty.neighborhood,
+        latitude: sourceProperty.latitude,
+        longitude: sourceProperty.longitude,
+        contactName: sourceProperty.contactName,
+        contactEmail: sourceProperty.contactEmail,
+        contactPhone: sourceProperty.contactPhone,
+        createdByUserId: input.actorUserId,
+        updatedByUserId: input.actorUserId,
+      })
+      .returning({ id: properties.id });
+
+    if (!property) {
+      throw new Error("Failed to duplicate property.");
+    }
+
+    const [listing] = await tx
+      .insert(listings)
+      .values({
+        propertyId: property.id,
+        createdByUserId: input.actorUserId,
+        updatedByUserId: input.actorUserId,
+        title: input.title,
+        description: source.description,
+        status: "draft",
+        unitNumber: source.unitNumber,
+        buildingType: source.buildingType,
+        bedrooms: source.bedrooms,
+        bathrooms: source.bathrooms,
+        squareFeet: source.squareFeet,
+        monthlyRentCents: source.monthlyRentCents,
+        availableOn: source.availableOn,
+        leaseTermMonths: source.leaseTermMonths,
+        utilitiesIncluded: source.utilitiesIncluded,
+        maxIncomeCents: source.maxIncomeCents,
+        applicationUrl: source.applicationUrl,
+        applicationEmail: source.applicationEmail,
+        applicationPhone: source.applicationPhone,
+        applicationInstructions: source.applicationInstructions,
+        customFields: source.customFields as ListingCustomFields,
+        publishedAt: null,
+        archivedAt: null,
+      })
+      .returning({ id: listings.id });
+
+    if (!listing) {
+      throw new Error("Failed to duplicate listing.");
+    }
+
+    // Copy image rows in SQL so bytea payloads never leave the database.
+    await tx.execute(sql`
+      insert into listing_images (
+        listing_id, uploaded_by_user_id, image_url, image_data, content_type,
+        size_bytes, width, height, original_filename, alt_text, sort_order
+      )
+      select ${listing.id}::uuid, uploaded_by_user_id, image_url, image_data, content_type,
+        size_bytes, width, height, original_filename, alt_text, sort_order
+      from listing_images
+      where listing_id = ${input.listingId}::uuid
+    `);
+
+    return listing;
+  });
+}
+
 export async function findOwnerListings(ownerUserId: string): Promise<OwnerListingRow[]> {
   return db
     .select({

--- a/lib/listings/listing.repository.ts
+++ b/lib/listings/listing.repository.ts
@@ -480,13 +480,15 @@ export async function duplicateListingGraph(input: {
         title: input.title,
         description: source.description,
         status: "draft",
-        unitNumber: source.unitNumber,
+        // Cleared rather than copied: these are the two fields that are
+        // near-certain to differ for a new unit in the same building.
+        unitNumber: null,
         buildingType: source.buildingType,
         bedrooms: source.bedrooms,
         bathrooms: source.bathrooms,
         squareFeet: source.squareFeet,
         monthlyRentCents: source.monthlyRentCents,
-        availableOn: source.availableOn,
+        availableOn: null,
         leaseTermMonths: source.leaseTermMonths,
         utilitiesIncluded: source.utilitiesIncluded,
         maxIncomeCents: source.maxIncomeCents,

--- a/lib/listings/listing.repository.ts
+++ b/lib/listings/listing.repository.ts
@@ -13,7 +13,7 @@ import {
   type ListingStatus,
   type UtilityIncluded,
 } from "@/db/schema";
-import { DEFAULT_PROPERTY_COUNTRY } from "@/lib/listings/store";
+import { buildDuplicateListingPlan, DEFAULT_PROPERTY_COUNTRY } from "@/lib/listings/store";
 import type {
   CreateListingInput,
   ListingDuplicateScope,
@@ -442,12 +442,6 @@ export async function duplicateListingGraph(input: {
   copyPhotos: boolean;
   customFields: ListingCustomFields;
 }) {
-  // "building" copies the property row and the landlord-level listing fields;
-  // "unit" copies the unit-level listing fields. Fields outside the chosen
-  // scope start blank, exactly as they do for a brand new draft.
-  const copiesBuilding = input.scope !== "unit";
-  const copiesUnit = input.scope !== "building";
-
   return db.transaction(async (tx) => {
     const [source] = await tx
       .select()
@@ -469,28 +463,18 @@ export async function duplicateListingGraph(input: {
       throw new Error("Failed to load property to duplicate.");
     }
 
+    const plan = buildDuplicateListingPlan({
+      source,
+      sourceProperty,
+      actorUserId: input.actorUserId,
+      title: input.title,
+      scope: input.scope,
+      customFields: input.customFields,
+    });
+
     const [property] = await tx
       .insert(properties)
-      .values({
-        // The copy stays under the original owner so it still shows up in
-        // their listings when an admin duplicates on their behalf.
-        ownerUserId: sourceProperty.ownerUserId,
-        name: copiesBuilding ? sourceProperty.name : "",
-        street1: copiesBuilding ? sourceProperty.street1 : "",
-        street2: copiesBuilding ? sourceProperty.street2 : null,
-        city: copiesBuilding ? sourceProperty.city : "",
-        province: copiesBuilding ? sourceProperty.province : "",
-        postalCode: copiesBuilding ? sourceProperty.postalCode : "",
-        country: copiesBuilding ? sourceProperty.country : DEFAULT_PROPERTY_COUNTRY,
-        neighborhood: copiesBuilding ? sourceProperty.neighborhood : null,
-        latitude: copiesBuilding ? sourceProperty.latitude : null,
-        longitude: copiesBuilding ? sourceProperty.longitude : null,
-        contactName: copiesBuilding ? sourceProperty.contactName : "",
-        contactEmail: copiesBuilding ? sourceProperty.contactEmail : "",
-        contactPhone: copiesBuilding ? sourceProperty.contactPhone : "",
-        createdByUserId: input.actorUserId,
-        updatedByUserId: input.actorUserId,
-      })
+      .values(plan.property)
       .returning({ id: properties.id });
 
     if (!property) {
@@ -499,33 +483,7 @@ export async function duplicateListingGraph(input: {
 
     const [listing] = await tx
       .insert(listings)
-      .values({
-        propertyId: property.id,
-        createdByUserId: input.actorUserId,
-        updatedByUserId: input.actorUserId,
-        title: input.title,
-        status: "draft",
-        // Cleared rather than copied: these are the two fields that are
-        // near-certain to differ for a new unit in the same building.
-        unitNumber: null,
-        availableOn: null,
-        description: copiesUnit ? source.description : null,
-        bedrooms: copiesUnit ? source.bedrooms : 0,
-        bathrooms: copiesUnit ? source.bathrooms : 0,
-        squareFeet: copiesUnit ? source.squareFeet : null,
-        monthlyRentCents: copiesUnit ? source.monthlyRentCents : 0,
-        leaseTermMonths: copiesUnit ? source.leaseTermMonths : null,
-        utilitiesIncluded: copiesUnit ? source.utilitiesIncluded : [],
-        maxIncomeCents: copiesUnit ? source.maxIncomeCents : null,
-        buildingType: copiesBuilding ? source.buildingType : null,
-        applicationUrl: copiesBuilding ? source.applicationUrl : null,
-        applicationEmail: copiesBuilding ? source.applicationEmail : "",
-        applicationPhone: copiesBuilding ? source.applicationPhone : "",
-        applicationInstructions: copiesBuilding ? source.applicationInstructions : null,
-        customFields: input.customFields,
-        publishedAt: null,
-        archivedAt: null,
-      })
+      .values({ ...plan.listing, propertyId: property.id })
       .returning({ id: listings.id });
 
     if (!listing) {

--- a/lib/listings/listing.repository.ts
+++ b/lib/listings/listing.repository.ts
@@ -16,6 +16,7 @@ import {
 import { DEFAULT_PROPERTY_COUNTRY } from "@/lib/listings/store";
 import type {
   CreateListingInput,
+  ListingDuplicateScope,
   ListingIdParam,
   UpdateListingInput,
 } from "@/shared/schemas/listings";
@@ -330,6 +331,20 @@ export async function findPublicFeatureDefinitionsByKeys(keys: string[]) {
     );
 }
 
+export async function findFeatureDefinitionCategoriesByKeys(keys: string[]) {
+  if (keys.length === 0) {
+    return [];
+  }
+
+  return db
+    .select({
+      key: customListingFields.key,
+      category: customListingFields.category,
+    })
+    .from(customListingFields)
+    .where(inArray(customListingFields.key, keys));
+}
+
 export async function findPublicBooleanFeatureDefinitions() {
   return db
     .select({
@@ -423,7 +438,16 @@ export async function duplicateListingGraph(input: {
   listingId: ListingIdParam;
   actorUserId: string;
   title: string;
+  scope: ListingDuplicateScope;
+  copyPhotos: boolean;
+  customFields: ListingCustomFields;
 }) {
+  // "building" copies the property row and the landlord-level listing fields;
+  // "unit" copies the unit-level listing fields. Fields outside the chosen
+  // scope start blank, exactly as they do for a brand new draft.
+  const copiesBuilding = input.scope !== "unit";
+  const copiesUnit = input.scope !== "building";
+
   return db.transaction(async (tx) => {
     const [source] = await tx
       .select()
@@ -448,20 +472,22 @@ export async function duplicateListingGraph(input: {
     const [property] = await tx
       .insert(properties)
       .values({
+        // The copy stays under the original owner so it still shows up in
+        // their listings when an admin duplicates on their behalf.
         ownerUserId: sourceProperty.ownerUserId,
-        name: sourceProperty.name,
-        street1: sourceProperty.street1,
-        street2: sourceProperty.street2,
-        city: sourceProperty.city,
-        province: sourceProperty.province,
-        postalCode: sourceProperty.postalCode,
-        country: sourceProperty.country,
-        neighborhood: sourceProperty.neighborhood,
-        latitude: sourceProperty.latitude,
-        longitude: sourceProperty.longitude,
-        contactName: sourceProperty.contactName,
-        contactEmail: sourceProperty.contactEmail,
-        contactPhone: sourceProperty.contactPhone,
+        name: copiesBuilding ? sourceProperty.name : "",
+        street1: copiesBuilding ? sourceProperty.street1 : "",
+        street2: copiesBuilding ? sourceProperty.street2 : null,
+        city: copiesBuilding ? sourceProperty.city : "",
+        province: copiesBuilding ? sourceProperty.province : "",
+        postalCode: copiesBuilding ? sourceProperty.postalCode : "",
+        country: copiesBuilding ? sourceProperty.country : DEFAULT_PROPERTY_COUNTRY,
+        neighborhood: copiesBuilding ? sourceProperty.neighborhood : null,
+        latitude: copiesBuilding ? sourceProperty.latitude : null,
+        longitude: copiesBuilding ? sourceProperty.longitude : null,
+        contactName: copiesBuilding ? sourceProperty.contactName : "",
+        contactEmail: copiesBuilding ? sourceProperty.contactEmail : "",
+        contactPhone: copiesBuilding ? sourceProperty.contactPhone : "",
         createdByUserId: input.actorUserId,
         updatedByUserId: input.actorUserId,
       })
@@ -478,25 +504,25 @@ export async function duplicateListingGraph(input: {
         createdByUserId: input.actorUserId,
         updatedByUserId: input.actorUserId,
         title: input.title,
-        description: source.description,
         status: "draft",
         // Cleared rather than copied: these are the two fields that are
         // near-certain to differ for a new unit in the same building.
         unitNumber: null,
-        buildingType: source.buildingType,
-        bedrooms: source.bedrooms,
-        bathrooms: source.bathrooms,
-        squareFeet: source.squareFeet,
-        monthlyRentCents: source.monthlyRentCents,
         availableOn: null,
-        leaseTermMonths: source.leaseTermMonths,
-        utilitiesIncluded: source.utilitiesIncluded,
-        maxIncomeCents: source.maxIncomeCents,
-        applicationUrl: source.applicationUrl,
-        applicationEmail: source.applicationEmail,
-        applicationPhone: source.applicationPhone,
-        applicationInstructions: source.applicationInstructions,
-        customFields: source.customFields as ListingCustomFields,
+        description: copiesUnit ? source.description : null,
+        bedrooms: copiesUnit ? source.bedrooms : 0,
+        bathrooms: copiesUnit ? source.bathrooms : 0,
+        squareFeet: copiesUnit ? source.squareFeet : null,
+        monthlyRentCents: copiesUnit ? source.monthlyRentCents : 0,
+        leaseTermMonths: copiesUnit ? source.leaseTermMonths : null,
+        utilitiesIncluded: copiesUnit ? source.utilitiesIncluded : [],
+        maxIncomeCents: copiesUnit ? source.maxIncomeCents : null,
+        buildingType: copiesBuilding ? source.buildingType : null,
+        applicationUrl: copiesBuilding ? source.applicationUrl : null,
+        applicationEmail: copiesBuilding ? source.applicationEmail : "",
+        applicationPhone: copiesBuilding ? source.applicationPhone : "",
+        applicationInstructions: copiesBuilding ? source.applicationInstructions : null,
+        customFields: input.customFields,
         publishedAt: null,
         archivedAt: null,
       })
@@ -506,17 +532,19 @@ export async function duplicateListingGraph(input: {
       throw new Error("Failed to duplicate listing.");
     }
 
-    // Copy image rows in SQL so bytea payloads never leave the database.
-    await tx.execute(sql`
-      insert into listing_images (
-        listing_id, uploaded_by_user_id, image_url, image_data, content_type,
-        size_bytes, width, height, original_filename, alt_text, sort_order
-      )
-      select ${listing.id}::uuid, uploaded_by_user_id, image_url, image_data, content_type,
-        size_bytes, width, height, original_filename, alt_text, sort_order
-      from listing_images
-      where listing_id = ${input.listingId}::uuid
-    `);
+    if (input.copyPhotos) {
+      // Copy image rows in SQL so bytea payloads never leave the database.
+      await tx.execute(sql`
+        insert into listing_images (
+          listing_id, uploaded_by_user_id, image_url, image_data, content_type,
+          size_bytes, width, height, original_filename, alt_text, sort_order
+        )
+        select ${listing.id}::uuid, uploaded_by_user_id, image_url, image_data, content_type,
+          size_bytes, width, height, original_filename, alt_text, sort_order
+        from listing_images
+        where listing_id = ${input.listingId}::uuid
+      `);
+    }
 
     return listing;
   });

--- a/lib/listings/listing.service.ts
+++ b/lib/listings/listing.service.ts
@@ -6,6 +6,7 @@ import { listings } from "@/db/schema";
 import type { getOptionalSession } from "@/lib/auth/session";
 import { buildListingFeatureDefinitionLookup } from "@/lib/listings/listing-feature-definitions";
 import {
+  buildDuplicateListingTitle,
   buildListingFeatureCategories,
   buildListingCustomFields,
   centsToDollars,
@@ -40,6 +41,7 @@ import {
   archiveListing,
   createDraftListing,
   createListing,
+  duplicateListingGraph,
   findListingImagesByListingIds,
   findListingImagesByListingId,
   findOwnerListings,
@@ -63,6 +65,7 @@ import type {
   CreateListingResponse,
   CreateDraftListingResponse,
   DeleteListingResponse,
+  DuplicateListingResponse,
   ListingByIdResponse,
   ListingDetails,
   ListingEditorData,
@@ -317,6 +320,47 @@ export async function createDraftListingService(): Promise<
     message: "Draft listing created",
     data: {
       id: listing.id,
+    },
+  });
+}
+
+export async function duplicateListingByIdService(
+  listingId: ListingIdParam,
+): Promise<DomainResult<DuplicateListingResponse>> {
+  const actorResult = await requireListingWriteActor();
+
+  if (!actorResult.ok) {
+    return actorResult;
+  }
+
+  const listing = await findListingRecordById(listingId);
+
+  if (!listing) {
+    return fail("not_found", "Listing not found");
+  }
+
+  if (
+    !canEditListing(
+      {
+        ownerUserId: listing.property.ownerUserId,
+        status: listing.status,
+      },
+      actorResult.value.actor,
+    )
+  ) {
+    return fail("forbidden", "Forbidden");
+  }
+
+  const duplicatedListing = await duplicateListingGraph({
+    listingId,
+    actorUserId: actorResult.value.actor.userId,
+    title: buildDuplicateListingTitle(listing.title),
+  });
+
+  return succeed({
+    message: "Listing duplicated",
+    data: {
+      id: duplicatedListing.id,
     },
   });
 }

--- a/lib/listings/listing.service.ts
+++ b/lib/listings/listing.service.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { asc, desc, type SQL } from "drizzle-orm";
 
-import { listings } from "@/db/schema";
+import { listings, type ListingCustomFields } from "@/db/schema";
 import type { getOptionalSession } from "@/lib/auth/session";
 import { buildListingFeatureDefinitionLookup } from "@/lib/listings/listing-feature-definitions";
 import {
@@ -20,6 +20,7 @@ import {
   getListingSquareFeet,
   mergeListingCustomFields,
   resolveListingStatusTimestamps,
+  selectDuplicateCustomFields,
 } from "@/lib/listings/store";
 import {
   andListingSpecifications,
@@ -42,6 +43,7 @@ import {
   createDraftListing,
   createListing,
   duplicateListingGraph,
+  findFeatureDefinitionCategoriesByKeys,
   findListingImagesByListingIds,
   findListingImagesByListingId,
   findOwnerListings,
@@ -60,14 +62,20 @@ import {
   type ListingActor,
 } from "@/lib/policies/listing-policy";
 import { getOptionalSession as getAuthSession } from "@/lib/auth/session";
+import {
+  DEFAULT_LISTING_DUPLICATE_COPY_PHOTOS,
+  DEFAULT_LISTING_DUPLICATE_SCOPE,
+} from "@/shared/schemas/listings";
 import type {
   CreateListingInput,
   CreateListingResponse,
   CreateDraftListingResponse,
   DeleteListingResponse,
+  DuplicateListingInput,
   DuplicateListingResponse,
   ListingByIdResponse,
   ListingDetails,
+  ListingDuplicateScope,
   ListingEditorData,
   ListingEditorResponse,
   ListingIdParam,
@@ -326,6 +334,7 @@ export async function createDraftListingService(): Promise<
 
 export async function duplicateListingByIdService(
   listingId: ListingIdParam,
+  input: DuplicateListingInput = {},
 ): Promise<DomainResult<DuplicateListingResponse>> {
   const actorResult = await requireListingWriteActor();
 
@@ -351,10 +360,14 @@ export async function duplicateListingByIdService(
     return fail("forbidden", "Forbidden");
   }
 
+  const scope = input.scope ?? DEFAULT_LISTING_DUPLICATE_SCOPE;
   const duplicatedListing = await duplicateListingGraph({
     listingId,
     actorUserId: actorResult.value.actor.userId,
     title: buildDuplicateListingTitle(listing.title),
+    scope,
+    copyPhotos: input.copyPhotos ?? DEFAULT_LISTING_DUPLICATE_COPY_PHOTOS,
+    customFields: await resolveDuplicateCustomFields(listing.customFields, scope),
   });
 
   return succeed({
@@ -362,6 +375,23 @@ export async function duplicateListingByIdService(
     data: {
       id: duplicatedListing.id,
     },
+  });
+}
+
+async function resolveDuplicateCustomFields(
+  customFields: ListingCustomFields,
+  scope: ListingDuplicateScope,
+): Promise<ListingCustomFields> {
+  if (scope === "all") {
+    return customFields;
+  }
+
+  const definitions = await findFeatureDefinitionCategoriesByKeys(Object.keys(customFields));
+
+  return selectDuplicateCustomFields({
+    customFields,
+    categoryByKey: new Map(definitions.map((definition) => [definition.key, definition.category])),
+    scope,
   });
 }
 
@@ -374,10 +404,12 @@ export async function getMyListingsService(): Promise<
       price: number;
       address: string;
       city: string;
+      unitNumber?: string;
       beds: number;
       baths: number;
       sqft: number;
       imageUrl?: string;
+      imageCount: number;
       updatedAt: string;
       publishedAt?: string;
       editUrl: string;
@@ -395,11 +427,21 @@ export async function getMyListingsService(): Promise<
   const listingIds = rows.map((row) => row.id);
   const imageRows = await findListingImagesByListingIds(listingIds);
   const imageByListingId = new Map<string, string>();
+  const imageCountByListingId = new Map<string, number>();
 
   for (const image of imageRows) {
-    if (image.listingId && !imageByListingId.has(image.listingId)) {
+    if (!image.listingId) {
+      continue;
+    }
+
+    if (!imageByListingId.has(image.listingId)) {
       imageByListingId.set(image.listingId, getListingImageUrl(image.id, image.imageUrl));
     }
+
+    imageCountByListingId.set(
+      image.listingId,
+      (imageCountByListingId.get(image.listingId) ?? 0) + 1,
+    );
   }
 
   return succeed({
@@ -410,10 +452,12 @@ export async function getMyListingsService(): Promise<
       price: centsToDollars(row.monthlyRentCents),
       address: formatListingAddress(row.street1, row.unitNumber) || "Address pending",
       city: row.city || "Location pending",
+      unitNumber: row.unitNumber?.trim() || undefined,
       beds: row.bedrooms,
       baths: row.bathrooms,
       sqft: getListingSquareFeet(row.squareFeet),
       imageUrl: imageByListingId.get(row.id),
+      imageCount: imageCountByListingId.get(row.id) ?? 0,
       updatedAt: row.updatedAt.toISOString(),
       publishedAt: row.publishedAt?.toISOString(),
       editUrl: `/listing-form/${row.id}`,

--- a/lib/listings/store.ts
+++ b/lib/listings/store.ts
@@ -92,6 +92,12 @@ export function formatListingAddress(street1: string, unitNumber: string | null)
   return unitNumber ? `${street1} #${unitNumber}` : street1;
 }
 
+export function buildDuplicateListingTitle(title: string) {
+  const trimmedTitle = title.trim();
+
+  return trimmedTitle ? `Copy of ${trimmedTitle}` : "";
+}
+
 export function getListingImageUrl(imageId: string, imageUrl: string | null) {
   return imageUrl ?? `/api/image-uploads/${imageId}`;
 }

--- a/lib/listings/store.ts
+++ b/lib/listings/store.ts
@@ -2,7 +2,14 @@ import "server-only";
 
 import { formatDistanceToNow } from "date-fns";
 
-import type { ListingCustomFields, ListingStatus } from "@/db/schema";
+import type {
+  Listing,
+  ListingCustomFields,
+  ListingStatus,
+  NewListing,
+  NewProperty,
+  Property,
+} from "@/db/schema";
 import { sortCustomListingFieldsForDisplay } from "@/lib/custom-listing-fields/custom-listing-field-ordering";
 import {
   buildListingFeatureDefinitionLookup,
@@ -139,6 +146,87 @@ export function selectDuplicateCustomFields(input: {
   }
 
   return selected;
+}
+
+/**
+ * The values a duplicate is created from. `propertyId` is left to the caller
+ * because the new property row has to be inserted before its id exists.
+ */
+export type DuplicateListingPlan = {
+  property: NewProperty;
+  listing: Omit<NewListing, "propertyId">;
+};
+
+/**
+ * Decides what a duplicate carries over. This is the duplication policy —
+ * which fields belong to the building, which belong to the unit, what is
+ * deliberately reset, and who ends up owning the copy. It is pure so the rules
+ * can be tested without a database; the repository decides how the resulting
+ * plan is persisted.
+ */
+export function buildDuplicateListingPlan(input: {
+  source: Listing;
+  sourceProperty: Property;
+  actorUserId: string;
+  title: string;
+  scope: ListingDuplicateScope;
+  customFields: ListingCustomFields;
+}): DuplicateListingPlan {
+  // "building" copies the property row and the landlord-level listing fields;
+  // "unit" copies the unit-level listing fields. Fields outside the chosen
+  // scope start blank, exactly as they do for a brand new draft.
+  const copiesBuilding = input.scope !== "unit";
+  const copiesUnit = input.scope !== "building";
+  const { source, sourceProperty, actorUserId } = input;
+
+  return {
+    property: {
+      // The copy stays under the original owner so it still shows up in
+      // their listings when an admin duplicates on their behalf.
+      ownerUserId: sourceProperty.ownerUserId,
+      name: copiesBuilding ? sourceProperty.name : "",
+      street1: copiesBuilding ? sourceProperty.street1 : "",
+      street2: copiesBuilding ? sourceProperty.street2 : null,
+      city: copiesBuilding ? sourceProperty.city : "",
+      province: copiesBuilding ? sourceProperty.province : "",
+      postalCode: copiesBuilding ? sourceProperty.postalCode : "",
+      country: copiesBuilding ? sourceProperty.country : DEFAULT_PROPERTY_COUNTRY,
+      neighborhood: copiesBuilding ? sourceProperty.neighborhood : null,
+      latitude: copiesBuilding ? sourceProperty.latitude : null,
+      longitude: copiesBuilding ? sourceProperty.longitude : null,
+      contactName: copiesBuilding ? sourceProperty.contactName : "",
+      contactEmail: copiesBuilding ? sourceProperty.contactEmail : "",
+      contactPhone: copiesBuilding ? sourceProperty.contactPhone : "",
+      createdByUserId: actorUserId,
+      updatedByUserId: actorUserId,
+    },
+    listing: {
+      createdByUserId: actorUserId,
+      updatedByUserId: actorUserId,
+      title: input.title,
+      status: "draft",
+      // Cleared rather than copied: these are the two fields that are
+      // near-certain to differ for a new unit in the same building.
+      unitNumber: null,
+      availableOn: null,
+      description: copiesUnit ? source.description : null,
+      bedrooms: copiesUnit ? source.bedrooms : 0,
+      bathrooms: copiesUnit ? source.bathrooms : 0,
+      squareFeet: copiesUnit ? source.squareFeet : null,
+      monthlyRentCents: copiesUnit ? source.monthlyRentCents : 0,
+      leaseTermMonths: copiesUnit ? source.leaseTermMonths : null,
+      utilitiesIncluded: copiesUnit ? source.utilitiesIncluded : [],
+      maxIncomeCents: copiesUnit ? source.maxIncomeCents : null,
+      buildingType: copiesBuilding ? source.buildingType : null,
+      applicationUrl: copiesBuilding ? source.applicationUrl : null,
+      applicationEmail: copiesBuilding ? source.applicationEmail : "",
+      applicationPhone: copiesBuilding ? source.applicationPhone : "",
+      applicationInstructions: copiesBuilding ? source.applicationInstructions : null,
+      customFields: input.customFields,
+      publishedAt: null,
+      archivedAt: null,
+    },
+  };
 }
 
 export function getListingImageUrl(imageId: string, imageUrl: string | null) {

--- a/lib/listings/store.ts
+++ b/lib/listings/store.ts
@@ -6,11 +6,13 @@ import type { ListingCustomFields, ListingStatus } from "@/db/schema";
 import { sortCustomListingFieldsForDisplay } from "@/lib/custom-listing-fields/custom-listing-field-ordering";
 import {
   buildListingFeatureDefinitionLookup,
+  normalizeListingFeatureToken,
   type ListingFeatureDefinition,
 } from "@/lib/listings/listing-feature-definitions";
 import type {
   CreateListingInput,
   ListingDetails,
+  ListingDuplicateScope,
   UpdateListingInput,
 } from "@/shared/schemas/listings";
 
@@ -96,6 +98,47 @@ export function buildDuplicateListingTitle(title: string) {
   const trimmedTitle = title.trim();
 
   return trimmedTitle ? `Copy of ${trimmedTitle}` : "";
+}
+
+/**
+ * Feature categories that describe the building rather than the unit, used to
+ * split accessibility features when only part of a listing is duplicated.
+ * Categories are admin-editable, so anything unrecognized is treated as a unit
+ * feature: it then travels with the unit, and the copy is a draft the lister
+ * reviews before publishing.
+ */
+export const BUILDING_SCOPE_FEATURE_CATEGORIES = ["BUILDING AMENITIES", "ENTRY & EXTERIOR"];
+
+const buildingScopeFeatureCategoryTokens = new Set(
+  BUILDING_SCOPE_FEATURE_CATEGORIES.map(normalizeListingFeatureToken),
+);
+
+export function isBuildingScopeFeatureCategory(category: string) {
+  return buildingScopeFeatureCategoryTokens.has(normalizeListingFeatureToken(category));
+}
+
+export function selectDuplicateCustomFields(input: {
+  customFields: ListingCustomFields;
+  categoryByKey: Map<string, string>;
+  scope: ListingDuplicateScope;
+}): ListingCustomFields {
+  if (input.scope === "all") {
+    return { ...input.customFields };
+  }
+
+  const wantsBuildingFeatures = input.scope === "building";
+  const selected: ListingCustomFields = {};
+
+  for (const [key, value] of Object.entries(input.customFields)) {
+    const category = input.categoryByKey.get(key);
+    const isBuildingFeature = category ? isBuildingScopeFeatureCategory(category) : false;
+
+    if (isBuildingFeature === wantsBuildingFeatures) {
+      selected[key] = value;
+    }
+  }
+
+  return selected;
 }
 
 export function getListingImageUrl(imageId: string, imageUrl: string | null) {

--- a/lib/listings/store.unit.test.ts
+++ b/lib/listings/store.unit.test.ts
@@ -2,12 +2,26 @@ import { describe, expect, it } from "@jest/globals";
 
 import type { ListingCustomFields } from "@/db/schema";
 import {
+  buildDuplicateListingTitle,
   buildListingCustomFields,
   buildListingFeatureCategories,
   getDisplayAccessibilityFeatures,
   getListingApplicationUrl,
   mergeListingCustomFields,
 } from "./store";
+
+describe("buildDuplicateListingTitle", () => {
+  it("prefixes the source title with Copy of", () => {
+    expect(buildDuplicateListingTitle("Sunny 2BR near uptown")).toBe(
+      "Copy of Sunny 2BR near uptown",
+    );
+  });
+
+  it("keeps untitled drafts untitled", () => {
+    expect(buildDuplicateListingTitle("")).toBe("");
+    expect(buildDuplicateListingTitle("   ")).toBe("");
+  });
+});
 
 describe("buildListingFeatureCategories", () => {
   it("applies alphabetical category order and per-category sort order for custom fields", () => {

--- a/lib/listings/store.unit.test.ts
+++ b/lib/listings/store.unit.test.ts
@@ -6,6 +6,8 @@ import {
   buildListingCustomFields,
   buildListingFeatureCategories,
   getDisplayAccessibilityFeatures,
+  isBuildingScopeFeatureCategory,
+  selectDuplicateCustomFields,
   getListingApplicationUrl,
   mergeListingCustomFields,
 } from "./store";
@@ -20,6 +22,48 @@ describe("buildDuplicateListingTitle", () => {
   it("keeps untitled drafts untitled", () => {
     expect(buildDuplicateListingTitle("")).toBe("");
     expect(buildDuplicateListingTitle("   ")).toBe("");
+  });
+});
+
+describe("selectDuplicateCustomFields", () => {
+  const customFields: ListingCustomFields = {
+    elevator_in_building: true,
+    main_entrance_is_barrier_free: true,
+    roll_in_shower: true,
+    legacy_unmapped_feature: true,
+  };
+  const categoryByKey = new Map([
+    ["elevator_in_building", "BUILDING AMENITIES"],
+    ["main_entrance_is_barrier_free", "ENTRY & EXTERIOR"],
+    ["roll_in_shower", "KITCHEN & BATH"],
+  ]);
+
+  it("keeps every feature when all fields are copied", () => {
+    expect(selectDuplicateCustomFields({ customFields, categoryByKey, scope: "all" })).toEqual(
+      customFields,
+    );
+  });
+
+  it("keeps only building-level features for the building scope", () => {
+    expect(selectDuplicateCustomFields({ customFields, categoryByKey, scope: "building" })).toEqual(
+      {
+        elevator_in_building: true,
+        main_entrance_is_barrier_free: true,
+      },
+    );
+  });
+
+  it("keeps unit-level and unrecognized features for the unit scope", () => {
+    expect(selectDuplicateCustomFields({ customFields, categoryByKey, scope: "unit" })).toEqual({
+      roll_in_shower: true,
+      legacy_unmapped_feature: true,
+    });
+  });
+
+  it("matches building categories regardless of case and punctuation", () => {
+    expect(isBuildingScopeFeatureCategory("Entry and Exterior")).toBe(true);
+    expect(isBuildingScopeFeatureCategory("building amenities")).toBe(true);
+    expect(isBuildingScopeFeatureCategory("UNIT INTERIOR")).toBe(false);
   });
 });
 

--- a/lib/listings/store.unit.test.ts
+++ b/lib/listings/store.unit.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "@jest/globals";
 
-import type { ListingCustomFields } from "@/db/schema";
+import type { Listing, ListingCustomFields, Property } from "@/db/schema";
 import {
+  buildDuplicateListingPlan,
   buildDuplicateListingTitle,
   buildListingCustomFields,
   buildListingFeatureCategories,
+  DEFAULT_PROPERTY_COUNTRY,
   getDisplayAccessibilityFeatures,
   isBuildingScopeFeatureCategory,
   selectDuplicateCustomFields,
@@ -64,6 +66,171 @@ describe("selectDuplicateCustomFields", () => {
     expect(isBuildingScopeFeatureCategory("Entry and Exterior")).toBe(true);
     expect(isBuildingScopeFeatureCategory("building amenities")).toBe(true);
     expect(isBuildingScopeFeatureCategory("UNIT INTERIOR")).toBe(false);
+  });
+});
+
+describe("buildDuplicateListingPlan", () => {
+  const OWNER_USER_ID = "11111111-1111-4111-8111-111111111111";
+  const ACTOR_USER_ID = "22222222-2222-4222-8222-222222222222";
+
+  const sourceProperty: Property = {
+    id: "33333333-3333-4333-8333-333333333333",
+    ownerUserId: OWNER_USER_ID,
+    name: "Riverbend Apartments",
+    street1: "120 King St W",
+    street2: "Suite 4",
+    city: "Kitchener",
+    province: "ON",
+    postalCode: "N2G 1A7",
+    country: "Canada",
+    neighborhood: "Downtown",
+    latitude: 43.4516,
+    longitude: -80.4925,
+    contactName: "Dana Reyes",
+    contactEmail: "dana@example.com",
+    contactPhone: "519-555-0142",
+    createdByUserId: OWNER_USER_ID,
+    updatedByUserId: OWNER_USER_ID,
+    createdAt: new Date("2026-01-05T00:00:00Z"),
+    updatedAt: new Date("2026-02-05T00:00:00Z"),
+  };
+
+  const source: Listing = {
+    id: "44444444-4444-4444-8444-444444444444",
+    propertyId: sourceProperty.id,
+    createdByUserId: OWNER_USER_ID,
+    updatedByUserId: OWNER_USER_ID,
+    title: "Sunny 2BR near uptown",
+    description: "Bright corner unit.",
+    status: "published",
+    unitNumber: "301",
+    buildingType: "apartment",
+    bedrooms: 2,
+    bathrooms: 1.5,
+    squareFeet: 880,
+    monthlyRentCents: 185000,
+    availableOn: "2026-09-01",
+    leaseTermMonths: 12,
+    utilitiesIncluded: ["heat", "water"],
+    maxIncomeCents: 7200000,
+    applicationUrl: "https://example.com/apply",
+    applicationEmail: "apply@example.com",
+    applicationPhone: "519-555-0143",
+    applicationInstructions: "Bring proof of income.",
+    customFields: { elevator_in_building: true },
+    publishedAt: new Date("2026-03-01T00:00:00Z"),
+    archivedAt: null,
+    createdAt: new Date("2026-01-06T00:00:00Z"),
+    updatedAt: new Date("2026-02-06T00:00:00Z"),
+  };
+
+  const planFor = (scope: "all" | "building" | "unit") =>
+    buildDuplicateListingPlan({
+      source,
+      sourceProperty,
+      actorUserId: ACTOR_USER_ID,
+      title: "Copy of Sunny 2BR near uptown",
+      scope,
+      customFields: { elevator_in_building: true },
+    });
+
+  it("carries over building and unit fields when everything is copied", () => {
+    const plan = planFor("all");
+
+    expect(plan.property).toMatchObject({
+      name: "Riverbend Apartments",
+      street1: "120 King St W",
+      city: "Kitchener",
+      country: "Canada",
+      contactEmail: "dana@example.com",
+    });
+    expect(plan.listing).toMatchObject({
+      description: "Bright corner unit.",
+      bedrooms: 2,
+      bathrooms: 1.5,
+      monthlyRentCents: 185000,
+      buildingType: "apartment",
+      applicationUrl: "https://example.com/apply",
+    });
+  });
+
+  it("blanks the unit fields for the building scope", () => {
+    const plan = planFor("building");
+
+    expect(plan.property).toMatchObject({ street1: "120 King St W", city: "Kitchener" });
+    expect(plan.listing).toMatchObject({
+      description: null,
+      bedrooms: 0,
+      bathrooms: 0,
+      squareFeet: null,
+      monthlyRentCents: 0,
+      leaseTermMonths: null,
+      utilitiesIncluded: [],
+      maxIncomeCents: null,
+      // Landlord-level fields still belong to the building.
+      buildingType: "apartment",
+      applicationInstructions: "Bring proof of income.",
+    });
+  });
+
+  it("blanks the building and address fields for the unit scope", () => {
+    const plan = planFor("unit");
+
+    expect(plan.property).toMatchObject({
+      name: "",
+      street1: "",
+      street2: null,
+      city: "",
+      province: "",
+      postalCode: "",
+      neighborhood: null,
+      latitude: null,
+      longitude: null,
+      contactName: "",
+      contactEmail: "",
+      contactPhone: "",
+    });
+    expect(plan.listing).toMatchObject({
+      description: "Bright corner unit.",
+      bedrooms: 2,
+      monthlyRentCents: 185000,
+      buildingType: null,
+      applicationUrl: null,
+      applicationEmail: "",
+      applicationPhone: "",
+      applicationInstructions: null,
+    });
+  });
+
+  it("falls back to the default country when the building is not copied", () => {
+    expect(planFor("unit").property.country).toBe(DEFAULT_PROPERTY_COUNTRY);
+    expect(planFor("building").property.country).toBe("Canada");
+  });
+
+  it("always resets the copy to an unpublished draft regardless of scope", () => {
+    for (const scope of ["all", "building", "unit"] as const) {
+      expect(planFor(scope).listing).toMatchObject({
+        status: "draft",
+        unitNumber: null,
+        availableOn: null,
+        publishedAt: null,
+        archivedAt: null,
+      });
+    }
+  });
+
+  it("keeps the source owner while recording the actor as the editor", () => {
+    const plan = planFor("all");
+
+    expect(plan.property.ownerUserId).toBe(OWNER_USER_ID);
+    expect(plan.property).toMatchObject({
+      createdByUserId: ACTOR_USER_ID,
+      updatedByUserId: ACTOR_USER_ID,
+    });
+    expect(plan.listing).toMatchObject({
+      createdByUserId: ACTOR_USER_ID,
+      updatedByUserId: ACTOR_USER_ID,
+    });
   });
 });
 

--- a/lib/listings/store.unit.test.ts
+++ b/lib/listings/store.unit.test.ts
@@ -15,13 +15,10 @@ import {
 } from "./store";
 
 describe("buildDuplicateListingTitle", () => {
-  it("prefixes the source title with Copy of", () => {
+  it("prefixes titled listings and keeps untitled drafts untitled", () => {
     expect(buildDuplicateListingTitle("Sunny 2BR near uptown")).toBe(
       "Copy of Sunny 2BR near uptown",
     );
-  });
-
-  it("keeps untitled drafts untitled", () => {
     expect(buildDuplicateListingTitle("")).toBe("");
     expect(buildDuplicateListingTitle("   ")).toBe("");
   });

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -17,6 +17,10 @@ export const LISTING_BUILDING_TYPE_LABELS: Record<ListingBuildingType, string> =
   townhouse: "Townhouse",
   condo: "Condo",
 };
+export const LISTING_DUPLICATE_SCOPE_VALUES = ["all", "building", "unit"] as const;
+export type ListingDuplicateScope = (typeof LISTING_DUPLICATE_SCOPE_VALUES)[number];
+export const DEFAULT_LISTING_DUPLICATE_SCOPE: ListingDuplicateScope = "all";
+export const DEFAULT_LISTING_DUPLICATE_COPY_PHOTOS = false;
 export const UTILITY_INCLUDED_VALUES = ["heat", "water", "electricity", "gas", "internet"] as const;
 export type UtilityIncluded = (typeof UTILITY_INCLUDED_VALUES)[number];
 export const UTILITY_INCLUDED_LABELS = {
@@ -297,6 +301,13 @@ export const createDraftListingResponseSchema = z.object({
   data: listingIdDataSchema,
 });
 
+// Both fields are optional so the endpoint stays usable without a body; the
+// service applies DEFAULT_LISTING_DUPLICATE_* when they are omitted.
+export const duplicateListingSchema = z.object({
+  scope: z.enum(LISTING_DUPLICATE_SCOPE_VALUES).optional(),
+  copyPhotos: z.boolean().optional(),
+});
+
 export const duplicateListingResponseSchema = z.object({
   message: z.string(),
   data: listingIdDataSchema,
@@ -325,6 +336,7 @@ export type CreateListingInput = z.infer<typeof createListingSchema>;
 export type UpdateListingInput = z.infer<typeof updateListingSchema>;
 export type CreateListingResponse = z.infer<typeof createListingResponseSchema>;
 export type CreateDraftListingResponse = z.infer<typeof createDraftListingResponseSchema>;
+export type DuplicateListingInput = z.infer<typeof duplicateListingSchema>;
 export type DuplicateListingResponse = z.infer<typeof duplicateListingResponseSchema>;
 export type UpdateListingResponse = z.infer<typeof updateListingResponseSchema>;
 export type DeleteListingResponse = z.infer<typeof deleteListingResponseSchema>;

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -297,6 +297,11 @@ export const createDraftListingResponseSchema = z.object({
   data: listingIdDataSchema,
 });
 
+export const duplicateListingResponseSchema = z.object({
+  message: z.string(),
+  data: listingIdDataSchema,
+});
+
 export const updateListingResponseSchema = z.object({
   message: z.string(),
   data: listingIdDataSchema.and(updateListingPayloadSchema),
@@ -320,5 +325,6 @@ export type CreateListingInput = z.infer<typeof createListingSchema>;
 export type UpdateListingInput = z.infer<typeof updateListingSchema>;
 export type CreateListingResponse = z.infer<typeof createListingResponseSchema>;
 export type CreateDraftListingResponse = z.infer<typeof createDraftListingResponseSchema>;
+export type DuplicateListingResponse = z.infer<typeof duplicateListingResponseSchema>;
 export type UpdateListingResponse = z.infer<typeof updateListingResponseSchema>;
 export type DeleteListingResponse = z.infer<typeof deleteListingResponseSchema>;

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -301,8 +301,9 @@ export const createDraftListingResponseSchema = z.object({
   data: listingIdDataSchema,
 });
 
-// Both fields are optional so the endpoint stays usable without a body; the
-// service applies DEFAULT_LISTING_DUPLICATE_* when they are omitted.
+// A JSON body is required (the route declares the content type so malformed
+// requests fail with 415/400 rather than silently duplicating), but both
+// fields are optional: `{}` applies DEFAULT_LISTING_DUPLICATE_*.
 export const duplicateListingSchema = z.object({
   scope: z.enum(LISTING_DUPLICATE_SCOPE_VALUES).optional(),
   copyPhotos: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds a **Duplicate** button to each active card on `/my-listings`. Clicking it opens a dialog where the lister chooses **what** to copy — all fields, building information only, or unit information only — plus whether to bring the photos across. Confirming creates a new draft titled `Copy of <original title>`, which appears in the list once the request completes.

<img src="https://gist.githubusercontent.com/adinschmidt/e1165a3812e6c1811581c89610f5b988/raw/dup-02-dialog-default.png" width="460"> <img src="https://gist.githubusercontent.com/adinschmidt/e1165a3812e6c1811581c89610f5b988/raw/dup-04-dialog-unit-photos.png" width="460">

<img src="https://gist.githubusercontent.com/adinschmidt/e1165a3812e6c1811581c89610f5b988/raw/dup-03-dialog-building.png" width="460"> <img src="https://gist.githubusercontent.com/adinschmidt/e1165a3812e6c1811581c89610f5b988/raw/dup-07-dialog-no-photos.png" width="460">

## How it works

- New endpoint `POST /api/listings/[id]/duplicate` (next-rest-framework route + handler), authorized with the existing `canEditListing` policy (owner or admin). It takes a JSON body `{ scope: "all" | "building" | "unit", copyPhotos: boolean }`. Both fields are optional — `{}` applies the previous all-fields / no-photos behaviour — but the JSON body itself is required: the route declares its content type, so a request without one returns 415 and an empty body returns 400, both before the handler runs.
- `duplicateListingByIdService` loads the source listing and delegates to `duplicateListingGraph`, which copies the **property row, listing row, and (optionally) image rows in one transaction**:
  - The property is copied (not shared) because listing edits mutate the property in place — sharing would let edits to the copy corrupt the original.
  - Fields **outside** the chosen scope start blank, exactly as they do on a brand new draft (`bedrooms: 0`, empty address, and so on):
    - *Building scope* — property row (name, address, contact), building type, and the application contact details.
    - *Unit scope* — description, bedrooms, bathrooms, square feet, rent, lease term, utilities, and max income.
  - Image rows are copied via a single SQL `INSERT … SELECT` so bytea payloads never leave the database, and only when **Copy photos** is on. It defaults to off: photos of the source unit are usually wrong for the new one, and each copy duplicates the image storage.
  - The copy starts as `draft` with `publishedAt`/`archivedAt` cleared and audit fields pointing at the duplicating user.
  - **`unitNumber` and `availableOn` are cleared in every scope.** The expected use is listing another unit in the same building, so these two are near-certain to be wrong on the copy and are the most harmful if published stale (duplicate unit number / past availability date). The dialog says so before you confirm.
- **Accessibility features** are split by their field-definition category: `BUILDING AMENITIES` and `ENTRY & EXTERIOR` travel with the building, everything else with the unit. Categories are admin-editable free text, so an unrecognized category is treated as a unit feature — it stays with the unit, and the copy is a draft the lister reviews before publishing. (A `scope` column on `listing_field_definitions` would make this explicit rather than inferred; that's a migration + admin UI change, deliberately not in this PR.)
- Untitled drafts stay untitled when copied (the card already renders "Untitled draft").
- Deleted (archived) cards don't get the button — they already have Undelete, which restores to draft.

## Testing

- Unit tests for the dialog (scope selection, photo toggle, summary copy, confirm payload) and for the building/unit feature split; full jest suite (140 tests), typecheck, oxlint, and the production build all pass.
- Exercised against a running app and local database with Playwright:
  - *Unit information only + photos* → draft with rent/beds/description and 8 photos, blank address, blank building type, and only the in-unit features.
  - *Building information only* → draft with the address, contact, and building type, `bedrooms`/rent zeroed, no photos, and only the shared-amenity features.
  - A listing with no photos disables the toggle and says so in the summary.


Closes #306
