### PR TITLE
Separate listing PUT and PATCH contracts

### DIFF
--- a/app/api/listings/[id]/handlers.ts
+++ b/app/api/listings/[id]/handlers.ts
@@ -4,14 +4,17 @@ import { mapDomainErrorToHttpResponse } from "@/lib/http/map-domain-error";
 import {
   deleteListingByIdService,
   getListingByIdService,
-  updateListingByIdService,
+  patchListingByIdService,
+  replaceListingByIdService,
 } from "@/lib/listings/listing.service";
 import type {
   DeleteListingResponse,
   ListingByIdResponse,
   ListingParams,
-  UpdateListingInput,
-  UpdateListingResponse,
+  PatchListingInput,
+  PatchListingResponse,
+  ReplaceListingInput,
+  ReplaceListingResponse,
 } from "@/shared/schemas/listings";
 
 type ListingByIdRouteContext = {
@@ -33,12 +36,12 @@ export async function getListingByIdHandler(
   });
 }
 
-export async function updateListingByIdHandler(
-  request: TypedNextRequest<"PUT", "application/json", UpdateListingInput>,
+export async function replaceListingByIdHandler(
+  request: TypedNextRequest<"PUT", "application/json", ReplaceListingInput>,
   { params }: ListingByIdRouteContext,
 ) {
   const body = await request.json();
-  const result = await updateListingByIdService({
+  const result = await replaceListingByIdService({
     listingId: params.id,
     payload: body,
   });
@@ -47,7 +50,26 @@ export async function updateListingByIdHandler(
     return mapDomainErrorToHttpResponse(result.error);
   }
 
-  return TypedNextResponse.json<UpdateListingResponse, 200, "application/json">({
+  return TypedNextResponse.json<ReplaceListingResponse, 200, "application/json">({
+    ...result.value,
+  });
+}
+
+export async function patchListingByIdHandler(
+  request: TypedNextRequest<"PATCH", "application/json", PatchListingInput>,
+  { params }: ListingByIdRouteContext,
+) {
+  const body = await request.json();
+  const result = await patchListingByIdService({
+    listingId: params.id,
+    payload: body,
+  });
+
+  if (!result.ok) {
+    return mapDomainErrorToHttpResponse(result.error);
+  }
+
+  return TypedNextResponse.json<PatchListingResponse, 200, "application/json">({
     ...result.value,
   });
 }

--- a/app/api/listings/[id]/route.ts
+++ b/app/api/listings/[id]/route.ts
@@ -5,16 +5,19 @@ import {
   deleteListingResponseSchema,
   listingByIdResponseSchema,
   listingParamsSchema,
-  updateListingResponseSchema,
-  updateListingSchema,
+  patchListingResponseSchema,
+  patchListingSchema,
+  replaceListingResponseSchema,
+  replaceListingSchema,
 } from "@/shared/schemas/listings";
 import {
   deleteListingByIdHandler,
   getListingByIdHandler,
-  updateListingByIdHandler,
+  patchListingByIdHandler,
+  replaceListingByIdHandler,
 } from "./handlers";
 
-export const { GET, PUT, DELETE } = route({
+export const { GET, PUT, PATCH, DELETE } = route({
   getListingById: routeOperation({ method: "GET" })
     .input({ params: listingParamsSchema })
     .outputs([
@@ -24,20 +27,35 @@ export const { GET, PUT, DELETE } = route({
     ])
     .handler(getListingByIdHandler),
 
-  updateListingById: routeOperation({ method: "PUT" })
+  replaceListingById: routeOperation({ method: "PUT" })
     .input({
       params: listingParamsSchema,
       contentType: "application/json",
-      body: updateListingSchema,
+      body: replaceListingSchema,
     })
     .outputs([
-      { status: 200, contentType: "application/json", body: updateListingResponseSchema },
+      { status: 200, contentType: "application/json", body: replaceListingResponseSchema },
       { status: 401, contentType: "application/json", body: errorMessageSchema },
       { status: 403, contentType: "application/json", body: errorMessageSchema },
       { status: 404, contentType: "application/json", body: errorMessageSchema },
       { status: 400, contentType: "application/json", body: errorMessageSchema },
     ])
-    .handler(updateListingByIdHandler),
+    .handler(replaceListingByIdHandler),
+
+  patchListingById: routeOperation({ method: "PATCH" })
+    .input({
+      params: listingParamsSchema,
+      contentType: "application/json",
+      body: patchListingSchema,
+    })
+    .outputs([
+      { status: 200, contentType: "application/json", body: patchListingResponseSchema },
+      { status: 401, contentType: "application/json", body: errorMessageSchema },
+      { status: 403, contentType: "application/json", body: errorMessageSchema },
+      { status: 404, contentType: "application/json", body: errorMessageSchema },
+      { status: 400, contentType: "application/json", body: errorMessageSchema },
+    ])
+    .handler(patchListingByIdHandler),
 
   deleteListingById: routeOperation({ method: "DELETE" })
     .input({ params: listingParamsSchema })

--- a/app/listing-form/api.ts
+++ b/app/listing-form/api.ts
@@ -6,7 +6,8 @@ import {
   listingEditorResponseSchema,
   type CreateListingInput,
   type ListingEditorData,
-  type UpdateListingInput,
+  type PatchListingInput,
+  type ReplaceListingInput,
 } from "@/shared/schemas/listings";
 import type { ListingFormData, ListingFormInput } from "./types";
 
@@ -20,42 +21,45 @@ export function mapListingFormToCreateListingInput(data: ListingFormData): Creat
   return buildListingPayloadFromForm(data);
 }
 
-export function mapListingFormToUpdateListingInput(
+export function mapListingFormToReplaceListingInput(
   data: ListingFormData,
   status = data.status,
   rawInput?: ListingFormInput,
-): UpdateListingInput {
+): ReplaceListingInput {
   const payload = {
     ...buildListingPayloadFromForm(data),
     status,
   };
-  const patch: UpdateListingInput = { ...payload };
+  const replacement: ReplaceListingInput = { ...payload };
 
   if (
     rawInput?.unitNumber !== undefined &&
     normalizeOptionalString(rawInput.unitNumber) === undefined
   ) {
-    patch.unitNumber = null;
+    replacement.unitNumber = null;
   }
 
   const applicationUrl = normalizeOptionalString(data.applicationUrl);
   if (applicationUrl) {
-    patch.applicationUrl = applicationUrl;
+    replacement.applicationUrl = applicationUrl;
   } else if (rawInput?.applicationUrl !== undefined) {
-    patch.applicationUrl = null;
+    replacement.applicationUrl = null;
   }
 
-  return patch;
+  return replacement;
 }
 
-export function mapListingFormToAutosaveUpdateInput(
+/** @deprecated Use mapListingFormToReplaceListingInput for submitted full-form saves. */
+export const mapListingFormToUpdateListingInput = mapListingFormToReplaceListingInput;
+
+export function mapListingFormToAutosavePatchInput(
   data: ListingFormInput,
   status = data.status ?? "draft",
-): UpdateListingInput | null {
-  const patch: UpdateListingInput = {};
-  const address: NonNullable<UpdateListingInput["address"]> = {};
-  const contact: NonNullable<UpdateListingInput["contact"]> = {};
-  const unit: NonNullable<UpdateListingInput["units"]>[number] = {};
+): PatchListingInput | null {
+  const patch: PatchListingInput = {};
+  const address: NonNullable<PatchListingInput["address"]> = {};
+  const contact: NonNullable<PatchListingInput["contact"]> = {};
+  const unit: NonNullable<PatchListingInput["units"]>[number] = {};
 
   assignTrimmedString(patch, "title", data.title);
   assignTrimmedString(patch, "name", data.name);
@@ -143,6 +147,9 @@ export function mapListingFormToAutosaveUpdateInput(
 
   return Object.keys(patch).length > 0 ? patch : null;
 }
+
+/** @deprecated Use mapListingFormToAutosavePatchInput for partial autosaves. */
+export const mapListingFormToAutosaveUpdateInput = mapListingFormToAutosavePatchInput;
 
 export async function parseCreateDraftListingResponse(response: Response): Promise<{ id: string }> {
   if (!response.ok) {

--- a/app/listing-form/useEditListingQuery.ts
+++ b/app/listing-form/useEditListingQuery.ts
@@ -1,17 +1,22 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/app/query-keys";
-import type { UpdateListingInput } from "@/shared/schemas/listings";
+import type { PatchListingInput, ReplaceListingInput } from "@/shared/schemas/listings";
 import { parseCreateListingResponse } from "./api";
 
-interface EditListingInput {
+interface ReplaceListingVariables {
   listingId: string;
-  payload: UpdateListingInput;
+  payload: ReplaceListingInput;
+}
+
+interface PatchListingVariables {
+  listingId: string;
+  payload: PatchListingInput;
 }
 
 export function useEditListingQuery() {
   const queryClient = useQueryClient();
-  const mutation = useMutation({
-    mutationFn: async ({ listingId, payload }: EditListingInput) => {
+  const replaceMutation = useMutation({
+    mutationFn: async ({ listingId, payload }: ReplaceListingVariables) => {
       const response = await fetch(`/api/listings/${listingId}`, {
         method: "PUT",
         headers: {
@@ -23,17 +28,41 @@ export function useEditListingQuery() {
       return await parseCreateListingResponse(response);
     },
     onSuccess: (_data, variables) => {
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.listingEditor(variables.listingId),
+      invalidateListingQueries(queryClient, variables.listingId);
+    },
+  });
+  const patchMutation = useMutation({
+    mutationFn: async ({ listingId, payload }: PatchListingVariables) => {
+      const response = await fetch(`/api/listings/${listingId}`, {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
       });
-      void queryClient.invalidateQueries({ queryKey: queryKeys.myListings() });
-      void queryClient.invalidateQueries({ queryKey: ["listings"] });
+
+      return await parseCreateListingResponse(response);
+    },
+    onSuccess: (_data, variables) => {
+      invalidateListingQueries(queryClient, variables.listingId);
     },
   });
 
   return {
-    editListing: mutation.mutateAsync,
-    isLoading: mutation.isPending,
-    isError: mutation.isError,
+    replaceListing: replaceMutation.mutateAsync,
+    patchListing: patchMutation.mutateAsync,
+    isLoading: replaceMutation.isPending || patchMutation.isPending,
+    isError: replaceMutation.isError || patchMutation.isError,
   };
+}
+
+function invalidateListingQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  listingId: string,
+) {
+  void queryClient.invalidateQueries({
+    queryKey: queryKeys.listingEditor(listingId),
+  });
+  void queryClient.invalidateQueries({ queryKey: queryKeys.myListings() });
+  void queryClient.invalidateQueries({ queryKey: ["listings"] });
 }

--- a/app/listing-form/useListingForm.ts
+++ b/app/listing-form/useListingForm.ts
@@ -3,7 +3,7 @@ import { useRouter } from "next/navigation";
 import { useForm, useWatch, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
-import { mapListingFormToAutosaveUpdateInput, mapListingFormToUpdateListingInput } from "./api";
+import { mapListingFormToAutosavePatchInput, mapListingFormToReplaceListingInput } from "./api";
 import {
   listingFormSchema,
   ListingFormContext,
@@ -46,8 +46,8 @@ export function useListingForm(initialListingId?: string) {
     isError: isFetchError,
   } = useGetListingQuery(initialListingId);
   const { createDraftListing, isLoading: isCreatingDraft } = useCreateDraftListingQuery();
-  const { editListing, isLoading: isEditing } = useEditListingQuery();
-  const autosavePayload = mapListingFormToAutosaveUpdateInput(
+  const { patchListing, replaceListing, isLoading: isEditing } = useEditListingQuery();
+  const autosavePayload = mapListingFormToAutosavePatchInput(
     watchedValues,
     initialListingId ? watchedValues.status : "draft",
   );
@@ -101,20 +101,20 @@ export function useListingForm(initialListingId?: string) {
       return listingId;
     }
 
-    const currentDraftPayload = mapListingFormToAutosaveUpdateInput(form.getValues(), "draft");
+    const currentDraftPayload = mapListingFormToAutosavePatchInput(form.getValues(), "draft");
 
     if (!currentDraftPayload) {
       return listingId;
     }
 
-    await editListing({
+    await patchListing({
       listingId,
       payload: currentDraftPayload,
     });
     lastAutosavedPayloadRef.current = JSON.stringify(currentDraftPayload);
 
     return listingId;
-  }, [createDraftListingId, editListing, form]);
+  }, [createDraftListingId, form, patchListing]);
 
   useEffect(() => {
     setActiveListingId(initialListingId);
@@ -125,7 +125,7 @@ export function useListingForm(initialListingId?: string) {
       if (!form.formState.isDirty || initialListingId) {
         form.reset(initialData);
         lastAutosavedPayloadRef.current = JSON.stringify(
-          mapListingFormToAutosaveUpdateInput(
+          mapListingFormToAutosavePatchInput(
             initialData,
             initialListingId ? initialData.status : "draft",
           ),
@@ -161,7 +161,7 @@ export function useListingForm(initialListingId?: string) {
             })),
       )
         .then(({ listingId, shouldActivateDraft }) =>
-          editListing({
+          patchListing({
             listingId,
             payload: autosavePayload,
           }).then(() => {
@@ -201,7 +201,7 @@ export function useListingForm(initialListingId?: string) {
     autosavePayload,
     autosavePayloadKey,
     createDraftListingId,
-    editListing,
+    patchListing,
     shouldAutosaveDraft,
   ]);
 
@@ -298,9 +298,9 @@ export function useListingForm(initialListingId?: string) {
         createdDraftListingId = listingId;
       }
 
-      await editListing({
+      await replaceListing({
         listingId,
-        payload: mapListingFormToUpdateListingInput(data, "published", watchedValues),
+        payload: mapListingFormToReplaceListingInput(data, "published", watchedValues),
       });
       router.push(`/listings/${listingId}`);
       router.refresh();

--- a/app/my-listings/MyListingsClient.tsx
+++ b/app/my-listings/MyListingsClient.tsx
@@ -69,7 +69,7 @@ export function MyListingsClient({ initialListings, renderedAt }: MyListingsClie
     }) => {
       const isDelete = nextStatus === "archived";
       const response = await fetch(`/api/listings/${listingId}`, {
-        method: isDelete ? "DELETE" : "PUT",
+        method: isDelete ? "DELETE" : "PATCH",
         headers: isDelete ? undefined : { "content-type": "application/json" },
         body: isDelete ? undefined : JSON.stringify({ status: nextStatus }),
       });

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -31,21 +31,22 @@ Error responses use:
 
 ## Listings
 
-| Method   | Path                       | Auth                                                     | Purpose                                                 | Contract source                                      |
-| -------- | -------------------------- | -------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------- |
-| `GET`    | `/api/listings`            | Active session; draft/archive visibility is role-limited | List listings with filters and pagination.              | `listingQuerySchema`, `listingListResponseSchema`    |
-| `POST`   | `/api/listings`            | Admin or partner                                         | Create a full listing.                                  | `createListingSchema`, `createListingResponseSchema` |
-| `GET`    | `/api/listings/:id`        | Active session; owner/admin for private                  | Get listing details.                                    | `listingParamsSchema`, `listingByIdResponseSchema`   |
-| `PUT`    | `/api/listings/:id`        | Admin or owning partner                                  | Update listing data, status, images, and custom fields. | `updateListingSchema`, `updateListingResponseSchema` |
-| `DELETE` | `/api/listings/:id`        | Admin or owning partner                                  | Archive a listing.                                      | `deleteListingResponseSchema`                        |
-| `GET`    | `/api/listings/:id/editor` | Admin or owning partner                                  | Load editor-shaped listing data.                        | `listingEditorResponseSchema`                        |
-| `POST`   | `/api/listing-drafts`      | Admin or partner                                         | Create an empty draft listing and property.             | `createDraftListingResponseSchema`                   |
+| Method   | Path                       | Auth                                                     | Purpose                                                          | Contract source                                        |
+| -------- | -------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------ |
+| `GET`    | `/api/listings`            | Active session; draft/archive visibility is role-limited | List listings with filters and pagination.                       | `listingQuerySchema`, `listingListResponseSchema`      |
+| `POST`   | `/api/listings`            | Admin or partner                                         | Create a full listing.                                           | `createListingSchema`, `createListingResponseSchema`   |
+| `GET`    | `/api/listings/:id`        | Active session; owner/admin for private                  | Get listing details.                                             | `listingParamsSchema`, `listingByIdResponseSchema`     |
+| `PUT`    | `/api/listings/:id`        | Admin or owning partner                                  | Replace the complete client-owned listing representation.        | `replaceListingSchema`, `replaceListingResponseSchema` |
+| `PATCH`  | `/api/listings/:id`        | Admin or owning partner                                  | Partially update listing data, status, images, or custom fields. | `patchListingSchema`, `patchListingResponseSchema`     |
+| `DELETE` | `/api/listings/:id`        | Admin or owning partner                                  | Archive a listing.                                               | `deleteListingResponseSchema`                          |
+| `GET`    | `/api/listings/:id/editor` | Admin or owning partner                                  | Load editor-shaped listing data.                                 | `listingEditorResponseSchema`                          |
+| `POST`   | `/api/listing-drafts`      | Admin or partner                                         | Create an empty draft listing and property.                      | `createDraftListingResponseSchema`                     |
 
 Listing query parameters are documented in [Listings](listings.md).
 
 Listing create/update payloads submit selected accessibility features as `accessibilityFeatures`. Each submitted feature must include the field-definition `id`; storage persists selected public boolean field definitions as boolean keys in `listings.custom_fields`.
 
-Create payloads may include `applicationUrl` as a valid HTTP(S) URL. Update payloads may include `applicationUrl` as a valid HTTP(S) URL or `null` to clear the stored URL.
+Create payloads may include `applicationUrl` as a valid HTTP(S) URL. Replacement and partial-update payloads may include `applicationUrl` as a valid HTTP(S) URL or `null` to clear the stored URL.
 
 ## Image Uploads
 

--- a/docs/listings.md
+++ b/docs/listings.md
@@ -140,7 +140,7 @@ The form uses:
 1. A new form starts with local defaults and no listing ID.
 2. When autosave needs a persisted row, it calls `POST /api/listing-drafts`.
 3. The URL is replaced with `/listing-form/:id` after a draft is created.
-4. Form changes are mapped to update payloads and saved after an 800 ms debounce.
+4. Form changes are mapped to partial-update payloads and saved with `PATCH` after an 800 ms debounce.
 5. Publish waits for in-flight autosave, then sends a final `PUT /api/listings/:id` with status `published`.
 
 Published listing edits do not draft-autosave. The UI warns before navigating away with unsaved published changes.
@@ -151,7 +151,9 @@ Creation and update behavior is split across service and repository code:
 
 - `createDraftListingService` creates an empty property and draft listing.
 - `createListingService` creates a property and listing in one transaction.
-- `updateListingByIdService` checks edit access, merges dynamic feature state in `customFields`, updates property/listing columns, and syncs images.
+- `replaceListingByIdService` handles submitted full-form `PUT` replacements.
+- `patchListingByIdService` handles autosave and status-only `PATCH` updates while preserving omitted values.
+- Both update services share edit-access checks, dynamic feature merging in `customFields`, property/listing updates, and image synchronization.
 - `deleteListingByIdService` archives the listing rather than deleting it.
 
 Status timestamps are managed by `resolveListingStatusTimestamps`.

--- a/lib/listings/listing.repository.ts
+++ b/lib/listings/listing.repository.ts
@@ -17,7 +17,7 @@ import { DEFAULT_PROPERTY_COUNTRY } from "@/lib/listings/store";
 import type {
   CreateListingInput,
   ListingIdParam,
-  UpdateListingInput,
+  ListingMutationInput,
 } from "@/shared/schemas/listings";
 
 export type ListingSummaryRow = {
@@ -585,7 +585,7 @@ export async function updateListingGraph(input: {
     publishedAt: Date | null;
     archivedAt: Date | null;
   };
-  images?: NonNullable<UpdateListingInput["images"]>;
+  images?: NonNullable<ListingMutationInput["images"]>;
   imageAltTextBase: string;
 }) {
   await db.transaction(async (tx) => {

--- a/lib/listings/listing.service.ts
+++ b/lib/listings/listing.service.ts
@@ -69,9 +69,12 @@ import type {
   ListingEditorResponse,
   ListingIdParam,
   ListingListResponse,
+  ListingMutationInput,
   ListingQuery,
-  UpdateListingInput,
-  UpdateListingResponse,
+  PatchListingInput,
+  PatchListingResponse,
+  ReplaceListingInput,
+  ReplaceListingResponse,
 } from "@/shared/schemas/listings";
 
 type OptionalSessionResult = Awaited<ReturnType<typeof getOptionalSession>>;
@@ -412,10 +415,41 @@ export async function createListingService(
   });
 }
 
-export async function updateListingByIdService(input: {
+export async function replaceListingByIdService(input: {
   listingId: ListingIdParam;
-  payload: UpdateListingInput;
-}): Promise<DomainResult<UpdateListingResponse>> {
+  payload: ReplaceListingInput;
+}): Promise<DomainResult<ReplaceListingResponse>> {
+  return updateListingById({
+    ...input,
+    method: "replace",
+  });
+}
+
+export async function patchListingByIdService(input: {
+  listingId: ListingIdParam;
+  payload: PatchListingInput;
+}): Promise<DomainResult<PatchListingResponse>> {
+  return updateListingById({
+    ...input,
+    method: "patch",
+  });
+}
+
+type ListingUpdateOperation =
+  | {
+      method: "replace";
+      listingId: ListingIdParam;
+      payload: ReplaceListingInput;
+    }
+  | {
+      method: "patch";
+      listingId: ListingIdParam;
+      payload: PatchListingInput;
+    };
+
+async function updateListingById<TPayload extends ListingMutationInput>(
+  input: ListingUpdateOperation & { payload: TPayload },
+): Promise<DomainResult<{ message: string; data: { id: ListingIdParam } & TPayload }>> {
   const actorResult = await requireListingWriteActor();
 
   if (!actorResult.ok) {
@@ -700,7 +734,7 @@ async function buildListingEditorData(listing: ListingRecord): Promise<ListingEd
 }
 
 function resolveNextApplicationUrl(input: {
-  payload: UpdateListingInput;
+  payload: ListingMutationInput;
   listingApplicationUrl: string | null;
 }) {
   if (input.payload.applicationUrl !== undefined) {

--- a/lib/listings/store.ts
+++ b/lib/listings/store.ts
@@ -11,7 +11,7 @@ import {
 import type {
   CreateListingInput,
   ListingDetails,
-  UpdateListingInput,
+  ListingMutationInput,
 } from "@/shared/schemas/listings";
 
 export const DEFAULT_PROPERTY_COUNTRY = "Canada";
@@ -31,7 +31,7 @@ export function buildListingCustomFields(
 
 export function mergeListingCustomFields(
   existing: ListingCustomFields,
-  input: UpdateListingInput,
+  input: ListingMutationInput,
   definitions: ListingFeatureDefinition[],
 ): ListingCustomFields {
   const next = { ...existing };
@@ -110,7 +110,7 @@ function applyAccessibilityFeatureState(
   customFields: ListingCustomFields,
   features:
     | CreateListingInput["accessibilityFeatures"]
-    | UpdateListingInput["accessibilityFeatures"],
+    | ListingMutationInput["accessibilityFeatures"],
   definitions: ListingFeatureDefinition[],
 ) {
   const allowedKeys = new Set(definitions.map((definition) => definition.key));

--- a/shared/schemas/listings.ts
+++ b/shared/schemas/listings.ts
@@ -195,7 +195,7 @@ const listingUnitPatchSchema = listingUnitSchema.partial().refine(hasAtLeastOneF
   message: "Each unit update must include at least one field.",
 });
 
-const updateListingBasePayloadSchema = z.object({
+const patchListingBasePayloadSchema = z.object({
   title: nonEmptyString.optional(),
   name: nonEmptyString.optional(),
   description: optionalTrimmedString(),
@@ -211,7 +211,7 @@ const updateListingBasePayloadSchema = z.object({
   utilitiesIncluded: z.array(utilityIncludedSchema).optional(),
   applicationUrl: z.union([z.httpUrl({ normalize: true }), z.null()]).optional(),
 });
-const updateListingPayloadSchema = updateListingBasePayloadSchema.refine(
+const patchListingPayloadSchema = patchListingBasePayloadSchema.refine(
   (value) => hasAtLeastOneField(value),
   {
     message: "At least one field is required.",
@@ -241,7 +241,17 @@ const listingPayloadSchema = z.object({
 
 export const createListingSchema = listingPayloadSchema;
 
-export const updateListingSchema = updateListingPayloadSchema;
+export const replaceListingSchema = listingPayloadSchema
+  .omit({ imageUploadSessionId: true })
+  .extend({
+    unitNumber: z.union([nonEmptyString, z.null()]).optional(),
+    applicationUrl: z.union([z.httpUrl({ normalize: true }), z.null()]).optional(),
+  });
+
+export const patchListingSchema = patchListingPayloadSchema;
+
+/** @deprecated Use patchListingSchema for the partial update contract. */
+export const updateListingSchema = patchListingSchema;
 
 export const listingEditorDataSchema = z.object({
   title: z.string(),
@@ -297,10 +307,18 @@ export const createDraftListingResponseSchema = z.object({
   data: listingIdDataSchema,
 });
 
-export const updateListingResponseSchema = z.object({
+export const replaceListingResponseSchema = z.object({
   message: z.string(),
-  data: listingIdDataSchema.and(updateListingPayloadSchema),
+  data: listingIdDataSchema.and(replaceListingSchema),
 });
+
+export const patchListingResponseSchema = z.object({
+  message: z.string(),
+  data: listingIdDataSchema.and(patchListingSchema),
+});
+
+/** @deprecated Use patchListingResponseSchema for the partial update contract. */
+export const updateListingResponseSchema = patchListingResponseSchema;
 
 export const deleteListingResponseSchema = z.object({
   message: z.string(),
@@ -317,8 +335,15 @@ export type ListingByIdResponse = z.infer<typeof listingByIdResponseSchema>;
 export type ListingEditorData = z.infer<typeof listingEditorDataSchema>;
 export type ListingEditorResponse = z.infer<typeof listingEditorResponseSchema>;
 export type CreateListingInput = z.infer<typeof createListingSchema>;
-export type UpdateListingInput = z.infer<typeof updateListingSchema>;
+export type ReplaceListingInput = z.infer<typeof replaceListingSchema>;
+export type PatchListingInput = z.infer<typeof patchListingSchema>;
+export type ListingMutationInput = ReplaceListingInput | PatchListingInput;
+/** @deprecated Use PatchListingInput for the partial update contract. */
+export type UpdateListingInput = PatchListingInput;
 export type CreateListingResponse = z.infer<typeof createListingResponseSchema>;
 export type CreateDraftListingResponse = z.infer<typeof createDraftListingResponseSchema>;
-export type UpdateListingResponse = z.infer<typeof updateListingResponseSchema>;
+export type ReplaceListingResponse = z.infer<typeof replaceListingResponseSchema>;
+export type PatchListingResponse = z.infer<typeof patchListingResponseSchema>;
+/** @deprecated Use PatchListingResponse for the partial update contract. */
+export type UpdateListingResponse = PatchListingResponse;
 export type DeleteListingResponse = z.infer<typeof deleteListingResponseSchema>;


### PR DESCRIPTION
## What changed

- added distinct full-replacement (`PUT`) and partial-update (`PATCH`) request/response schemas and inferred types
- exposed both methods from the listing-by-id route with separate typed handlers and service entry points
- moved draft autosave and status-only restoration to `PATCH` while keeping submitted full-form saves on `PUT`
- documented both listing update contracts

## Why

The existing `PUT /api/listings/:id` validated a partial payload and preserved omitted values, so the method label did not match its behavior. Full-form submission, autosave, and status-only updates all shared that ambiguous contract.

## User impact

Submitted listing forms now use a complete client-owned replacement contract. Draft autosave and status-only changes can continue sending only changed fields without overwriting omitted listing data. Authentication, authorization, domain errors, status timestamps, image synchronization, custom fields, creation, and deletion retain their existing behavior.

## Root cause

A single partial update schema, handler, service entry point, and client mutation had been reused for callers with different replacement semantics.

## Checks

- changed-file formatting check
- changed-file lint
- `npm run typecheck`
- focused schema smoke check: status-only PATCH accepted, empty PATCH rejected, complete PUT accepted, status-only PUT rejected
- `npm run build`

No tests were added or modified, per project testing policy.

Closes #396