### PR TITLE
chore: generate Next types before typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:secrets": "infisical run --env=dev -- next dev",
     "build": "next build",
     "build:secrets": "infisical run --env=dev -- next build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "next typegen && tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:secrets": "infisical run --env=dev -- drizzle-kit migrate",


### PR DESCRIPTION
## Problem

`npm run typecheck` fails on a clean checkout containing only tracked files.

The image and route module type declarations come from `next-env.d.ts`, which is gitignored (`.gitignore:53`) and only generated by a Next command. `tsc --noEmit` therefore runs before anything has produced it, and the script passes only if you happen to have run `next dev` or `next build` first.

This is latent on `main` today because no file imports a static asset. As soon as one does — #359 adds four JPG imports — a fresh clone reports `TS2307` for each of them, and editors show the same errors until a Next command runs.

## Fix

```diff
-"typecheck": "tsc --noEmit",
+"typecheck": "next typegen && tsc --noEmit",
```

`next typegen` generates the definitions without a full build:

```
Usage: next typegen [directory] [options]
Generate TypeScript definitions for routes, pages, and layouts without running a full build.
```

Committing `next-env.d.ts` is not an alternative — Next 16 manages that file and expects it to stay generated and gitignored.

## Verification

Deleted `next-env.d.ts`, then ran `npm run typecheck`:

- `next typegen` regenerated it, `tsc --noEmit` exited 0.
- The regenerated file references `next/image-types/global`, which is what declares `*.jpg`, `*.jpeg`, and `*.png`.

`npm run lockfile:check` and `npm run format:check` both pass; `package-lock.json` is untouched.

## Notes

- CI is unaffected either way. There is no `typecheck` job — the `build` job runs `next build`, which generates `next-env.d.ts` and type-checks by default, so types are already covered there. This fixes the local and editor experience.
- Side effect: `npm run typecheck` now writes `.next/types/`. That directory is gitignored.
- Follow-up worth considering separately: a dedicated `typecheck` CI job would surface type errors in ~20s rather than only inside the slowest job.