### PR TITLE
Improve public listing text previews

### DIFF
--- a/components/listing-form-features/ListingFormFeatures.tsx
+++ b/components/listing-form-features/ListingFormFeatures.tsx
@@ -60,13 +60,8 @@ export function ListingFormFeatures({ control }: ListingFormFeaturesProps) {
                     <FormControl>
                       <ToggleField
                         title={option.label}
-                        description={[
-                          option.helpText,
-                          option.description &&
-                            `Public listing text: This is shown to renters and applicants on the listing. ${option.description}`,
-                        ]
-                          .filter(Boolean)
-                          .join("\n\n")}
+                        description={option.helpText}
+                        publicText={option.description}
                         variant="primary"
                         options={[
                           { label: "Yes", value: "yes" },

--- a/components/toggle-field/ToggleField.tsx
+++ b/components/toggle-field/ToggleField.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 export type ToggleFieldProps = {
   title?: string;
   description?: string;
+  publicText?: string;
   options: {
     value: string;
     label: string;
@@ -22,6 +23,7 @@ export type ToggleFieldProps = {
 export function ToggleField({
   title,
   description,
+  publicText,
   options,
   value,
   onValueChange,
@@ -39,7 +41,12 @@ export function ToggleField({
             {title}
           </FieldLabel>
           {description && (
-            <p className="text-sm text-muted-foreground whitespace-pre-line">{description}</p>
+            <p className="text-sm text-foreground whitespace-pre-line">{description}</p>
+          )}
+          {publicText && (
+            <blockquote className="text-xs leading-snug text-foreground/75 whitespace-pre-line before:content-['“'] after:content-['”']">
+              {publicText}
+            </blockquote>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

- separate lister guidance from the exact public listing copy
- render public-facing sentences as subtle semantic quotations without repeated labels or boilerplate
- keep the published wording and toggle behaviour unchanged

## Screenshots
### Before
<img width="669" height="160" alt="image" src="https://github.com/user-attachments/assets/2da7be70-39ae-4385-b6d9-cc712b092977" />

### After
<img width="672" height="132" alt="image" src="https://github.com/user-attachments/assets/18451c1c-a630-4b7d-96ca-a2d93faf41d7" />

## Verification

- `npm run typecheck`
- focused `oxlint` and `oxfmt` checks
- `npm run build` via the pre-push hook
- verified `/listing-form` and its custom-fields request in Brave

Closes #377