### PR TITLE
test: prune unit tests that cannot fail

### DIFF
--- a/app/listing-form/api.unit.test.ts
+++ b/app/listing-form/api.unit.test.ts
@@ -139,50 +139,8 @@ describe("mapListingFormToCreateListingInput", () => {
         ...validFormData,
         applicationUrl: "https://example.org/apply",
       }),
-    ).toEqual({
-      title: "Accessible Two Bedroom",
-      name: "Cedar Court",
-      description: undefined,
-      address: {
-        street: "123 Main Street",
-        street2: "Building A",
-        city: "Waterloo",
-        province: "ON",
-        postalCode: "N2L 3A1",
-      },
-      units: [
-        {
-          bedrooms: 2,
-          bathrooms: 1.5,
-          sqft: 920,
-          rent: 1850,
-          availableDate: "2026-05-01",
-        },
-      ],
-      accessibilityFeatures: [
-        {
-          id: "ramp_entry",
-          name: "Ramp entry",
-          description: "Step-free building entry",
-        },
-      ],
+    ).toMatchObject({
       applicationUrl: "https://example.org/apply",
-      images: [
-        {
-          id: "6ee785fa-7f75-414f-b6e7-c65fb22083b2",
-          caption: "Front exterior",
-        },
-      ],
-      contact: {
-        name: "Leasing Office",
-        email: "leasing@example.org",
-        phone: "519-555-0100",
-      },
-      status: "draft",
-      unitNumber: "204",
-      buildingType: "apartment",
-      leaseTermMonths: 12,
-      utilitiesIncluded: ["heat", "water"],
     });
   });
 
@@ -447,49 +405,9 @@ describe("mapListingFormToCreateListingInput", () => {
         "published",
         rawInput,
       ),
-    ).toEqual({
-      title: "Accessible Two Bedroom",
-      name: "Cedar Court",
-      description: undefined,
-      address: {
-        street: "123 Main Street",
-        street2: "Building A",
-        city: "Waterloo",
-        province: "ON",
-        postalCode: "N2L 3A1",
-      },
-      units: [
-        {
-          bedrooms: 2,
-          bathrooms: 1.5,
-          sqft: 920,
-          rent: 1850,
-          availableDate: "2026-05-01",
-        },
-      ],
-      accessibilityFeatures: [
-        {
-          id: "ramp_entry",
-          name: "Ramp entry",
-          description: "Step-free building entry",
-        },
-      ],
-      images: [
-        {
-          id: "6ee785fa-7f75-414f-b6e7-c65fb22083b2",
-          caption: "Front exterior",
-        },
-      ],
-      contact: {
-        name: "Leasing Office",
-        email: "leasing@example.org",
-        phone: "519-555-0100",
-      },
+    ).toMatchObject({
       status: "published",
       unitNumber: null,
-      buildingType: "apartment",
-      leaseTermMonths: 12,
-      utilitiesIncluded: ["heat", "water"],
     });
   });
 });

--- a/app/listing-form/types.unit.test.ts
+++ b/app/listing-form/types.unit.test.ts
@@ -88,29 +88,22 @@ describe("listingFormSchema", () => {
     expect(parsed.images[0]?.url).toBe("/api/image-uploads/ec53dba9-e6c0-491c-9c8c-f63b8fa43c1a");
   });
 
