### PR TITLE
feat: add an included-utilities input to the listing form

### DIFF
--- a/app/listing-form/fieldDefinitions.ts
+++ b/app/listing-form/fieldDefinitions.ts
@@ -1,7 +1,19 @@
-import { LISTING_BUILDING_TYPE_VALUES } from "@/shared/schemas/listings";
+import {
+  LISTING_BUILDING_TYPE_VALUES,
+  UTILITY_INCLUDED_LABELS,
+  UTILITY_INCLUDED_VALUES,
+} from "@/shared/schemas/listings";
 import type { ListingFormInput } from "./types";
 
-export type CoreFieldType = "text" | "number" | "select" | "textarea" | "email" | "tel" | "url";
+export type CoreFieldType =
+  | "text"
+  | "number"
+  | "select"
+  | "textarea"
+  | "email"
+  | "tel"
+  | "url"
+  | "checkbox-group";
 
 export interface FieldOption {
   label: string;
@@ -14,6 +26,7 @@ type KeysMatching<T, V> = {
 
 type ListingStringKey = Extract<KeysMatching<ListingFormInput, string | undefined>, string>;
 type ListingNumberKey = Extract<KeysMatching<ListingFormInput, number | undefined>, string>;
+type ListingStringArrayKey = Extract<KeysMatching<ListingFormInput, string[] | undefined>, string>;
 
 interface BaseCoreFieldDefinition {
   displayName: string;
@@ -43,10 +56,17 @@ interface NumberFieldDefinition extends BaseCoreFieldDefinition {
   options?: never;
 }
 
+interface CheckboxGroupFieldDefinition extends BaseCoreFieldDefinition {
+  key: ListingStringArrayKey;
+  fieldType: "checkbox-group";
+  options: FieldOption[];
+}
+
 export type CoreFieldDefinition =
   | TextLikeFieldDefinition
   | SelectFieldDefinition
-  | NumberFieldDefinition;
+  | NumberFieldDefinition
+  | CheckboxGroupFieldDefinition;
 
 export const CORE_FIELD_CATEGORIES = [
   {
@@ -149,6 +169,20 @@ export const CORE_FIELD_DEFINITIONS: CoreFieldDefinition[] = [
     sortOrder: 9,
     placeholder: "E.g. 12",
     helpText: "Enter the lease term in months.",
+  },
+  {
+    key: "utilitiesIncluded",
+    displayName: "Utilities Included",
+    fieldType: "checkbox-group",
+    category: "listing_details",
+    isRequired: false,
+    sortOrder: 10,
+    colSpan: 2,
+    helpText: "Select all utilities included in the monthly rent.",
+    options: UTILITY_INCLUDED_VALUES.map((value) => ({
+      label: UTILITY_INCLUDED_LABELS[value],
+      value,
+    })),
   },
 
   {

--- a/components/listing-form-fields/ListingFormFields.tsx
+++ b/components/listing-form-fields/ListingFormFields.tsx
@@ -12,6 +12,7 @@ import {
   FormMessage,
   FormDescription,
 } from "@/components/ui/form";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -66,6 +67,53 @@ function FieldRenderer({
             <FormMessage />
           </FormItem>
         )}
+      />
+    );
+  }
+
+  if (def.fieldType === "checkbox-group") {
+    return (
+      <FormField
+        control={control}
+        name={def.key}
+        render={({ field }) => {
+          const selected: string[] = Array.isArray(field.value) ? field.value : [];
+          return (
+            <FormItem
+              className={def.colSpan === 2 ? "md:col-span-2" : undefined}
+              data-field-name={def.key}
+            >
+              <FormLabel>{label}</FormLabel>
+              <div className="flex flex-wrap gap-x-6 gap-y-2 pt-1">
+                {def.options.map((opt) => {
+                  const checkboxId = `${def.key}-${opt.value}`;
+                  return (
+                    <div key={opt.value} className="flex items-center gap-2">
+                      <FormControl>
+                        <Checkbox
+                          id={checkboxId}
+                          checked={selected.includes(opt.value)}
+                          onCheckedChange={(checked) => {
+                            field.onChange(
+                              checked === true
+                                ? [...selected, opt.value]
+                                : selected.filter((value) => value !== opt.value),
+                            );
+                          }}
+                        />
+                      </FormControl>
+                      <label htmlFor={checkboxId} className="text-sm font-normal">
+                        {opt.label}
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+              {def.helpText && <FormDescription>{def.helpText}</FormDescription>}
+              <FormMessage />
+            </FormItem>
+          );
+        }}
       />
     );
   }

--- a/components/listing-form-fields/ListingFormFields.unit.test.tsx
+++ b/components/listing-form-fields/ListingFormFields.unit.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "@jest/globals";
+import { useForm } from "react-hook-form";
+
+import {
+  CREATE_FORM_DEFAULTS,
+  type ListingFormContext,
+  type ListingFormData,
+  type ListingFormInput,
+  type ListingFormMethods,
+} from "@/app/listing-form/types";
+import { Form } from "@/components/ui/form";
+import { ListingFormFields } from "./ListingFormFields";
+
+function Harness({
+  defaultValues,
+  onReady,
+}: {
+  defaultValues?: Partial<ListingFormInput>;
+  onReady: (methods: ListingFormMethods) => void;
+}) {
+  const form = useForm<ListingFormInput, ListingFormContext, ListingFormData>({
+    defaultValues: {
+      ...CREATE_FORM_DEFAULTS,
+      monthlyRentCents: 150000,
+      leaseTerm: 12,
+      ...defaultValues,
+    },
+  });
+  onReady(form);
+
+  return (
+    <Form {...form}>
+      <ListingFormFields control={form.control} />
+    </Form>
+  );
+}
+
+function renderFields(defaultValues?: Partial<ListingFormInput>) {
+  let methods: ListingFormMethods | undefined;
+  render(
+    <Harness
+      defaultValues={defaultValues}
+      onReady={(form) => {
+        methods = form;
+      }}
+    />,
+  );
+
+  if (!methods) {
+    throw new Error("Form methods were not captured");
+  }
+
+  return methods;
+}
+
+describe("ListingFormFields utilities included", () => {
+  it("renders an unchecked checkbox for each utility", () => {
+    renderFields();
+
+    for (const name of ["Heat", "Water", "Electricity", "Gas", "Internet"]) {
+      const checkbox = screen.getByRole("checkbox", { name });
+      expect(checkbox.getAttribute("aria-checked")).toBe("false");
+    }
+  });
+
+  it("adds and removes utilities from the form value when toggled", () => {
+    const methods = renderFields();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Heat" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Internet" }));
+    expect(methods.getValues("utilitiesIncluded")).toEqual(["heat", "internet"]);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Heat" }));
+    expect(methods.getValues("utilitiesIncluded")).toEqual(["internet"]);
+  });
+
+  it("renders saved utilities as checked", () => {
+    renderFields({ utilitiesIncluded: ["water", "gas"] });
+
+    expect(screen.getByRole("checkbox", { name: "Water" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("checkbox", { name: "Gas" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("checkbox", { name: "Heat" }).getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+});


### PR DESCRIPTION
Closes #329

## What

Adds the missing form control for `listings.utilitiesIncluded`. The schema column, the form's zod types (default `[]`), and the create/patch API payloads all already carried the field — but there was no input, so listers couldn't set it and only seeded data would ever show utilities on the display side added in #316.

- New `checkbox-group` core field type in `app/listing-form/fieldDefinitions.ts`, with keys constrained to string-array form fields
- A `utilitiesIncluded` definition in the Listing Details section whose options mirror `UTILITY_INCLUDED_VALUES` / `UTILITY_INCLUDED_LABELS`
- A renderer branch in `ListingFormFields` using the existing `Checkbox` primitive, with per-option `id`/`htmlFor` label association

## Screenshots

The new checkbox group in the Listing Details section:

![Utilities Included checkbox group with Heat, Water, and Internet checked](https://gist.github.com/adinschmidt/9f8604fe72962cc7832eab50e6ad707e/raw/form-utilities-checked.png)

Selections flowing through to the live preview (details view):

![Listing form with the live preview showing Utilities Included: Heat, Water, Internet](https://gist.github.com/adinschmidt/9f8604fe72962cc7832eab50e6ad707e/raw/form-with-live-preview.png)

## Testing

- 3 new unit tests (`ListingFormFields.unit.test.tsx`): all five checkboxes render unchecked, toggling adds/removes values from the form state, and saved values hydrate as checked.
- Driven end-to-end with Playwright against the dev server as a partner user:
  - All five utility checkboxes render in the Listing Details section
  - Toggling works via the box, the text label (`htmlFor` association), and keyboard (Space)
  - Selections show up in the live preview details view ("Utilities included: Heat, Water, Internet")
  - Draft autosave persists the selection (`utilities_included = {heat,internet,water}` in Postgres) and reloading `/listing-form/<id>` hydrates the checkboxes back as checked
