### PR TITLE
feat: display description, building type, lease term, and available date on listing details

### DIFF
--- a/app/listings/[id]/page.tsx
+++ b/app/listings/[id]/page.tsx
@@ -22,6 +22,10 @@ export default async function ListingDetailsPage({ params }: Readonly<PageProps>
       title={details.title}
       editUrl={details.editUrl}
       price={details.price}
+      description={details.description}
+      buildingType={details.buildingType}
+      leaseTermMonths={details.leaseTermMonths}
+      availableOn={details.availableOn}
       unitNumber={details.unitNumber}
       street1={details.address.street1}
       street2={details.address.street2}

--- a/components/listing-details/ListingDetails.rental-details.unit.test.tsx
+++ b/components/listing-details/ListingDetails.rental-details.unit.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "@jest/globals";
+
+import { ListingDetails } from "./ListingDetails";
+
+const baseProps = {
+  price: 1500,
+  street1: "123 Main St",
+  city: "Waterloo",
+  beds: 2,
+  baths: 1,
+  sqft: 900,
+  images: [],
+  timeAgo: "2 days ago",
+  features: [],
+};
+
+describe("ListingDetails rental details", () => {
+  it("shows the description, building type, lease term, and available date when provided", () => {
+    render(
+      <ListingDetails
+        {...baseProps}
+        description="Bright corner unit near the LRT."
+        buildingType="apartment"
+        leaseTermMonths={12}
+        availableOn="2026-09-01"
+      />,
+    );
+
+    expect(screen.queryByText("Description")).not.toBeNull();
+    expect(screen.queryByText("Bright corner unit near the LRT.")).not.toBeNull();
+    expect(screen.queryByText("Building Type")).not.toBeNull();
+    expect(screen.queryByText("Apartment")).not.toBeNull();
+    expect(screen.queryByText("Lease Term")).not.toBeNull();
+    expect(screen.queryByText("12-month lease")).not.toBeNull();
+    expect(screen.queryByText("Available")).not.toBeNull();
+    expect(screen.queryByText("September 1, 2026")).not.toBeNull();
+  });
+
+  it("omits the rows and description section when the fields are missing", () => {
+    render(<ListingDetails {...baseProps} />);
+
+    expect(screen.queryByText("Description")).toBeNull();
+    expect(screen.queryByText("Building Type")).toBeNull();
+    expect(screen.queryByText("Lease Term")).toBeNull();
+    expect(screen.queryByText("Available")).toBeNull();
+  });
+
+  it("does not render a description section for whitespace-only descriptions", () => {
+    render(<ListingDetails {...baseProps} description="   " />);
+
+    expect(screen.queryByText("Description")).toBeNull();
+  });
+
+  it("falls back to the raw available date when it cannot be parsed", () => {
+    render(<ListingDetails {...baseProps} availableOn="Now" />);
+
+    expect(screen.queryByText("Available")).not.toBeNull();
+    expect(screen.queryByText("Now")).not.toBeNull();
+  });
+});

--- a/components/listing-details/ListingDetails.tsx
+++ b/components/listing-details/ListingDetails.tsx
@@ -4,10 +4,13 @@ import { Button } from "../ui/button";
 import { CardHeader, CardTitle, CardContent, Card } from "../ui/card";
 import { buildAddress } from "@/lib/address";
 import {
+  LISTING_BUILDING_TYPE_LABELS,
   UTILITY_INCLUDED_LABELS,
   UTILITY_INCLUDED_VALUES,
+  type ListingBuildingType,
   type UtilityIncluded,
 } from "@/shared/schemas/listings";
+import { format, parseISO } from "date-fns";
 import Link from "next/link";
 import { ListingApplyButton } from "./ListingApplyButton";
 
@@ -30,6 +33,11 @@ export interface ListingDetailProps {
   title?: string;
   editUrl?: string;
   price: number;
+  description?: string;
+  buildingType?: ListingBuildingType;
+  leaseTermMonths?: number;
+  /** ISO date string (YYYY-MM-DD). */
+  availableOn?: string;
   unitNumber?: string;
   street1: string;
   street2?: string;
@@ -49,10 +57,19 @@ export interface ListingDetailProps {
   embedded?: boolean;
 }
 
+function formatAvailableDate(isoDate: string) {
+  const parsed = parseISO(isoDate);
+  return Number.isNaN(parsed.getTime()) ? isoDate : format(parsed, "MMMM d, yyyy");
+}
+
 export function ListingDetails({
   title,
   editUrl,
   price,
+  description,
+  buildingType,
+  leaseTermMonths,
+  availableOn,
   city,
   beds,
   baths,
@@ -75,9 +92,14 @@ export function ListingDetails({
   const rentalCost = `$${price.toLocaleString()}`;
   const WrapperElement = embedded ? "section" : "main";
 
+  const trimmedDescription = description?.trim();
+
   const rentalDetailRows: Array<{ label: string; value: string; fullWidth?: boolean }> = [
     { label: "Address", value: address || "Address Here", fullWidth: true },
     { label: "Rental Cost", value: rentalCost },
+    ...(buildingType
+      ? [{ label: "Building Type", value: LISTING_BUILDING_TYPE_LABELS[buildingType] }]
+      : []),
     { label: "Bedrooms", value: String(beds) },
     { label: "Bathrooms", value: String(baths) },
     { label: "Square Feet", value: `${sqft.toLocaleString()} sqft` },
@@ -90,6 +112,8 @@ export function ListingDetails({
               .join(", ")
           : "None listed",
     },
+    ...(leaseTermMonths ? [{ label: "Lease Term", value: `${leaseTermMonths}-month lease` }] : []),
+    ...(availableOn ? [{ label: "Available", value: formatAvailableDate(availableOn) }] : []),
     { label: "Posted", value: timeAgo },
   ];
   const contactRows = [
@@ -131,6 +155,17 @@ export function ListingDetails({
         </div>
 
         {images.length > 0 && <ListingImageCarousel images={images} altPrefix={address} />}
+
+        {trimmedDescription && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Description</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="whitespace-pre-line text-sm text-foreground">{trimmedDescription}</p>
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardHeader>

--- a/components/listing-form-preview/ListingFormPreview.tsx
+++ b/components/listing-form-preview/ListingFormPreview.tsx
@@ -2,6 +2,7 @@ import type { ListingFormInput } from "@/app/listing-form/types";
 import { ListingDetails } from "@/components/listing-details/ListingDetails";
 import { ListingsCard } from "@/components/listings-card/ListingsCard";
 import { buildAddress } from "@/lib/address";
+import { LISTING_BUILDING_TYPE_VALUES } from "@/shared/schemas/listings";
 
 export type ListingFormPreviewMode = "card" | "details";
 
@@ -37,6 +38,9 @@ export function ListingFormPreview({
   );
   const previewAvailability = formData.availableOn || "Now";
   const previewPrice = Math.round((formData.monthlyRentCents ?? 0) / 100);
+  const previewBuildingType = LISTING_BUILDING_TYPE_VALUES.find(
+    (value) => value === formData.buildingType,
+  );
 
   const previewFeaturesByCategory = Object.values(
     (formData.customFeatures ?? []).reduce<
@@ -66,6 +70,10 @@ export function ListingFormPreview({
           embedded
           title={previewTitle}
           price={previewPrice}
+          description={formData.description}
+          buildingType={previewBuildingType}
+          leaseTermMonths={formData.leaseTerm}
+          availableOn={formData.availableOn || undefined}
           unitNumber={previewUnitNumberValue}
           street1={previewStreet1}
           street2={previewStreet2Value}

--- a/lib/listings/listing.service.ts
+++ b/lib/listings/listing.service.ts
@@ -608,6 +608,10 @@ async function buildListingDetailsResponse(listing: ListingRecord): Promise<List
     title: listing.title,
     unitNumber: listing.unitNumber ?? undefined,
     price: centsToDollars(listing.monthlyRentCents),
+    description: listing.description?.trim() ? listing.description.trim() : undefined,
+    buildingType: listing.buildingType ?? undefined,
+    leaseTermMonths: listing.leaseTermMonths ?? undefined,
+    availableOn: listing.availableOn ?? undefined,
     address: {
       street1: listing.property.street1,
       street2: listing.property.street2 ?? undefined,

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -10,6 +10,13 @@ import { positiveIntegerQueryParamSchema, positiveIntegerQueryParamWithMaxSchema
 const nonEmptyString = requiredTrimmedString();
 const listingStatusSchema = z.enum(["draft", "published", "archived"]);
 export const LISTING_BUILDING_TYPE_VALUES = ["apartment", "house", "townhouse", "condo"] as const;
+export type ListingBuildingType = (typeof LISTING_BUILDING_TYPE_VALUES)[number];
+export const LISTING_BUILDING_TYPE_LABELS: Record<ListingBuildingType, string> = {
+  apartment: "Apartment",
+  house: "House",
+  townhouse: "Townhouse",
+  condo: "Condo",
+};
 export const UTILITY_INCLUDED_VALUES = ["heat", "water", "electricity", "gas", "internet"] as const;
 export type UtilityIncluded = (typeof UTILITY_INCLUDED_VALUES)[number];
 export const UTILITY_INCLUDED_LABELS = {
@@ -120,6 +127,10 @@ export const listingDetailsSchema = z.object({
   editUrl: z.string().optional(),
   unitNumber: nonEmptyString.optional(),
   price: z.number().min(0),
+  description: nonEmptyString.optional(),
+  buildingType: listingBuildingTypeSchema.optional(),
+  leaseTermMonths: listingLeaseTermMonthsSchema.optional(),
+  availableOn: z.iso.date().optional(),
   address: listingDetailsAddressSchema,
   beds: z.number().int().min(0),
   baths: z.number().min(0),


### PR DESCRIPTION
Closes #330

## What

Renders the collected-but-hidden listing fields on the details page:

- **Description** — new card between the image carousel and Rental Details (`whitespace-pre-line`, so lister paragraph breaks survive). Omitted when empty/whitespace-only.
- **Building Type** — new Rental Details row, shown with its human label (`apartment` → "Apartment") via a new `LISTING_BUILDING_TYPE_LABELS` map in `shared/schemas/listings.ts`.
- **Lease Term** — new Rental Details row, spelled out as e.g. **"12-month lease"** per the survey feedback that the bare number was ambiguous.
- **Available** — new Rental Details row with the formatted date (e.g. "May 28, 2026"); falls back to the raw string if unparseable.

Rows are conditionally included, so listings without these values render exactly as before. The listing-form details preview passes the same fields through, so listers see them while composing.

`utilitiesIncluded` is intentionally untouched (handled in #316).

## How

- `listingDetailsSchema` gains optional `description`, `buildingType`, `leaseTermMonths`, `availableOn`; `buildListingDetailsResponse` populates them from the already-fetched `ListingRecord` (no query changes).
- `ListingDetails` accepts them as optional props — nothing else changes for existing callers.
- New unit tests in `ListingDetails.rental-details.unit.test.tsx` cover: all fields shown, all fields omitted, whitespace-only description, unparseable date fallback.

## Testing

- `npm run test:unit` — 84/84 pass (4 new)
- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- Drove the running app with Playwright against local dev DB (signed in, visited listing details at desktop + mobile widths, asserted the new content and its absence on a listing without building type/lease term)

### Screenshots from Playwright testing

Listing with all fields populated:

![Details page with description card and building type, lease term, available rows](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/issue-330-screenshots/01-details-all-fields.png)

Listing with no building type / lease term — rows omitted, layout unchanged:

![Details page without building type and lease term rows](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/issue-330-screenshots/03-details-partial-fields.png)

Mobile (390px):

![Mobile details page](https://raw.githubusercontent.com/CivicTechWR/accessible-housing-portal/assets/issue-330-screenshots/02-details-mobile.png)

_Screenshots live on the orphan branch `assets/issue-330-screenshots` (not part of this PR's diff); delete it after review if unwanted._
