### PR TITLE
perf: lazy-load the listings filter drawer to reduce initial JS

### DIFF
--- a/app/listings/listings.tsx
+++ b/app/listings/listings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DynamicFilterGroup } from "@/components/feature-accordian/FeatureAccordian";
-import { ListingFilters } from "@/components/listing-filter/ListingFilter";
+import type { ListingFiltersProps } from "@/components/listing-filter/ListingFilter";
 import { useListingFilters } from "@/components/listing-filter/useListingFilter";
 import {
   DisplayMode,
@@ -15,6 +15,18 @@ import type { ListingListResponse, ListingQuery, ListingSummary } from "@/shared
 import dynamic from "next/dynamic";
 import { useListingsQuery } from "./useListingsQuery";
 import { AlertBanner } from "@/components/ui/alert-banner";
+
+const LazyListingFilters = dynamic<ListingFiltersProps>(
+  () =>
+    import("../../components/listing-filter/ListingFilter.tsx").then((mod) => mod.ListingFilters),
+  {
+    loading: () => (
+      <div className="flex items-center justify-center p-6 text-sm text-muted-foreground">
+        Loading filters...
+      </div>
+    ),
+  },
+);
 
 const LazyMapView = dynamic<{ listings: ListingSummary[] }>(
   () => import("../../components/map-view/MapView.tsx").then((mod) => mod.MapView),
@@ -172,7 +184,7 @@ export default function ListingsDashboard({
             filterButtonProps={filterButtonProps}
             mobileFilters={
               isFilterOpen && isMobileViewport ? (
-                <ListingFilters
+                <LazyListingFilters
                   bathroomToggleProps={bathroomToggleProps}
                   bedroomToggleProps={bedroomToggleProps}
                   priceRangeProps={priceRangeProps}
@@ -201,7 +213,7 @@ export default function ListingsDashboard({
             aria-label="Filters"
             className="absolute inset-y-0 right-0 z-30 w-full max-w-sm border-l bg-background shadow-xl"
           >
-            <ListingFilters
+            <LazyListingFilters
               bathroomToggleProps={bathroomToggleProps}
               bedroomToggleProps={bedroomToggleProps}
               priceRangeProps={priceRangeProps}


### PR DESCRIPTION
Closes #226

## What

`ListingFilters` was statically imported into the listings dashboard, so the filter drawer shipped in the initial client bundle even though it only renders after the user opens filters. This replaces the static import in `app/listings/listings.tsx` with a `next/dynamic` import (mirroring the existing `LazyMapView` precedent in the same file) plus a lightweight "Loading filters..." placeholder. Both render sites — the desktop aside and the mobile `mobileFilters` slot — use the lazy component; props and `nuqs` query-state wiring are untouched.

## Acceptance criteria

- [x] Opening `/listings` in default mode does not eagerly load the filter panel module — verified via Playwright network capture: zero `listing-filter` chunk requests on initial load; the chunk (`components_listing-filter_ListingFilter_tsx_*.js`) is fetched only after clicking **All Filters**.
- [x] Clicking the filter button opens the same filter UI on desktop and mobile (screenshots below).
- [x] Filters still work — the panel renders all controls (price, bedrooms, bathrooms, move-in date, dynamic custom-field groups); exercised bedrooms end-to-end: selecting "2" wrote `?bedrooms=2` to the URL and **Clear** removed it. State wiring is unchanged (same props from `useListingFilters`).
- [x] URL query-state behavior through `nuqs` unchanged (verified via the bedrooms round-trip above).
- [x] `npm run typecheck` passes (also `npm run lint` and `oxfmt --check`).

## Screenshots

Desktop, initial load (no filter chunk loaded):

<img src="https://gist.githubusercontent.com/adinschmidt/c1bed929dbec031bc3cf2b79b6339778/raw/desktop-initial.png" width="720" alt="Listings page initial load, drawer closed">

Desktop, drawer open with bedrooms=2 active:

<img src="https://gist.githubusercontent.com/adinschmidt/c1bed929dbec031bc3cf2b79b6339778/raw/desktop-drawer-open.png" width="720" alt="Filter drawer open on desktop with bedrooms filter applied">

Mobile, filter panel open:

<img src="https://gist.githubusercontent.com/adinschmidt/c1bed929dbec031bc3cf2b79b6339778/raw/mobile-filters-open.png" width="320" alt="Mobile filter panel open">
