### PR TITLE
Restrict custom field mutations to Boolean fields

### DIFF
--- a/app/admin/custom-listing-fields/custom-listing-fields-dashboard-forms.ts
+++ b/app/admin/custom-listing-fields/custom-listing-fields-dashboard-forms.ts
@@ -55,7 +55,6 @@ export function toCreateFieldDialogPayload(
     publicOnly: values.publicOnly,
     filterableOnly: values.filterableOnly,
     required: values.required,
-    options: null,
   };
 }
 

--- a/app/admin/custom-listing-fields/custom-listing-fields-dashboard-utils.unit.test.ts
+++ b/app/admin/custom-listing-fields/custom-listing-fields-dashboard-utils.unit.test.ts
@@ -234,7 +234,6 @@ describe("custom listing field dashboard utilities", () => {
       publicOnly: true,
       filterableOnly: true,
       required: false,
-      options: null,
     });
   });
 

--- a/lib/custom-listing-fields/custom-listing-field-admin.repository.ts
+++ b/lib/custom-listing-fields/custom-listing-field-admin.repository.ts
@@ -70,7 +70,6 @@ export async function createCustomListingField(input: {
   isFilterable: boolean;
   isRequired: boolean;
   sortOrder: number;
-  options: null;
   actorUserId: string;
 }) {
   const [field] = await db
@@ -87,7 +86,7 @@ export async function createCustomListingField(input: {
       isFilterable: input.isFilterable,
       isRequired: input.isRequired,
       sortOrder: input.sortOrder,
-      options: input.options,
+      options: null,
       createdByUserId: input.actorUserId,
       updatedByUserId: input.actorUserId,
     })
@@ -109,7 +108,6 @@ export async function updateCustomListingFieldById(input: {
   isFilterable?: boolean;
   isRequired?: boolean;
   sortOrder?: number;
-  options?: typeof customListingFields.$inferInsert.options;
   actorUserId: string;
 }) {
   const [field] = await db
@@ -126,7 +124,6 @@ export async function updateCustomListingFieldById(input: {
       isFilterable: input.isFilterable,
       isRequired: input.isRequired,
       sortOrder: input.sortOrder,
-      options: input.options,
       updatedByUserId: input.actorUserId,
     })
     .where(eq(customListingFields.id, input.fieldId))

--- a/lib/custom-listing-fields/custom-listing-field-admin.repository.ts
+++ b/lib/custom-listing-fields/custom-listing-field-admin.repository.ts
@@ -70,7 +70,7 @@ export async function createCustomListingField(input: {
   isFilterable: boolean;
   isRequired: boolean;
   sortOrder: number;
-  options?: typeof customListingFields.$inferInsert.options;
+  options: null;
   actorUserId: string;
 }) {
   const [field] = await db
@@ -87,7 +87,7 @@ export async function createCustomListingField(input: {
       isFilterable: input.isFilterable,
       isRequired: input.isRequired,
       sortOrder: input.sortOrder,
-      options: input.options ?? null,
+      options: input.options,
       createdByUserId: input.actorUserId,
       updatedByUserId: input.actorUserId,
     })

--- a/lib/custom-listing-fields/custom-listing-field-admin.service.ts
+++ b/lib/custom-listing-fields/custom-listing-field-admin.service.ts
@@ -152,7 +152,6 @@ export async function createAdminCustomListingFieldService(
     isFilterable: input.filterableOnly,
     isRequired: input.required,
     sortOrder: input.sortOrder,
-    options: input.options,
     actorUserId: actorResult.value.actor.userId,
   });
 
@@ -209,7 +208,6 @@ export async function updateAdminCustomListingFieldByIdService(input: {
     isFilterable: input.payload.filterableOnly,
     isRequired: input.payload.required,
     sortOrder: input.payload.sortOrder,
-    options: input.payload.options,
     actorUserId: actorResult.value.actor.userId,
   });
 

--- a/shared/schemas/custom-listing-fields.ts
+++ b/shared/schemas/custom-listing-fields.ts
@@ -91,12 +91,10 @@ const customListingFieldMutationSchema = z.object({
   filterableOnly: z.boolean(),
   required: z.boolean(),
   sortOrder: z.number().int().min(0),
-  options: z.array(customListingFieldSelectableOptionSchema).nullable().optional(),
 });
 
 const booleanCustomListingFieldMutationSchema = customListingFieldMutationSchema.extend({
   type: z.literal("boolean"),
-  options: z.null(),
 });
 
 export const createCustomListingFieldSchema = booleanCustomListingFieldMutationSchema;

--- a/shared/schemas/custom-listing-fields.ts
+++ b/shared/schemas/custom-listing-fields.ts
@@ -83,7 +83,7 @@ const customListingFieldMutationSchema = z.object({
   key: nonEmptyString,
   label: nonEmptyString,
   description: z.string().trim().nullable().optional(),
-  type: customListingFieldTypeSchema,
+  type: z.literal("boolean"),
   category: nonEmptyString,
   helpText: z.string().trim().nullable().optional(),
   placeholder: z.string().trim().nullable().optional(),
@@ -93,12 +93,8 @@ const customListingFieldMutationSchema = z.object({
   sortOrder: z.number().int().min(0),
 });
 
-const booleanCustomListingFieldMutationSchema = customListingFieldMutationSchema.extend({
-  type: z.literal("boolean"),
-});
-
-export const createCustomListingFieldSchema = booleanCustomListingFieldMutationSchema;
-export const updateCustomListingFieldSchema = booleanCustomListingFieldMutationSchema
+export const createCustomListingFieldSchema = customListingFieldMutationSchema;
+export const updateCustomListingFieldSchema = customListingFieldMutationSchema
   .partial()
   .refine((value) => Object.keys(value).length > 0, {
     message: "At least one field is required.",

--- a/shared/schemas/custom-listing-fields.ts
+++ b/shared/schemas/custom-listing-fields.ts
@@ -94,8 +94,13 @@ const customListingFieldMutationSchema = z.object({
   options: z.array(customListingFieldSelectableOptionSchema).nullable().optional(),
 });
 
-export const createCustomListingFieldSchema = customListingFieldMutationSchema;
-export const updateCustomListingFieldSchema = customListingFieldMutationSchema
+const booleanCustomListingFieldMutationSchema = customListingFieldMutationSchema.extend({
+  type: z.literal("boolean"),
+  options: z.null(),
+});
+
+export const createCustomListingFieldSchema = booleanCustomListingFieldMutationSchema;
+export const updateCustomListingFieldSchema = booleanCustomListingFieldMutationSchema
   .partial()
   .refine((value) => Object.keys(value).length > 0, {
     message: "At least one field is required.",


### PR DESCRIPTION
## Summary

- restrict custom-field create and update payloads to the currently supported Boolean field type
- require explicit `type: "boolean"` on creation while allowing partial updates to omit `type`
- remove `options` from the mutation contract and stop the admin UI from sending it
- ignore surplus `options` supplied by clients through normal Zod object parsing
- persist `options: null` directly when creating Boolean fields and prevent updates from changing options

## Why

The admin workflow currently supports Boolean custom fields only. The API should require the field type because it records the client's intended operation, but Boolean fields have no configurable choices, so `options` is not information the client needs to provide.

This keeps the audit focused on missing intent: omitting `type` fails validation instead of silently assuming Boolean, while irrelevant extra `options` data is harmlessly ignored.

## Impact

The supported admin workflow continues to create Boolean fields. Its payload is simpler, and direct clients must explicitly select the Boolean type. Read and storage schemas remain broad enough to represent existing data, while mutation endpoints no longer accept future field-type configuration before it is implemented end to end.

## Validation

- `npm run typecheck`
- targeted Oxlint on the five changed files
- targeted Jest run for the existing dashboard utilities unit test (9 tests passed)
- contract probe confirmed surplus `options` is stripped and missing `type` is rejected
- `git diff --check`

Closes #386