-  it("rejects invalid application URLs", () => {
-    const result = listingFormSchema.safeParse({
-      ...validFormInput,
-      applicationUrl: "not-a-url",
+  it("rejects application URLs that are malformed or not http(s)", () => {
+    ["not-a-url", "mailto:leasing@example.org"].forEach((applicationUrl) => {
+      const result = listingFormSchema.safeParse({
+        ...validFormInput,
+        applicationUrl,
+      });
+
+      expect(result.success).toBe(false);
+
+      if (result.success) {
+        throw new Error("Expected schema parse to fail");
+      }
+
+      expect(result.error.issues.some((issue) => issue.path.join(".") === "applicationUrl")).toBe(
+        true,
+      );
     });
-
-    expect(result.success).toBe(false);
-
-    if (result.success) {
-      throw new Error("Expected schema parse to fail");
-    }
-
-    expect(result.error.issues.some((issue) => issue.path.join(".") === "applicationUrl")).toBe(
-      true,
-    );
-  });
-
-  it("rejects non-http application URL protocols", () => {
-    const result = listingFormSchema.safeParse({
-      ...validFormInput,
-      applicationUrl: "mailto:leasing@example.org",
-    });
-
-    expect(result.success).toBe(false);
   });
 });

--- a/components/listing-details/ListingDetails.rental-details.unit.test.tsx
+++ b/components/listing-details/ListingDetails.rental-details.unit.test.tsx
@@ -51,11 +51,4 @@ describe("ListingDetails rental details", () => {
 
     expect(screen.queryByText("Description")).toBeNull();
   });
-
-  it("falls back to the raw available date when it cannot be parsed", () => {
-    render(<ListingDetails {...baseProps} availableOn="Now" />);
-
-    expect(screen.queryByText("Available")).not.toBeNull();
-    expect(screen.queryByText("Now")).not.toBeNull();
-  });
 });

--- a/components/listing-details/ListingDetails.unit.test.tsx
+++ b/components/listing-details/ListingDetails.unit.test.tsx
@@ -29,10 +29,4 @@ describe("ListingDetails", () => {
     expect(screen.queryByText("Utilities Included")).not.toBeNull();
     expect(screen.queryByText("None listed")).not.toBeNull();
   });
-
-  it("shows the empty state when utilities data is missing", () => {
-    render(<ListingDetails {...baseProps} />);
-
-    expect(screen.queryByText("None listed")).not.toBeNull();
-  });
 });

--- a/components/price-range-input/PriceRangeInput.unit.test.ts
+++ b/components/price-range-input/PriceRangeInput.unit.test.ts
@@ -12,9 +12,4 @@ describe("parsePriceInputValue", () => {
     expect(parsePriceInputValue("0")).toBe(0);
     expect(parsePriceInputValue("1200")).toBe(1200);
   });
-
-  it("rejects negative numbers", () => {
-    expect(parsePriceInputValue("-1")).toBeUndefined();
-    expect(parsePriceInputValue("-250")).toBeUndefined();
-  });
 });

--- a/lib/email-queue/queue.unit.test.ts
+++ b/lib/email-queue/queue.unit.test.ts
@@ -79,14 +79,6 @@ describe("enqueueEmail", () => {
     });
   });
 
