### PR TITLE
Require explicit account invite choices

### DIFF
--- a/lib/accounts/account.service.ts
+++ b/lib/accounts/account.service.ts
@@ -109,14 +109,13 @@ export async function createAccountService(
     role: input.role,
     organization: input.organization,
     invitedByUserId: actorResult.value.actor.userId,
-    sendInviteEmail: input.sendInviteEmail === true,
+    sendInviteEmail: input.sendInviteEmail,
   });
 
   return succeed({
-    message:
-      input.sendInviteEmail === true
-        ? "Account invited. The invite email is queued for delivery."
-        : "Account invited",
+    message: input.sendInviteEmail
+      ? "Account invited. The invite email is queued for delivery."
+      : "Account invited",
     data: {
       id: invite.userId,
       email: invite.email,

--- a/lib/auth/invite-service.ts
+++ b/lib/auth/invite-service.ts
@@ -16,9 +16,9 @@ export async function createInvite(params: {
   email: string;
   fullName: string;
   role: UserRole;
-  organization?: string | null;
+  organization: string | null;
   invitedByUserId: string;
-  sendInviteEmail?: boolean;
+  sendInviteEmail: boolean;
 }) {
   const normalizedEmail = params.email.trim().toLowerCase();
   const now = new Date();
@@ -36,11 +36,6 @@ export async function createInvite(params: {
       .where(eq(lower(users.email), normalizedEmail))
       .limit(1);
 
-    const organization =
-      params.organization === undefined
-        ? (existingUser?.organization ?? null)
-        : params.organization;
-
     const userId = existingUser?.id ?? randomUUID();
 
     if (existingUser) {
@@ -48,7 +43,7 @@ export async function createInvite(params: {
         .update(users)
         .set({
           fullName: params.fullName,
-          organization,
+          organization: params.organization,
           role: params.role,
           status: existingUser.passwordHash ? existingUser.status : "invited",
         })
@@ -58,7 +53,7 @@ export async function createInvite(params: {
         id: userId,
         email: normalizedEmail,
         fullName: params.fullName,
-        organization,
+        organization: params.organization,
         role: params.role,
         status: "invited",
       });
@@ -105,7 +100,7 @@ export async function createInvite(params: {
       invite,
       userId,
       email: normalizedEmail,
-      organization,
+      organization: params.organization,
     };
   });
 

--- a/shared/schemas/account-management.ts
+++ b/shared/schemas/account-management.ts
@@ -35,8 +35,8 @@ export const createAccountInviteSchema = z.object({
   email: z.string().trim().toLowerCase().pipe(z.email("Invalid email address.")),
   name: nonEmptyString,
   role: accountRoleSchema,
-  organization: z.string().trim().nullable().optional(),
-  sendInviteEmail: z.boolean().optional(),
+  organization: z.string().trim().nullable(),
+  sendInviteEmail: z.boolean(),
 });
 
 export const updateAccountSchema = z


### PR DESCRIPTION
## Summary

- require account-invite clients to provide both organization and email-delivery decisions
- remove service fallbacks for omitted organization and delivery values
- preserve explicit null organization behavior for new invites and reinvites

## Verification

- npm run typecheck
- focused schema contract check for omitted and explicit values
- oxlint and oxfmt checks on changed files
- git diff --check

Closes #383