### PR TITLE
feat: add dark mode with a light/dark/system theme toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -176,6 +176,39 @@
   --sidebar-ring: oklch(0.56 0.021 213.5);
 }
 
+/* MapLibre's attribution control ships light-only styling; restyle it with theme
+   tokens when the site is in dark mode. The icons are inlined SVG data URIs, so
+   the dark variants repeat maplibre's icon with a white fill. */
+.dark .maplibregl-ctrl.maplibregl-ctrl-attrib {
+  background-color: color-mix(in oklab, var(--card) 50%, transparent);
+}
+
+.dark .maplibregl-ctrl-attrib.maplibregl-compact {
+  background-color: var(--card);
+  color: var(--card-foreground);
+}
+
+.dark .maplibregl-ctrl-attrib a {
+  color: color-mix(in oklab, var(--card-foreground) 75%, transparent);
+}
+
+.dark .maplibregl-ctrl-attrib a:hover {
+  color: var(--card-foreground);
+}
+
+.dark .maplibregl-ctrl-attrib-button,
+.dark .maplibregl-ctrl-attrib.maplibregl-compact:after {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%23fff' fill-rule='evenodd' viewBox='0 0 20 20'%3E%3Cpath d='M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0'/%3E%3C/svg%3E");
+}
+
+.dark .maplibregl-ctrl-attrib-button {
+  background-color: transparent;
+}
+
+.dark .maplibregl-ctrl-attrib.maplibregl-compact-show .maplibregl-ctrl-attrib-button {
+  background-color: rgb(255 255 255 / 10%);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/app/globals.css
+++ b/app/globals.css
@@ -209,6 +209,32 @@
   background-color: rgb(255 255 255 / 10%);
 }
 
+/* MapLibre popups are hardcoded white as well; match the card surface. */
+.dark .maplibregl-popup-content {
+  background: var(--card);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 40%);
+}
+
+.dark .maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.dark .maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+.dark .maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
+  border-bottom-color: var(--card);
+}
+
+.dark .maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.dark .maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+.dark .maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
+  border-top-color: var(--card);
+}
+
+.dark .maplibregl-popup-anchor-left .maplibregl-popup-tip {
+  border-right-color: var(--card);
+}
+
+.dark .maplibregl-popup-anchor-right .maplibregl-popup-tip {
+  border-left-color: var(--card);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ThemeProvider } from "next-themes";
 import { Geist, Geist_Mono } from "next/font/google";
 import { SiteHeader } from "@/components/site-header/SiteHeader";
 import { SiteFooter } from "@/components/site-footer/SiteFooter";
@@ -26,13 +27,24 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
+    >
       <body className="flex min-h-full flex-col">
-        <QueryProvider>
-          <SiteHeader />
-          <div className="flex-1">{children}</div>
-          <SiteFooter />
-        </QueryProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <QueryProvider>
+            <SiteHeader />
+            <div className="flex-1">{children}</div>
+            <SiteFooter />
+          </QueryProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/listings/error.tsx
+++ b/app/listings/error.tsx
@@ -14,10 +14,10 @@ export default function ListingsError({
   }, [error]);
 
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-4 bg-white p-8 text-center">
+    <div className="flex h-screen flex-col items-center justify-center gap-4 bg-background p-8 text-center">
       <div className="space-y-2">
-        <h1 className="text-2xl font-semibold text-slate-900">We couldn't load listings.</h1>
-        <p className="text-sm text-slate-600">
+        <h1 className="text-2xl font-semibold text-foreground">We couldn't load listings.</h1>
+        <p className="text-sm text-muted-foreground">
           Try again in a moment. If the issue keeps happening, there may be a data or network
           problem.
         </p>
