### PR TITLE
Password Change and Reset Flow

### DIFF
--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import { getUserForAuth, isUserAllowedToSignIn } from "@/lib/auth/user-store";
+import { sendPasswordResetEmail } from "@/lib/auth/password-reset-email";
+import { createPasswordResetToken } from "@/lib/auth/password-reset-token";
+import { forgotPasswordRequestSchema } from "@/lib/auth/validation";
+
+export type ForgotPasswordState = {
+  error: string;
+  success: string;
+};
+
+const SUCCESS_MESSAGE =
+  "If an account exists for that email, a password reset link has been sent.";
+
+export async function requestPasswordResetAction(
+  _state: ForgotPasswordState,
+  formData: FormData,
+): Promise<ForgotPasswordState> {
+  const parsed = forgotPasswordRequestSchema.safeParse({
+    email: formData.get("email"),
+  });
+
+  if (!parsed.success) {
+    return {
+      error: parsed.error.issues[0]?.message ?? "Invalid email address.",
+      success: "",
+    };
+  }
+
+  const user = await getUserForAuth(parsed.data.email);
+
+  if (!user?.passwordHash || !isUserAllowedToSignIn(user.status)) {
+    return {
+      error: "",
+      success: SUCCESS_MESSAGE,
+    };
+  }
+
+  const token = createPasswordResetToken({
+    userId: user.id,
+    passwordHash: user.passwordHash,
+  });
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ?? process.env.AUTH_URL ?? "http://localhost:3000";
+  const resetUrl = new URL(`/reset-password?token=${token}`, baseUrl).toString();
+
+  try {
+    await sendPasswordResetEmail({
+      email: user.email,
+      fullName: user.fullName,
+      resetUrl,
+    });
+  } catch {
+    return {
+      error: "Unable to send reset email right now.",
+      success: "",
+    };
+  }
+
+  return {
+    error: "",
+    success: SUCCESS_MESSAGE,
+  };
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+import { ForgotPasswordRequestForm } from "@/components/auth/ForgotPasswordRequestForm";
+import { AuthPageShell } from "@/components/auth/AuthPageShell";
+
+export const metadata: Metadata = {
+  title: "Forgot Password | WR Housing Bridge",
+};
+
+export default function ForgotPasswordPage() {
+  return (
+    <AuthPageShell>
+      <ForgotPasswordRequestForm />
+    </AuthPageShell>
+  );
+}

--- a/app/manage-account/actions.ts
+++ b/app/manage-account/actions.ts
@@ -1,0 +1,74 @@
+"use server";
+
+import { auth } from "@/auth";
+import { hashPassword, verifyPassword } from "@/lib/auth/password";
+import { getOptionalSession } from "@/lib/auth/session";
+import { getUserPasswordRecord, updateUserPasswordHash } from "@/lib/auth/user-store";
+import { resetPasswordSchema } from "@/lib/auth/validation";
+
+export type ManageAccountState = {
+  error: string;
+  success: string;
+};
+
+export async function resetPasswordAction(
+  _state: ManageAccountState,
+  formData: FormData,
+): Promise<ManageAccountState> {
+  const { session } = await getOptionalSession(await auth());
+
+  if (!session?.user?.id) {
+    return {
+      error: "You must be signed in to reset your password.",
+      success: "",
+    };
+  }
+
+  const parsed = resetPasswordSchema.safeParse({
+    currentPassword: formData.get("currentPassword"),
+    newPassword: formData.get("newPassword"),
+    confirmNewPassword: formData.get("confirmNewPassword"),
+  });
+
+  if (!parsed.success) {
+    return {
+      error: parsed.error.issues[0]?.message ?? "Invalid password details.",
+      success: "",
+    };
+  }
+
+  const userRecord = await getUserPasswordRecord(session.user.id);
+
+  if (!userRecord?.passwordHash) {
+    return {
+      error: "Unable to reset password for this account.",
+      success: "",
+    };
+  }
+
+  let currentPasswordMatches = false;
+
+  try {
+    currentPasswordMatches = await verifyPassword(
+      parsed.data.currentPassword,
+      userRecord.passwordHash,
+    );
+  } catch {
+    currentPasswordMatches = false;
+  }
+
+  if (!currentPasswordMatches) {
+    return {
+      error: "Current password is incorrect.",
+      success: "",
+    };
+  }
+
+  const passwordHash = await hashPassword(parsed.data.newPassword);
+  await updateUserPasswordHash(userRecord.id, passwordHash);
+
+  return {
+    error: "",
+    success: "Password updated successfully.",
+  };
+}

--- a/app/manage-account/page.tsx
+++ b/app/manage-account/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { ManageAccountPasswordForm } from "@/components/auth/ManageAccountPasswordForm";
+import { AppPageShell } from "@/components/page-shell/AppPageShell";
+import { getOptionalSession } from "@/lib/auth/session";
+
+export const metadata: Metadata = {
+  title: "Manage Account | WR Housing Bridge",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function ManageAccountPage() {
+  const { session } = await getOptionalSession();
+
+  if (!session?.user) {
+    redirect("/sign-in?callbackUrl=%2Fmanage-account");
+  }
+
+  return (
+    <AppPageShell>
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Manage Account</h1>
+          <p className="text-sm text-muted-foreground">
+            Update your password to keep your account secure.
+          </p>
+        </div>
+        <ManageAccountPasswordForm email={session.user.email ?? ""} />
+      </div>
+    </AppPageShell>
+  );
+}

--- a/app/reset-password/actions.ts
+++ b/app/reset-password/actions.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { hashPassword } from "@/lib/auth/password";
+import {
+  InvalidPasswordResetTokenError,
+  verifyPasswordResetToken,
+} from "@/lib/auth/password-reset-token";
+import { getUserPasswordRecord, updateUserPasswordHash } from "@/lib/auth/user-store";
+import { resetPasswordWithTokenSchema } from "@/lib/auth/validation";
+
+export type ResetPasswordWithTokenState = {
+  error: string;
+  success: string;
+};
+
+export async function resetPasswordWithTokenAction(
+  _state: ResetPasswordWithTokenState,
+  formData: FormData,
+): Promise<ResetPasswordWithTokenState> {
+  const parsed = resetPasswordWithTokenSchema.safeParse({
+    token: formData.get("token"),
+    newPassword: formData.get("newPassword"),
+    confirmNewPassword: formData.get("confirmNewPassword"),
+  });
+
+  if (!parsed.success) {
+    return {
+      error: parsed.error.issues[0]?.message ?? "Invalid password reset details.",
+      success: "",
+    };
+  }
+
+  let tokenPayload;
+
+  try {
+    tokenPayload = verifyPasswordResetToken(parsed.data.token);
+  } catch (error) {
+    if (error instanceof InvalidPasswordResetTokenError) {
+      return {
+        error: "This password reset link is invalid or has expired.",
+        success: "",
+      };
+    }
+
+    throw error;
+  }
+
+  const userRecord = await getUserPasswordRecord(tokenPayload.userId);
+
+  if (!userRecord?.passwordHash || userRecord.passwordHash !== tokenPayload.passwordHash) {
+    return {
+      error: "This password reset link is invalid or has expired.",
+      success: "",
+    };
+  }
+
+  const newPasswordHash = await hashPassword(parsed.data.newPassword);
+  await updateUserPasswordHash(userRecord.id, newPasswordHash);
+
+  return {
+    error: "",
+    success: "Password updated successfully. You can now sign in.",
+  };
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { AuthCard } from "@/components/auth/AuthCard";
+import { AuthPageShell } from "@/components/auth/AuthPageShell";
+import { ResetPasswordWithTokenForm } from "@/components/auth/ResetPasswordWithTokenForm";
+import { Button } from "@/components/ui/button";
+
+type ResetPasswordPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export const metadata: Metadata = {
+  title: "Reset Password | WR Housing Bridge",
+};
+
+export default async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const tokenValue = resolvedSearchParams.token;
+  const token = Array.isArray(tokenValue) ? tokenValue[0] : tokenValue;
+
+  if (!token) {
+    return <InvalidResetState />;
+  }
+
+  return (
+    <AuthPageShell>
+      <ResetPasswordWithTokenForm token={token} />
+    </AuthPageShell>
+  );
+}
+
+function InvalidResetState() {
+  return (
+    <AuthPageShell variant="default">
+      <AuthCard
+        title="Reset link unavailable"
+        description="This reset link is missing or invalid. Request a new reset email to continue."
+      >
+        <div className="pt-0">
+          <Button asChild size="sm" className="rounded-full px-4">
+            <Link href="/forgot-password">Request reset link</Link>
+          </Button>
+        </div>
+      </AuthCard>
+    </AuthPageShell>
+  );
+}

--- a/components/auth/ForgotPasswordRequestForm.tsx
+++ b/components/auth/ForgotPasswordRequestForm.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { type ForgotPasswordState, requestPasswordResetAction } from "@/app/forgot-password/actions";
+import { AuthCard } from "@/components/auth/AuthCard";
+import { AlertBanner } from "@/components/ui/alert-banner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const initialState: ForgotPasswordState = {
+  error: "",
+  success: "",
+};
+
+export function ForgotPasswordRequestForm() {
+  const [state, action, pending] = useActionState(requestPasswordResetAction, initialState);
+
+  return (
+    <form action={action}>
+      <AuthCard
+        title="Forgot password"
+        description="Enter your account email and we will send you a reset link."
+        footer={
+          <Button type="submit" size="sm" className="rounded-full px-4" disabled={pending}>
+            {pending ? "Sending..." : "Send reset link"}
+          </Button>
+        }
+      >
+        <div className="space-y-1.5">
+          <label htmlFor="email" className="text-xs font-medium text-foreground">
+            Email
+          </label>
+          <Input id="email" name="email" type="email" autoComplete="email" required />
+        </div>
+
+        {state.error ? (
+          <AlertBanner variant="error" size="sm">
+            {state.error}
+          </AlertBanner>
+        ) : null}
+
+        {state.success ? (
+          <AlertBanner variant="success" size="sm">
+            {state.success}
+          </AlertBanner>
+        ) : null}
+      </AuthCard>
+    </form>
+  );
+}

--- a/components/auth/ManageAccountPasswordForm.tsx
+++ b/components/auth/ManageAccountPasswordForm.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { type ManageAccountState, resetPasswordAction } from "@/app/manage-account/actions";
+import { AuthCard } from "@/components/auth/AuthCard";
+import { AlertBanner } from "@/components/ui/alert-banner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const initialState: ManageAccountState = {
+  error: "",
+  success: "",
+};
+
+type ManageAccountPasswordFormProps = {
+  email: string;
+};
+
+export function ManageAccountPasswordForm({ email }: ManageAccountPasswordFormProps) {
+  const [state, action, pending] = useActionState(resetPasswordAction, initialState);
+
+  return (
+    <form action={action}>
+      <AuthCard
+        title="Reset password"
+        description={email}
+        footer={
+          <Button type="submit" size="sm" className="rounded-full px-4" disabled={pending}>
+            {pending ? "Saving..." : "Update password"}
+          </Button>
+        }
+      >
+        <div className="space-y-1.5">
+          <label htmlFor="currentPassword" className="text-xs font-medium text-foreground">
+            Current password
+          </label>
+          <Input
+            id="currentPassword"
+            name="currentPassword"
+            type="password"
+            autoComplete="current-password"
+            required
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="newPassword" className="text-xs font-medium text-foreground">
+            New password
+          </label>
+          <Input
+            id="newPassword"
+            name="newPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="confirmNewPassword" className="text-xs font-medium text-foreground">
+            Confirm new password
+          </label>
+          <Input
+            id="confirmNewPassword"
+            name="confirmNewPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        {state.error ? (
+          <AlertBanner variant="error" size="sm">
+            {state.error}
+          </AlertBanner>
+        ) : null}
+        {state.success ? (
+          <AlertBanner variant="success" size="sm">
+            {state.success}
+          </AlertBanner>
+        ) : null}
+      </AuthCard>
+    </form>
+  );
+}

