### PR TITLE
fix(deps): resolve @hono/node-server to 2.0.12 to close GHSA-frvp-7c67-39w9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,12 +2020,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"


### PR DESCRIPTION
Follow-up to #372, which did not actually apply the security fix its title described.

## Why this is needed

#372 bumped `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, widening its dependency range to `"@hono/node-server": "^1.19.9 || ^2.0.5"`. That was a necessary first step, but npm kept the existing lockfile resolution at **1.19.14**, so the vulnerable package was still what got installed.

The net effect was that the SDK's own advisory entry cleared (it was only flagged for depending on a vulnerable hono) while the underlying advisory stayed open:

> [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) — Path traversal in `serve-static` on Windows via encoded backslash (`%5C`). Moderate, CVSS 5.9, affects `<2.0.5`.

## What this changes

Moves the resolved version to 2.0.12. Four lines in `package-lock.json`, one package:

```
node_modules/@hono/node-server: 1.19.14 → 2.0.12
  engines.node: >=18.14.1 → >=20
```

The 2.x engine requirement is satisfied by the project's own `engines.node: >=22.12.0` (CI runs Node 22, `.nvmrc` is 22.14.0).

`npm audit` totals: 14 on main → 13 after #372 → **12 here**, with both `@hono/node-server` and `@modelcontextprotocol/sdk` clear.

## Note on scope

A blanket `npm audit fix` was the obvious approach, but it is counterproductive on this tree: it re-nests `brace-expansion` under `test-exclude` and `glob`, which pulls the whole jest toolchain into the report and takes the totals from 13 to 29. The remaining `brace-expansion` advisory (`<=5.0.7`) has no non-breaking fix — npm proposes a major *downgrade* of `ts-jest` — so it is left alone here rather than churned. This PR is deliberately the minimal targeted bump.

## Risk

Low. `@hono/node-server` reaches the tree transitively via `shadcn` → `@modelcontextprotocol/sdk`. Nothing in the app imports the hono server or calls `serve-static`, so the vulnerability was not reachable at runtime; this is about not closing a Dependabot alert on a change that left the vulnerable code installed.

Separately worth considering (not changed here): `shadcn` is declared in `dependencies` rather than `devDependencies`, which is why a codegen CLI shows up in a production audit at all.

## Verification

All five CI jobs reproduced locally against the committed lockfile:

| Check | Result |
| --- | --- |
| `npm ci` + `lockfile:check` + `git diff --exit-code` | pass — lockfile stable |
| `npm run lint` | pass — 0 warnings, 0 errors |
| `npm run format:check` | pass |
| `npm run test` | pass — 21 suites, 125 tests |
| `npm run build` | pass |

The `integrity` hash was verified byte-for-byte against `npm view @hono/node-server@2.0.12 dist.integrity`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxBXt6wa5LNczse5jL8hK9)_