-  it("returns null when the same logical email is already enqueued", async () => {
-    bossInstance.send.mockResolvedValue(null);
-
-    const jobId = await enqueueEmail(buildTx() as unknown as EmailEnqueueTransaction, JOB_DATA);
-
-    expect(jobId).toBeNull();
-  });
-
   it("adapts drizzle's bare-array results to pg-boss's { rows } shape", async () => {
     const tx = buildTx();
 

--- a/lib/listings/store.unit.test.ts
+++ b/lib/listings/store.unit.test.ts
@@ -12,11 +12,13 @@ import {
 describe("buildListingFeatureCategories", () => {
   it("applies alphabetical category order and per-category sort order for custom fields", () => {
     const features = buildListingFeatureCategories(
+      // Deliberately the reverse of the expected output so that passing through
+      // insertion order cannot be mistaken for sorting.
       {
-        building_alpha: true,
-        building_beta: true,
-        unit_alpha: true,
         unit_beta: true,
+        unit_alpha: true,
+        building_beta: true,
+        building_alpha: true,
       } satisfies ListingCustomFields,
       [
         {


### PR DESCRIPTION
Removes four unit tests whose assertions are unreachable or tautological, narrows two that restated a whole payload to change one field, and strengthens one fixture. No production code changes.

Net: **-136 / +23** across 7 test files. Full suite still green: 21 suites, **125 → 120 tests** (the 4 deletions plus 2 cases folded into 1).

## Removed

| Test | Why it can't fail |
|---|---|
| `PriceRangeInput` — "rejects negative numbers" | Both call sites (`PriceRangeInput.tsx:80,98`) pass the output of `normalizePriceInputValue`, which ends in `Math.max(0, parsedValue).toString()` (line 42). The input is also `type="number" min={0}`. A negative string never reaches the parser. |
| `enqueueEmail` — "returns null when already enqueued" | `enqueueEmail` is a bare `return await boss.send(...)` (`queue.ts:117`). The test mocked `send` to resolve `null` and asserted `null` — it exercised the mock, not our code. |
| `ListingDetails` — "shows the empty state when utilities data is missing" | `ListingDetails.tsx:109` guards with `utilitiesIncluded && utilitiesIncluded.length > 0`, so `undefined` and `[]` share one branch. This test was also a strict subset of the `[]` test's assertions. |
| `ListingDetails` — "falls back to the raw available date when it cannot be parsed" | `availableOn` is a `date` column (`db/schema.ts:218`) validated by `z.iso.date()` (`shared/schemas/listings.ts:137,261`). `ListingFormPreview.tsx:39` computes its `"Now"` literal into `timeAgo` (lines 91, 110), while line 76 passes `formData.availableOn \|\| undefined`. Nothing can hand this component an unparseable date. |

Two deliberately kept:

- **`[]` utilities** — `"None listed"` is user-visible copy worth pinning, so only the `undefined` twin went.
- **`formatAvailableDate`'s NaN guard itself** stays in the component. Only the test is removed; the defensive branch costs nothing to keep.

## Narrowed

- `mapListingFormToCreateListingInput` application-URL and `mapListingFormToUpdateListingInput` unit-number-clearing tests each cloned the ~45-line expected payload from the base test to vary **one** field. Any mapper change broke four large literals for one real reason. Both now use `toMatchObject` on the actual delta — same branch coverage, ~90 fewer lines. This matches what the neighbouring test at line 236 already did correctly.
- The two `listingFormSchema` invalid-URL cases (`"not-a-url"`, `"mailto:"`) are folded into one table-driven test that keeps the `applicationUrl` issue-path assertion for both inputs.

The create/update/editor URL cases in `shared/schemas/listings.unit.test.ts` are **left alone on purpose** — they cover three separate schema boundaries (form input, create API input, editor API output), so they assert each schema is configured correctly rather than re-testing Zod.

## Strengthened

`buildListingFeatureCategories`'s fixture fed `customFields` keys already in final sorted order, so a version that merely preserved insertion order would have passed. Keys are now supplied in reverse of the expected output, which makes the assertion actually prove `sortCustomListingFieldsForDisplay` is wired in (`store.ts:197`). It passes, so the wiring is real.

## Considered and rejected

- **`getEmailJobIdempotencyKey`** duplicates a one-line template already asserted in `invite-email.unit.test.ts`, but it guards a cross-layer requirement: queue identity must keep delegating to the same key Resend sees. Cheap, so kept.
- **`getListingApplicationUrl`** is thin coverage for `?.trim() \|\| undefined`, but the normalization still matters for nullable/legacy DB values. Left as-is; better folded into service-level coverage than deleted outright.
- **`ListingForm` plain-field hydration** is more than a react-hook-form defaults check — it exercises fetch → response parsing → React Query → `form.reset(initialData)` → field rendering. Weaker than the Radix regression test above it, but a legitimate editor-hydration smoke test.

## Verification

`npm test` (21 suites, 120 tests), `npm run lint`, `npm run typecheck`, and `oxfmt --check` on the changed files all pass.

Note: `npm run typecheck` fails on a clean checkout if `.next/` still holds generated types from another branch — `rm -rf .next/types .next/dev/types` clears it. Unrelated to this change.

