### PR TITLE
fix: keep the hydrated building type when editing a listing

### DIFF
--- a/app/listing-form/ListingForm.unit.test.tsx
+++ b/app/listing-form/ListingForm.unit.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { ReactNode } from "react";
+
+import ListingForm from "./ListingForm";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+// jsdom has no ResizeObserver, which the Radix primitives measure with.
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const LISTING_ID = "11111111-1111-4111-8111-111111111111";
+
+const editorResponse = {
+  data: {
+    id: LISTING_ID,
+    title: "123 Main St Apartments",
+    description: "A bright family-sized apartment close to transit.",
+    buildingType: "apartment",
+    bedrooms: 3,
+    bathrooms: 2,
+    squareFeet: 1200,
+    monthlyRentCents: 235000,
+    leaseTerm: 12,
+    utilitiesIncluded: ["heat", "water"],
+    images: [],
+    availableOn: "2026-05-15",
+    status: "published",
+    name: "123 Main St Apartments",
+    street1: "123 Main St",
+    city: "Waterloo",
+    province: "ON",
+    postalCode: "N2J 2H1",
+    contactName: "Alex Morgan",
+    contactEmail: "leasing@waterloocoop.example.com",
+    contactPhone: "519-555-0100",
+    customFeatures: [],
+  },
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("ListingForm hydration", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(async (input: unknown) =>
+      String(input).includes("/editor")
+        ? { ok: true, status: 200, json: async () => editorResponse }
+        : { ok: true, status: 200, json: async () => ({ data: [] }) },
+    ) as unknown as typeof fetch;
+  });
+
+  it("keeps the persisted building type selected after the listing loads", async () => {
+    render(<ListingForm listingId={LISTING_ID} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.queryByText("Building Type *")).not.toBeNull());
+
+    const buildingType = () =>
+      document.querySelector('[data-field-name="buildingType"] [role="combobox"]');
+
+    await waitFor(() => expect(buildingType()?.textContent).toBe("Apartment"));
+
+    // The hidden native select Radix renders for form participation re-emits its
+    // pre-hydration value once the options register, so hold past that echo.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(buildingType()?.textContent).toBe("Apartment");
+    expect(buildingType()?.hasAttribute("data-placeholder")).toBe(false);
+  });
+
+  it("hydrates the remaining core fields from the editor payload", async () => {
+    render(<ListingForm listingId={LISTING_ID} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.queryByText("Title *")).not.toBeNull());
+
+    const valueOf = (fieldName: string) =>
+      (document.querySelector(`[data-field-name="${fieldName}"] input`) as HTMLInputElement | null)
+        ?.value;
+
+    await waitFor(() => expect(valueOf("title")).toBe("123 Main St Apartments"));
+    expect(valueOf("leaseTerm")).toBe("12");
+    expect(valueOf("bedrooms")).toBe("3");
+    expect(valueOf("city")).toBe("Waterloo");
+  });
+});

--- a/components/listing-form-fields/ListingFormFields.tsx
+++ b/components/listing-form-fields/ListingFormFields.tsx
@@ -46,7 +46,19 @@ function FieldRenderer({
           <FormItem data-field-name={def.key}>
             <FormLabel>{label}</FormLabel>
             <Select
-              onValueChange={field.onChange}
+              onValueChange={(value) => {
+                // Radix renders a hidden native <select> so the value participates in
+                // form submission, and re-dispatches its change event when the option
+                // list registers. On the edit form that echo lands after the listing
+                // loads and carries the pre-hydration empty value, which would wipe the
+                // selection. No option is empty, so an empty payload is only ever that
+                // echo.
+                if (value === "") {
+                  return;
+                }
+
+                field.onChange(value);
+              }}
               defaultValue={field.value ?? undefined}
               value={field.value ?? undefined}
             >


### PR DESCRIPTION
## Problem

Opening the edit form for a listing that has a saved building type shows the **"Select building type"** placeholder instead of the stored value. Clicking **Save Changes** then fails validation on the required field, so the listing cannot be saved at all — a release blocker found on staging with `123 Main St Apartments`.

The data itself is fine. `building_type` is `apartment` in the database, the details page renders **Building Type: Apartment**, and `GET /api/listings/:id/editor` returns `"buildingType": "apartment"`. Only the form fails to hold the value.

| Before | After |
| --- | --- |
| ![before](https://gist.githubusercontent.com/adinschmidt/7a61c505268154febb6797aab49d2c5c/raw/before.png) | ![after](https://gist.githubusercontent.com/adinschmidt/7a61c505268154febb6797aab49d2c5c/raw/after.png) |

## Cause

The field renders correctly for one commit and is then cleared. Instrumenting the controller shows the value going `"" → "apartment" → ""`, with the final change originating from Radix itself rather than any user interaction.

Because the `Select` sits inside a `<form>`, Radix renders a hidden native `<select>` so the value participates in form submission, and keys that element by its registered option values. The `SelectItem`s register their native options after mount, which changes the key and remounts the element. `SelectBubbleInput`'s effect compares against a now-empty `usePrevious`, treats the value as new, and dispatches a synthetic `change` event — which Radix routes back out through `onValueChange`.

On the edit form that echo lands just after the fetched listing is `reset()` into the form, and it carries the pre-hydration empty string. That empty string flows into `field.onChange` and overwrites the hydrated value, leaving the form invalid.

## Fix

A `SelectItem` cannot have an empty value, so an empty `onValueChange` payload is only ever that echo. Ignore it.

Building type is the form's only `select`, so it was the only field affected. Text and number inputs hydrate normally, and `utilitiesIncluded` / `availableOn` round-trip through form state untouched.

This is pre-existing, not a regression from the recent commits: the `Select` block dates to #219 (2026-04-20), and the repro still fails when checked out several commits back. None of the recent commits touch the listing form.

## Verification

- New `app/listing-form/ListingForm.unit.test.tsx` renders the real form against a mocked editor payload; it fails on `main` with `Received: "Select building type"` and passes with the fix.
- Drove the real app against the seeded listing: details page reads `BUILDING TYPE / Apartment`, edit form now loads with **Apartment** selected, **Save Changes** succeeds and redirects to the details page, and the saved row keeps `building_type=apartment`, `lease_term_months=12`, `utilities_included={heat,water}`.
- Changing the selection still works (verified switching to House).
- `npm run test:unit` (125 passed), `npm run typecheck`, and `npm run lint` all clean.