@@ -25,7 +25,7 @@ export default function ListingsError({
       <button
         type="button"
         onClick={() => reset()}
-        className="rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-800"
+        className="rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
       >
         Try again
       </button>

--- a/app/listings/loading.tsx
+++ b/app/listings/loading.tsx
@@ -1,3 +1,3 @@
 export default function ListingsLoading() {
-  return <div className="h-screen bg-white" />;
+  return <div className="h-screen bg-background" />;
 }

--- a/components/map-view/MapView.tsx
+++ b/components/map-view/MapView.tsx
@@ -2,15 +2,18 @@
 
 import { useState, useCallback, useMemo } from "react";
 import { Map, Marker, Popup } from "@vis.gl/react-maplibre";
+import { useTheme } from "next-themes";
 import type { Listing } from "@/components/listing-card-list/ListingsCardList";
 import { ListingsCard } from "../listings-card/ListingsCard";
 
-const OPENFREEMAP_STYLE = "https://tiles.openfreemap.org/styles/liberty";
+const OPENFREEMAP_LIGHT_STYLE = "https://tiles.openfreemap.org/styles/liberty";
+const OPENFREEMAP_DARK_STYLE = "https://tiles.openfreemap.org/styles/fiord";
 
 /** Default view centred on Waterloo Region */
 const DEFAULT_VIEW = { longitude: -80.52, latitude: 43.46, zoom: 12 } as const;
 
 export function MapView({ listings }: { listings: Listing[] }) {
+  const { resolvedTheme } = useTheme();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const mappableListings = useMemo(
     () =>
@@ -34,7 +37,7 @@ export function MapView({ listings }: { listings: Listing[] }) {
     <div className="relative h-full min-h-0 w-full flex-1">
       <div className="absolute inset-0">
         <Map
-          mapStyle={OPENFREEMAP_STYLE}
+          mapStyle={resolvedTheme === "dark" ? OPENFREEMAP_DARK_STYLE : OPENFREEMAP_LIGHT_STYLE}
           initialViewState={DEFAULT_VIEW}
           style={{ width: "100%", height: "100%" }}
           scrollZoom={true}

--- a/components/site-header/HeaderMobileMenu.tsx
+++ b/components/site-header/HeaderMobileMenu.tsx
@@ -7,6 +7,7 @@ import { UserIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { signOutFromHeader } from "@/components/site-header/actions";
+import { ThemeToggle } from "@/components/theme-toggle/ThemeToggle";
 
 type HeaderMobileMenuProps = {
   isSignedIn: boolean;
@@ -118,6 +119,11 @@ export function HeaderMobileMenu({
                 <span>Sign in</span>
               </Link>
             )}
+
+            <div className="flex items-center justify-between rounded-2xl bg-primary-foreground/10 px-4 py-3 text-sm font-medium text-primary-foreground">
+              <span>Theme</span>
+              <ThemeToggle />
+            </div>
           </nav>
         </div>
       ) : null}

--- a/components/site-header/SiteHeader.tsx
+++ b/components/site-header/SiteHeader.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { HeaderAccountMenu } from "@/components/site-header/HeaderAccountMenu";
 import { HeaderBreadcrumbs } from "@/components/site-header/HeaderBreadcrumbs";
 import { HeaderMobileMenu } from "@/components/site-header/HeaderMobileMenu";
+import { ThemeToggle } from "@/components/theme-toggle/ThemeToggle";
 import { getOptionalSession } from "@/lib/auth/session";
 
 export async function SiteHeader() {
@@ -21,6 +22,10 @@ export async function SiteHeader() {
           <Link href="/" className="text-lg font-semibold tracking-tight text-primary-foreground">
             WR Housing Bridge
           </Link>
+
+          <div className="absolute left-0 hidden lg:block">
+            <ThemeToggle />
+          </div>
 
           <nav className="absolute right-0 hidden items-center gap-2 lg:flex">
             {isSignedIn ? (

--- a/components/theme-toggle/ThemeToggle.tsx
+++ b/components/theme-toggle/ThemeToggle.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ComputerIcon, Moon02Icon, SmartPhone01Icon, Sun03Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useTheme } from "next-themes";
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+const itemClass =
+  "h-7 min-w-8 rounded-full px-2 text-primary-foreground/70 hover:bg-primary-foreground/20 hover:text-primary-foreground data-[state=on]:bg-primary-foreground/25 data-[state=on]:text-primary-foreground focus-visible:border-transparent focus-visible:ring-primary-foreground/40";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [isMounted, setIsMounted] = useState(false);
+
+  // next-themes only knows the stored theme on the client, so render without a
+  // selection until mounted to keep server and client markup identical.
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return (
+    <ToggleGroup
+      type="single"
+      spacing={1}
+      value={isMounted ? (theme ?? "system") : ""}
+      onValueChange={(value) => {
+        if (value) {
+          setTheme(value);
+        }
+      }}
+      aria-label="Colour theme"
+      className="rounded-full bg-primary-foreground/15 p-0.5"
+    >
+      <ToggleGroupItem
+        value="light"
+        title="Light theme"
+        aria-label="Light theme"
+        className={itemClass}
+      >
+        <HugeiconsIcon icon={Sun03Icon} strokeWidth={2} size={16} />
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="dark"
+        title="Dark theme"
+        aria-label="Dark theme"
+        className={itemClass}
+      >
+        <HugeiconsIcon icon={Moon02Icon} strokeWidth={2} size={16} />
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="system"
+        title="System theme"
+        aria-label="System theme"
+        className={itemClass}
+      >
+        <HugeiconsIcon
+          icon={ComputerIcon}
+          strokeWidth={2}
+          size={16}
+          className="pointer-coarse:hidden"
+        />
+        <HugeiconsIcon
+          icon={SmartPhone01Icon}
+          strokeWidth={2}
+          size={16}
+          className="hidden pointer-coarse:block"
+        />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next": "16.2.11",
         "next-auth": "5.0.0-beta.32",
         "next-rest-framework": "6.1.1",
+        "next-themes": "0.4.6",
         "nuqs": "2.8.9",
         "pg-boss": "12.18.3",
         "postgres": "3.4.9",
@@ -14083,6 +14084,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "next": "16.2.11",
     "next-auth": "5.0.0-beta.32",
     "next-rest-framework": "6.1.1",
+    "next-themes": "0.4.6",
     "nuqs": "2.8.9",
     "pg-boss": "12.18.3",
     "postgres": "3.4.9",


### PR DESCRIPTION
## Summary

Adds site-wide dark mode using [next-themes](https://github.com/pacocoursey/next-themes) on top of the shadcn `.dark` token set that already existed in `globals.css`.

- **Theme toggle**: tri-state segmented control (light / dark / system) in the site header, built on the existing shadcn `ToggleGroup` primitive with hugeicons. The system segment shows a computer icon, or a phone icon on coarse-pointer (touch) devices via Tailwind's `pointer-coarse:` variant — no JS device sniffing.
- **Desktop**: toggle sits on the left of the header (the right side is occupied by nav pills and would overlap the centered title).
- **Mobile**: the hamburger menu gets a matching "Theme" row.
- **Provider**: root layout wraps children in `ThemeProvider` (`attribute="class"`, `defaultTheme="system"`, `enableSystem`, `disableTransitionOnChange`) with `suppressHydrationWarning` on `<html>`.
- **Token fixes**: the listings error/loading screens used hardcoded `bg-white`/`slate-*` colors; converted to theme tokens so they follow the theme.

- **Map**: the listings map swaps to OpenFreeMap's `fiord` dark basemap when the resolved theme is dark (`liberty` stays for light). `@vis.gl/react-maplibre` restyles in place, and the price markers are DOM elements so they survive the switch.

The selection persists in localStorage and "system" live-follows the OS preference.

## Screenshots

Hosted on the [`assets/dark-mode-pr-333`](https://github.com/CivicTechWR/accessible-housing-portal/tree/assets/dark-mode-pr-333) branch (safe to delete after this PR closes).

| Light | Dark |
| --- | --- |
| ![listings light](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/listings-light.png) | ![listings dark](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/listings-dark.png) |
| ![detail light](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/detail-light.png) | ![detail dark](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/detail-dark.png) |
| ![sign-in light](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/signin-light.png) | ![sign-in dark](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/signin-dark.png) |

<details>
<summary>More dark-mode pages: map popup, listing form, admin users, mobile menu</summary>

Map price-pill popup (maplibre's popup and attribution chrome are hardcoded white upstream, so dark mode gets scoped CSS overrides):

![map popup dark](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/map-popup-dark.png)

![listing form dark](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/listing-form-dark.png)

![admin users dark](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/admin-users-dark.png)

The mobile menu's Theme row on a touch device — note the phone icon for the system segment:

<img src="https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/dark-mode-pr-333/mobile-menu-dark.png" width="390" alt="mobile menu dark" />

</details>

## Notes

- Verified locally with Playwright across sign-in, listings (split map view), listing detail, listing form, admin users, and the mobile menu — light, dark, and system (with emulated OS scheme changes), including persistence across reload.

## Test plan

- [ ] Toggle light/dark/system in the desktop header; page restyles immediately and persists across reload
- [ ] Set system and flip the OS appearance; page follows
- [ ] Open the mobile menu on a phone; Theme row shows a phone icon for the system segment
- [ ] Sanity-check listings, detail, form, and admin pages in dark mode