--- a/components/auth/ResetPasswordWithTokenForm.tsx
+++ b/components/auth/ResetPasswordWithTokenForm.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState } from "react";
+
+import {
+  type ResetPasswordWithTokenState,
+  resetPasswordWithTokenAction,
+} from "@/app/reset-password/actions";
+import { AuthCard } from "@/components/auth/AuthCard";
+import { AlertBanner } from "@/components/ui/alert-banner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const initialState: ResetPasswordWithTokenState = {
+  error: "",
+  success: "",
+};
+
+type ResetPasswordWithTokenFormProps = {
+  token: string;
+};
+
+export function ResetPasswordWithTokenForm({ token }: ResetPasswordWithTokenFormProps) {
+  const [state, action, pending] = useActionState(resetPasswordWithTokenAction, initialState);
+
+  return (
+    <form action={action}>
+      <input type="hidden" name="token" value={token} />
+      <AuthCard
+        title="Set a new password"
+        description="Create a new password for your account."
+        footer={
+          <div className="flex w-full items-center justify-between gap-3">
+            <Button asChild type="button" variant="ghost" size="sm" className="rounded-full px-4">
+              <Link href="/sign-in">Back to sign in</Link>
+            </Button>
+            {state.success ? (
+              <Button asChild size="sm" className="rounded-full px-4">
+                <Link href="/sign-in">Sign in now</Link>
+              </Button>
+            ) : (
+              <Button type="submit" size="sm" className="rounded-full px-4" disabled={pending}>
+                {pending ? "Saving..." : "Update password"}
+              </Button>
+            )}
+          </div>
+        }
+      >
+        <div className="space-y-1.5">
+          <label htmlFor="newPassword" className="text-xs font-medium text-foreground">
+            New password
+          </label>
+          <Input
+            id="newPassword"
+            name="newPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="confirmNewPassword" className="text-xs font-medium text-foreground">
+            Confirm new password
+          </label>
+          <Input
+            id="confirmNewPassword"
+            name="confirmNewPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        {state.error ? (
+          <AlertBanner variant="error" size="sm">
+            {state.error}
+          </AlertBanner>
+        ) : null}
+
+        {state.success ? (
+          <AlertBanner variant="success" size="sm">
+            {state.success}
+          </AlertBanner>
+        ) : null}
+      </AuthCard>
+    </form>
+  );
+}

