### PR TITLE
chore(deps): bump pinned tar and qs overrides off vulnerable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13581,21 +13581,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/next-rest-framework/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
@@ -16207,41 +16192,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
@@ -16836,9 +16786,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,11 +86,11 @@
   },
   "overrides": {
     "gitleaks-secret-scanner": {
-      "tar": "7.5.13"
+      "tar": "7.5.22"
     },
     "next-rest-framework": {
       "lodash": "4.18.1",
-      "qs": "6.15.1"
+      "qs": "6.15.3"
     }
   },
   "engines": {


### PR DESCRIPTION
## Why

The `overrides` block in `package.json` pins two transitive dependencies by hand. Dependabot does not edit that block, so while its security PRs cleared the rest of the backlog, these two sat on vulnerable releases indefinitely — `tar` reported `NO FIX PATH` in `npm audit` because our own pin was the thing blocking it.

## What

| Package | From | To | Severity | Advisory needs |
| --- | --- | --- | --- | --- |
| `tar` (via `gitleaks-secret-scanner`) | 7.5.13 | 7.5.22 | critical | >= 7.5.18 |
| `qs` (via `next-rest-framework`) | 6.15.1 | 6.15.3 | moderate | >= 6.15.2 |

Both stay within their current major.

The lockfile carried a stale nested `next-rest-framework/node_modules/qs@6.15.1` entry that `npm install` and `npm update qs` both kept reusing rather than re-resolving against the new override. Dropping that entry lets npm dedupe it to the hoisted `qs@6.15.3`, which is most of the lockfile diff.

## Verification

`npm audit` now reports `tar`, `qs`, `gitleaks-secret-scanner`, and `next-rest-framework` all clear (totals: 17 -> 15; the 2 remaining criticals are `next-auth`, covered by #365).

Run locally against this branch, all passing: `build`, `typecheck`, `test` (18 suites / 116 tests), `lint`, `format:check`, `lockfile:check`.

## Not covered here

- **`next-auth` / `@auth/core`** — Dependabot has it in #365.
- **`esbuild` via `drizzle-kit`** (dev-only, moderate) — blocked upstream. We are already on the latest `drizzle-kit` (0.31.10); `npm audit` suggests 0.18.1, which is a downgrade. Nothing to do until drizzle-kit drops the deprecated `@esbuild-kit/*` chain.
- **`@hono/node-server` / `@modelcontextprotocol/sdk` via `shadcn`** (moderate) — `npm audit` suggests `shadcn@3.8.3`, also a downgrade from our 4.1.2. The real fix is likely forward to 4.14.1, but that is a version bump rather than a security bump, and `open-pull-requests-limit: 0` in `.github/dependabot.yml` means Dependabot will not propose it. Worth a separate look.