### PR TITLE
fix: drop the internal cents detail from the rent help text

### DIFF
--- a/app/listing-form/fieldDefinitions.ts
+++ b/app/listing-form/fieldDefinitions.ts
@@ -158,7 +158,7 @@ export const CORE_FIELD_DEFINITIONS: CoreFieldDefinition[] = [
     isRequired: true,
     sortOrder: 8,
     placeholder: "E.g. 1500",
-    helpText: "Enter the monthly rent in dollars. Stored in cents internally.",
+    helpText: "Enter the monthly rent in dollars.",
   },
   {
     key: "leaseTerm",


### PR DESCRIPTION
## Summary

The Monthly Rent field's help text read:

> Enter the monthly rent in dollars. Stored in cents internally.

The second sentence leaks an implementation detail that means nothing to a lister typing in a dollar amount — and mildly worries them that the number they typed isn't the number being saved. Dropped it; the field now just reads "Enter the monthly rent in dollars."

No behavior change — `monthlyRentCents` is still stored in cents.

## Test plan

- [ ] Open the draft listing form and confirm the Monthly Rent help text reads "Enter the monthly rent in dollars."