--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useActionState } from "react";
 
 import { signInWithPassword } from "@/app/sign-in/actions";
@@ -48,6 +49,11 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
             autoComplete="current-password"
             required
           />
+          <div className="flex justify-end">
+            <Link href="/forgot-password" className="text-xs text-primary hover:underline">
+              Forgot password?
+            </Link>
+          </div>
         </div>
 
         {state.error ? <p className="text-xs text-destructive">{state.error}</p> : null}

--- a/components/site-header/HeaderAccountMenu.tsx
+++ b/components/site-header/HeaderAccountMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { UserIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { usePathname } from "next/navigation";
@@ -54,10 +55,13 @@ export function HeaderAccountMenu({ user }: HeaderAccountMenuProps) {
       </PopoverTrigger>
 
       <PopoverContent align="end" sideOffset={10} className="w-60 gap-2 p-1.5">
-        <div className="rounded-2xl bg-muted/60 px-3 py-2 text-sm font-medium text-foreground/70">
-          <p>Manage Account</p>
-          <p className="mt-1 text-foreground/60">Coming soon</p>
-        </div>
+        <Link
+          href="/manage-account"
+          className={cn(menuItemClass, "text-foreground hover:bg-muted")}
+          onClick={() => setIsOpen(false)}
+        >
+          Manage Account
+        </Link>
 
         <form action={signOutFromHeader}>
           <button

--- a/components/site-header/HeaderMobileMenu.tsx
+++ b/components/site-header/HeaderMobileMenu.tsx
@@ -99,6 +99,14 @@ export function HeaderMobileMenu({
                   </div>
                 ) : null}
 
+                <Link
+                  href="/manage-account"
+                  className={mobileMenuItemClass}
+                  onClick={() => setIsOpen(false)}
+                >
+                  <span>Manage Account</span>
+                </Link>
+
                 <form action={signOutFromHeader}>
                   <button
                     type="submit"

--- a/lib/auth/password-reset-email.ts
+++ b/lib/auth/password-reset-email.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { createResendClient, getEmailFromAddress } from "@/lib/email";
+
+export async function sendPasswordResetEmail(params: {
+  email: string;
+  fullName: string;
+  resetUrl: string;
+}) {
+  const resend = createResendClient();
+  const resetUrl = getSafeResetUrl(params.resetUrl);
+
+  const result = await resend.emails.send({
+    from: getEmailFromAddress(),
+    to: params.email,
+    subject: "Reset your Affordable Housing Portal password",
+    text: `Hello ${params.fullName},\n\nWe received a request to reset your password for the Affordable Housing Portal.\n\nUse the link below to set a new password:\n\n${resetUrl}\n\nIf you did not request this, you can ignore this email.`,
+    html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>We received a request to reset your password for the Affordable Housing Portal.</p><p><a href="${escapeHtml(resetUrl)}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
+  });
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+}
+
+function getSafeResetUrl(value: string) {
+  const url = new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Reset URL must use http or https.");
+  }
+
+  return url.toString();
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/lib/auth/password-reset-email.ts
+++ b/lib/auth/password-reset-email.ts
@@ -1,26 +1,32 @@
 import "server-only";
 
-import { createResendClient, getEmailFromAddress } from "@/lib/email";
+import { sendEmail } from "@/lib/email";
 
 export async function sendPasswordResetEmail(params: {
   email: string;
   fullName: string;
   resetUrl: string;
 }) {
-  const resend = createResendClient();
   const resetUrl = getSafeResetUrl(params.resetUrl);
+  const idempotencyKey = getPasswordResetEmailIdempotencyKey(resetUrl);
 
-  const result = await resend.emails.send({
-    from: getEmailFromAddress(),
+  return await sendEmail({
     to: params.email,
     subject: "Reset your Affordable Housing Portal password",
     text: `Hello ${params.fullName},\n\nWe received a request to reset your password for the Affordable Housing Portal.\n\nUse the link below to set a new password:\n\n${resetUrl}\n\nIf you did not request this, you can ignore this email.`,
     html: `<p>Hello ${escapeHtml(params.fullName)},</p><p>We received a request to reset your password for the Affordable Housing Portal.</p><p><a href="${escapeHtml(resetUrl)}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
+    idempotencyKey,
   });
+}
 
-  if (result.error) {
-    throw new Error(result.error.message);
+export function getPasswordResetEmailIdempotencyKey(resetUrl: string) {
+  const token = new URL(resetUrl).searchParams.get("token")?.trim();
+
+  if (!token) {
+    throw new Error("Reset URL must include a token query parameter.");
   }
+
+  return `password_reset/${token}`;
 }
 
 function getSafeResetUrl(value: string) {

--- a/lib/auth/password-reset-token.ts
+++ b/lib/auth/password-reset-token.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+type PasswordResetTokenPayload = {
+  userId: string;
+  passwordHash: string;
+  exp: number;
+};
+
+export class InvalidPasswordResetTokenError extends Error {
+  constructor() {
+    super("Password reset token is invalid.");
+    this.name = "InvalidPasswordResetTokenError";
+  }
+}
+
+const DEFAULT_TTL_SECONDS = 60 * 30;
+
+export function createPasswordResetToken(params: {
+  userId: string;
+  passwordHash: string;
+  ttlSeconds?: number;
+}) {
+  const payload: PasswordResetTokenPayload = {
+    userId: params.userId,
+    passwordHash: params.passwordHash,
+    exp: Math.floor(Date.now() / 1000) + (params.ttlSeconds ?? DEFAULT_TTL_SECONDS),
+  };
+
+  const encodedPayload = toBase64Url(JSON.stringify(payload));
+  const signature = signPayload(encodedPayload);
+
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyPasswordResetToken(token: string) {
+  const [encodedPayload, signature] = token.split(".");
+
+  if (!encodedPayload || !signature || token.split(".").length !== 2) {
+    throw new InvalidPasswordResetTokenError();
+  }
+
+  const expectedSignature = signPayload(encodedPayload);
+  const signatureBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+
+  if (
+    signatureBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(signatureBuffer, expectedBuffer)
+  ) {
+    throw new InvalidPasswordResetTokenError();
+  }
+
+  let payload: PasswordResetTokenPayload;
+
+  try {
+    payload = JSON.parse(fromBase64Url(encodedPayload)) as PasswordResetTokenPayload;
+  } catch {
+    throw new InvalidPasswordResetTokenError();
+  }
+
+  if (
+    typeof payload.userId !== "string" ||
+    typeof payload.passwordHash !== "string" ||
+    typeof payload.exp !== "number"
+  ) {
+    throw new InvalidPasswordResetTokenError();
+  }
+
+  if (payload.exp <= Math.floor(Date.now() / 1000)) {
+    throw new InvalidPasswordResetTokenError();
+  }
+
+  return payload;
+}
+
+function getPasswordResetSecret() {
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+
+  if (!secret) {
+    throw new Error("AUTH_SECRET is not set.");
+  }
+
+  return secret;
+}
+
+function signPayload(encodedPayload: string) {
+  return createHmac("sha256", getPasswordResetSecret()).update(encodedPayload).digest("base64url");
+}
+
+function toBase64Url(value: string) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function fromBase64Url(value: string) {
+  return Buffer.from(value, "base64url").toString("utf8");
+}

--- a/lib/auth/password-reset-token.unit.test.ts
+++ b/lib/auth/password-reset-token.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  createPasswordResetToken,
+  InvalidPasswordResetTokenError,
+  verifyPasswordResetToken,
+} from "@/lib/auth/password-reset-token";
+
+describe("password-reset-token", () => {
+  it("round-trips a valid token", () => {
+    process.env.AUTH_SECRET = "test-auth-secret";
+
+    const token = createPasswordResetToken({
+      userId: "user-123",
+      passwordHash: "hash-abc",
+      ttlSeconds: 60,
+    });
+
+    const payload = verifyPasswordResetToken(token);
+
+    expect(payload.userId).toBe("user-123");
+    expect(payload.passwordHash).toBe("hash-abc");
+    expect(typeof payload.exp).toBe("number");
+  });
+
+  it("rejects malformed tokens", () => {
+    process.env.AUTH_SECRET = "test-auth-secret";
+
+    expect(() => verifyPasswordResetToken("not-a-token")).toThrow(InvalidPasswordResetTokenError);
+  });
+
+  it("rejects expired tokens", () => {
+    process.env.AUTH_SECRET = "test-auth-secret";
+
+    const token = createPasswordResetToken({
+      userId: "user-123",
+      passwordHash: "hash-abc",
+      ttlSeconds: -1,
+    });
+
+    expect(() => verifyPasswordResetToken(token)).toThrow(InvalidPasswordResetTokenError);
+  });
+});

--- a/lib/auth/route-policy.ts
+++ b/lib/auth/route-policy.ts
@@ -10,6 +10,7 @@ const PROTECTED_PAGE_PATTERNS = [
   "/listings/:path*",
   "/listing-form/:path*",
   "/my-listings/:path*",
+  "/manage-account/:path*",
 ] as const;
 
 const PROTECTED_API_PATTERNS = ["/api/admin/:path*", "/api/listings/:path*"] as const;

--- a/lib/auth/route-policy.unit.test.ts
+++ b/lib/auth/route-policy.unit.test.ts
@@ -18,6 +18,9 @@ describe("requiresAuthSessionForRequest", () => {
     expect(requiresAuthSessionForRequest({ pathname: "/my-listings/drafts", method: "GET" })).toBe(
       true,
     );
+    expect(requiresAuthSessionForRequest({ pathname: "/manage-account", method: "GET" })).toBe(
+      true,
+    );
   });
 
   it("does not overmatch similar public paths", () => {
@@ -31,6 +34,9 @@ describe("requiresAuthSessionForRequest", () => {
       false,
     );
     expect(requiresAuthSessionForRequest({ pathname: "/my-listings-archive", method: "GET" })).toBe(
+      false,
+    );
+    expect(requiresAuthSessionForRequest({ pathname: "/manage-accounting", method: "GET" })).toBe(
       false,
     );
   });

--- a/lib/auth/user-store.ts
+++ b/lib/auth/user-store.ts
@@ -96,10 +96,27 @@ export async function getUserForSession(userId: string) {
   return user ?? null;
 }
 
+export async function getUserPasswordRecord(userId: string) {
+  const [user] = await db
+    .select({
+      id: users.id,
+      passwordHash: users.passwordHash,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  return user ?? null;
+}
+
 export function isUserAllowedToSignIn(status: UserStatus) {
   return status === "active";
 }
 
 export async function recordSuccessfulLogin(userId: string) {
   await db.update(users).set({ lastLoginAt: new Date() }).where(eq(users.id, userId));
+}
+
+export async function updateUserPasswordHash(userId: string, passwordHash: string) {
+  await db.update(users).set({ passwordHash }).where(eq(users.id, userId));
 }

--- a/lib/auth/validation.ts
+++ b/lib/auth/validation.ts
@@ -14,6 +14,10 @@ export const signInSchema = z.object({
   password: z.string().min(1),
 });
 
+export const forgotPasswordRequestSchema = z.object({
+  email: emailSchema,
+});
+
 export const acceptInviteSchema = z
   .object({
     token: z.string().min(1),
@@ -23,4 +27,30 @@ export const acceptInviteSchema = z
   .refine((value) => value.password === value.confirmPassword, {
     message: "Passwords do not match.",
     path: ["confirmPassword"],
+  });
+
+export const resetPasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Current password is required."),
+    newPassword: passwordSchema,
+    confirmNewPassword: z.string().min(1, "Please confirm your new password."),
+  })
+  .refine((value) => value.newPassword === value.confirmNewPassword, {
+    message: "Passwords do not match.",
+    path: ["confirmNewPassword"],
+  })
+  .refine((value) => value.currentPassword !== value.newPassword, {
+    message: "New password must be different from your current password.",
+    path: ["newPassword"],
+  });
+
+export const resetPasswordWithTokenSchema = z
+  .object({
+    token: z.string().min(1, "Reset token is required."),
+    newPassword: passwordSchema,
+    confirmNewPassword: z.string().min(1, "Please confirm your new password."),
+  })
+  .refine((value) => value.newPassword === value.confirmNewPassword, {
+    message: "Passwords do not match.",
+    path: ["confirmNewPassword"],
   });


### PR DESCRIPTION
Summary

- Adds end-to-end password reset flow for users.
- Adds account management password update flow for signed-in users.
- Adds forgot-password entry point from sign-in.

What’s included

- New forgot password pages and server actions.
- New reset password pages and server actions.
- New manage account pages and server actions.
- New auth form components for forgot/reset/manage password flows.
- Password reset token generation/validation utilities and unit tests.
- Auth policy and validation updates needed to support the new flows.
- Sign-in form updates for forgot-password access.
- Password reset email sending integration updates.

Testing

- Ran local dependency install and validated module resolution.
- Unit tests added for password reset token logic.
- Suggested reviewer checks:

1. Forgot password request flow sends reset email.
2. Reset link accepts valid token and rejects expired/invalid tokens.
3. Manage account password update works for authenticated users.
4. Existing sign-in behavior remains unchanged.

Risk and rollback

- Main risk is auth-flow regression around token validation and route access.
- Rollback is straightforward by reverting the two cherry-picked commits on PWD_reset_PR.