### PR TITLE
feat: add an included-utilities input to the listing form

### DIFF
--- a/app/listing-form/fieldDefinitions.ts
+++ b/app/listing-form/fieldDefinitions.ts
@@ -178,7 +178,7 @@ export const CORE_FIELD_DEFINITIONS: CoreFieldDefinition[] = [
     isRequired: false,
     sortOrder: 10,
     colSpan: 2,
-    helpText: "Select all utilities included in the rent.",
+    helpText: "Select all utilities included in the monthly rent.",
     options: UTILITY_INCLUDED_VALUES.map((value) => ({
       label: UTILITY_INCLUDED_LABELS[value],
       value,

--- a/app/listing-form/fieldDefinitions.ts
+++ b/app/listing-form/fieldDefinitions.ts
@@ -1,7 +1,15 @@
-import { LISTING_BUILDING_TYPE_VALUES } from "@/shared/schemas/listings";
+import { LISTING_BUILDING_TYPE_VALUES, UTILITY_INCLUDED_VALUES } from "@/shared/schemas/listings";
 import type { ListingFormInput } from "./types";
 
-export type CoreFieldType = "text" | "number" | "select" | "textarea" | "email" | "tel" | "url";
+export type CoreFieldType =
+  | "text"
+  | "number"
+  | "select"
+  | "textarea"
+  | "email"
+  | "tel"
+  | "url"
+  | "checkbox-group";
 
 export interface FieldOption {
   label: string;
@@ -14,6 +22,7 @@ type KeysMatching<T, V> = {
 
 type ListingStringKey = Extract<KeysMatching<ListingFormInput, string | undefined>, string>;
 type ListingNumberKey = Extract<KeysMatching<ListingFormInput, number | undefined>, string>;
+type ListingStringArrayKey = Extract<KeysMatching<ListingFormInput, string[] | undefined>, string>;
 
 interface BaseCoreFieldDefinition {
   displayName: string;
@@ -43,10 +52,17 @@ interface NumberFieldDefinition extends BaseCoreFieldDefinition {
   options?: never;
 }
 
+interface CheckboxGroupFieldDefinition extends BaseCoreFieldDefinition {
+  key: ListingStringArrayKey;
+  fieldType: "checkbox-group";
+  options: FieldOption[];
+}
+
 export type CoreFieldDefinition =
   | TextLikeFieldDefinition
   | SelectFieldDefinition
-  | NumberFieldDefinition;
+  | NumberFieldDefinition
+  | CheckboxGroupFieldDefinition;
 
 export const CORE_FIELD_CATEGORIES = [
   {
@@ -149,6 +165,23 @@ export const CORE_FIELD_DEFINITIONS: CoreFieldDefinition[] = [
     sortOrder: 9,
     placeholder: "E.g. 12",
     helpText: "Enter the lease term in months.",
+  },
+  {
+    key: "utilitiesIncluded",
+    displayName: "Utilities Included",
+    fieldType: "checkbox-group",
+    category: "listing_details",
+    isRequired: false,
+    sortOrder: 10,
+    colSpan: 2,
+    helpText: "Select all utilities included in the rent.",
+    options: [
+      { label: "Heat", value: UTILITY_INCLUDED_VALUES[0] },
+      { label: "Water", value: UTILITY_INCLUDED_VALUES[1] },
+      { label: "Electricity", value: UTILITY_INCLUDED_VALUES[2] },
+      { label: "Gas", value: UTILITY_INCLUDED_VALUES[3] },
+      { label: "Internet", value: UTILITY_INCLUDED_VALUES[4] },
+    ],
   },
 
   {

--- a/app/listing-form/fieldDefinitions.ts
+++ b/app/listing-form/fieldDefinitions.ts
@@ -1,4 +1,8 @@
-import { LISTING_BUILDING_TYPE_VALUES, UTILITY_INCLUDED_VALUES } from "@/shared/schemas/listings";
+import {
+  LISTING_BUILDING_TYPE_VALUES,
+  UTILITY_INCLUDED_LABELS,
+  UTILITY_INCLUDED_VALUES,
+} from "@/shared/schemas/listings";
 import type { ListingFormInput } from "./types";
 
 export type CoreFieldType =
@@ -175,13 +179,10 @@ export const CORE_FIELD_DEFINITIONS: CoreFieldDefinition[] = [
     sortOrder: 10,
     colSpan: 2,
     helpText: "Select all utilities included in the rent.",
-    options: [
-      { label: "Heat", value: UTILITY_INCLUDED_VALUES[0] },
-      { label: "Water", value: UTILITY_INCLUDED_VALUES[1] },
-      { label: "Electricity", value: UTILITY_INCLUDED_VALUES[2] },
-      { label: "Gas", value: UTILITY_INCLUDED_VALUES[3] },
-      { label: "Internet", value: UTILITY_INCLUDED_VALUES[4] },
-    ],
+    options: UTILITY_INCLUDED_VALUES.map((value) => ({
+      label: UTILITY_INCLUDED_LABELS[value],
+      value,
+    })),
   },
 
   {

--- a/components/listing-form-fields/ListingFormFields.tsx
+++ b/components/listing-form-fields/ListingFormFields.tsx
@@ -92,13 +92,14 @@ function FieldRenderer({
               <FormLabel>{label}</FormLabel>
               <div className="flex flex-wrap gap-x-6 gap-y-2">
                 {def.options.map((opt) => (
-                  <LabeledCheckbox
-                    key={opt.value}
-                    id={`${def.key}-${opt.value}`}
-                    label={opt.label}
-                    checked={selected.includes(opt.value)}
-                    onCheckedChange={(checked) => toggleOption(opt.value, checked === true)}
-                  />
+                  <FormControl key={opt.value}>
+                    <LabeledCheckbox
+                      id={`${def.key}-${opt.value}`}
+                      label={opt.label}
+                      checked={selected.includes(opt.value)}
+                      onCheckedChange={(checked) => toggleOption(opt.value, checked === true)}
+                    />
+                  </FormControl>
                 ))}
               </div>
               {def.helpText && <FormDescription>{def.helpText}</FormDescription>}

--- a/components/listing-form-fields/ListingFormFields.tsx
+++ b/components/listing-form-fields/ListingFormFields.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FormSection } from "@/components/listing-form-layout/ListingFormLayout";
+import { LabeledCheckbox } from "@/components/labeled-checkbox/LabeledCheckbox";
 
 export interface ListingFormFieldsProps {
   control: ListingFormControl;
@@ -66,6 +67,45 @@ function FieldRenderer({
             <FormMessage />
           </FormItem>
         )}
+      />
+    );
+  }
+
+  if (def.fieldType === "checkbox-group") {
+    return (
+      <FormField
+        control={control}
+        name={def.key}
+        render={({ field }) => {
+          const selected: string[] = Array.isArray(field.value) ? field.value : [];
+          const toggleOption = (value: string, checked: boolean) => {
+            const next = checked ? [...selected, value] : selected.filter((v) => v !== value);
+            // Keep the stored order stable regardless of the order boxes were checked
+            field.onChange(def.options.map((opt) => opt.value).filter((v) => next.includes(v)));
+          };
+
+          return (
+            <FormItem
+              className={def.colSpan === 2 ? "md:col-span-2" : undefined}
+              data-field-name={def.key}
+            >
+              <FormLabel>{label}</FormLabel>
+              <div className="flex flex-wrap gap-x-6 gap-y-2">
+                {def.options.map((opt) => (
+                  <LabeledCheckbox
+                    key={opt.value}
+                    id={`${def.key}-${opt.value}`}
+                    label={opt.label}
+                    checked={selected.includes(opt.value)}
+                    onCheckedChange={(checked) => toggleOption(opt.value, checked === true)}
+                  />
+                ))}
+              </div>
+              {def.helpText && <FormDescription>{def.helpText}</FormDescription>}
+              <FormMessage />
+            </FormItem>
+          );
+        }}
       />
     );
   }

--- a/components/listing-form-fields/ListingFormFields.unit.test.tsx
+++ b/components/listing-form-fields/ListingFormFields.unit.test.tsx
@@ -36,10 +36,12 @@ describe("ListingFormFields utilities included", () => {
     render(<TestListingForm />);
 
     expect(screen.queryByText("Utilities Included")).not.toBeNull();
+    const description = screen.getByText("Select all utilities included in the monthly rent.");
 
     for (const label of ["Heat", "Water", "Electricity", "Gas", "Internet"]) {
       const checkbox = screen.getByRole("checkbox", { name: label });
       expect(checkbox.getAttribute("aria-checked")).toBe("false");
+      expect(checkbox.getAttribute("aria-describedby")).toBe(description.id);
     }
   });
 

--- a/components/listing-form-fields/ListingFormFields.unit.test.tsx
+++ b/components/listing-form-fields/ListingFormFields.unit.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "@jest/globals";
+import { useForm } from "react-hook-form";
+
+import {
+  CREATE_FORM_DEFAULTS,
+  type ListingFormContext,
+  type ListingFormData,
+  type ListingFormInput,
+  type ListingFormMethods,
+} from "@/app/listing-form/types";
+import { Form } from "@/components/ui/form";
+import { ListingFormFields } from "./ListingFormFields";
+
+function TestListingForm({
+  defaultValues = CREATE_FORM_DEFAULTS,
+  onFormReady,
+}: {
+  defaultValues?: Partial<ListingFormInput>;
+  onFormReady?: (form: ListingFormMethods) => void;
+}) {
+  const form = useForm<ListingFormInput, ListingFormContext, ListingFormData>({
+    defaultValues,
+  });
+  onFormReady?.(form);
+
+  return (
+    <Form {...form}>
+      <ListingFormFields control={form.control} />
+    </Form>
+  );
+}
+
+describe("ListingFormFields utilities included", () => {
+  it("renders a checkbox for each utility", () => {
+    render(<TestListingForm />);
+
+    expect(screen.queryByText("Utilities Included")).not.toBeNull();
+
+    for (const label of ["Heat", "Water", "Electricity", "Gas", "Internet"]) {
+      const checkbox = screen.getByRole("checkbox", { name: label });
+      expect(checkbox.getAttribute("aria-checked")).toBe("false");
+    }
+  });
+
+  it("checks the boxes for utilities already selected", () => {
+    render(
+      <TestListingForm
+        defaultValues={{ ...CREATE_FORM_DEFAULTS, utilitiesIncluded: ["heat", "internet"] }}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: "Heat" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("checkbox", { name: "Internet" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("checkbox", { name: "Water" }).getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  it("adds and removes utilities in the form value when toggled", () => {
+    let form: ListingFormMethods | undefined;
+    render(<TestListingForm onFormReady={(f) => (form = f)} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Water" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Heat" }));
+    expect(form?.getValues("utilitiesIncluded")).toEqual(["heat", "water"]);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Water" }));
+    expect(form?.getValues("utilitiesIncluded")).toEqual(["heat"]);
+  });
+});


### PR DESCRIPTION
Closes #329

## What

Adds an included-utilities input to the listing form. `listings.utilitiesIncluded` and the form types already carried the field end-to-end (editor load → form → autosave/publish) — the only missing piece was a form control, so listers could never set it.

- Extends the core field-definition system with a `checkbox-group` field type (typed to string-array form keys).
- Adds a **Utilities Included** checkbox group to the Listing Details section, mirroring the `UTILITY_INCLUDED_VALUES` enum (Heat / Water / Electricity / Gas / Internet) with the same labels PR #316 uses on the display side.
- Renders it with the existing `LabeledCheckbox`; the stored array keeps the canonical enum order regardless of the order boxes are checked.
- Unit tests for rendering, pre-selected values, and toggling.

## Testing

`typecheck`, `oxlint`, and the full unit suite pass. Also tested end-to-end in the browser with Playwright: signed in, created a listing with Heat/Water/Internet checked, published it, and confirmed the row persisted (`utilities_included = {heat,water,internet}`) and the editor reloads with the same boxes checked.

### Screenshots from Playwright testing

New checkbox group in the Listing Details section:

![Utilities Included checkbox group, unchecked](https://gist.githubusercontent.com/adinschmidt/40b896cec374cb8b4fd30a325ec8cce7/raw/b68f9b861115218ae3fd1ad34a82d7206d930825/01-utilities-unchecked.png)

Heat, Water, and Internet checked before publishing:

![Heat, Water, Internet checked](https://gist.githubusercontent.com/adinschmidt/40b896cec374cb8b4fd30a325ec8cce7/raw/b68f9b861115218ae3fd1ad34a82d7206d930825/02-utilities-checked.png)

Editor reopened after publish — selections load back from the saved listing:

![Editor reload with utilities still checked](https://gist.githubusercontent.com/adinschmidt/40b896cec374cb8b4fd30a325ec8cce7/raw/b68f9b861115218ae3fd1ad34a82d7206d930825/03-editor-reload.png)

## Notes

- The display side ("Utilities Included" row with a "None listed" empty state on listing details) is PR #316; this PR is only the data-entry side and doesn't conflict with it.
- Unrelated pre-existing quirk noticed while testing: in edit mode the Building Type select shows its placeholder instead of the saved value (the value is saved correctly in the DB and preserved on save). Happy to file a follow-up issue.
