### PR TITLE
Require explicit utilities on listing creation

### DIFF
--- a/lib/listings/listing.repository.ts
+++ b/lib/listings/listing.repository.ts
@@ -503,7 +503,7 @@ export async function createListing(input: {
         monthlyRentCents: input.primaryUnitRentCents,
         availableOn: primaryUnit.availableDate ?? null,
         leaseTermMonths: input.payload.leaseTermMonths,
-        utilitiesIncluded: input.payload.utilitiesIncluded ?? [],
+        utilitiesIncluded: input.payload.utilitiesIncluded,
         maxIncomeCents: null,
         applicationUrl: input.payload.applicationUrl ?? null,
         applicationEmail: input.payload.contact.email,

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -236,7 +236,7 @@ const listingPayloadSchema = z.object({
   imageUploadSessionId: z.uuid("Invalid image upload session id.").optional(),
   buildingType: listingBuildingTypeSchema,
   leaseTermMonths: listingLeaseTermMonthsSchema,
-  utilitiesIncluded: z.array(utilityIncludedSchema).optional(),
+  utilitiesIncluded: z.array(utilityIncludedSchema),
 });
 
 export const createListingSchema = listingPayloadSchema;


### PR DESCRIPTION
## Summary

- require `utilitiesIncluded` on full listing creation
- keep an explicit empty array valid for “no utilities included”
- retain omission-as-preserve for partial listing updates
- remove the repository fallback that silently converted omission to `[]`

## Why

The existing full-form caller already sends this value. Treating omission as an empty array allowed malformed clients to succeed with an unintended answer.

## Impact

The current listing form continues to satisfy the API contract. New or external clients must provide an explicit utilities array when using `POST /api/listings`.

## Validation

- `npm run typecheck`
- targeted Oxlint on both changed files
- `git diff --check`

Closes #387